### PR TITLE
Added MCP support to Qwen Code.

### DIFF
--- a/AgentSkills/References/SetUpWolframMCPServer.md
+++ b/AgentSkills/References/SetUpWolframMCPServer.md
@@ -46,6 +46,7 @@ Replace `<ClientName>` with one of the supported clients:
 | Junie | `"Junie"` |
 | LM Studio | `"LMStudio"` |
 | OpenCode | `"OpenCode"` |
+| Qwen Code | `"QwenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |
 | Zed | `"Zed"` |

--- a/AgentSkills/Skills/wolfram-alpha/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-alpha/references/SetUpWolframMCPServer.md
@@ -46,6 +46,7 @@ Replace `<ClientName>` with one of the supported clients:
 | Junie | `"Junie"` |
 | LM Studio | `"LMStudio"` |
 | OpenCode | `"OpenCode"` |
+| Qwen Code | `"QwenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |
 | Zed | `"Zed"` |

--- a/AgentSkills/Skills/wolfram-language/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-language/references/SetUpWolframMCPServer.md
@@ -46,6 +46,7 @@ Replace `<ClientName>` with one of the supported clients:
 | Junie | `"Junie"` |
 | LM Studio | `"LMStudio"` |
 | OpenCode | `"OpenCode"` |
+| Qwen Code | `"QwenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |
 | Zed | `"Zed"` |

--- a/AgentSkills/Skills/wolfram-notebooks/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-notebooks/references/SetUpWolframMCPServer.md
@@ -46,6 +46,7 @@ Replace `<ClientName>` with one of the supported clients:
 | Junie | `"Junie"` |
 | LM Studio | `"LMStudio"` |
 | OpenCode | `"OpenCode"` |
+| Qwen Code | `"QwenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |
 | Zed | `"Zed"` |

--- a/AgentSkills/Skills/wolfram-paclets/references/SetUpWolframMCPServer.md
+++ b/AgentSkills/Skills/wolfram-paclets/references/SetUpWolframMCPServer.md
@@ -46,6 +46,7 @@ Replace `<ClientName>` with one of the supported clients:
 | Junie | `"Junie"` |
 | LM Studio | `"LMStudio"` |
 | OpenCode | `"OpenCode"` |
+| Qwen Code | `"QwenCode"` |
 | VS Code | `"VisualStudioCode"` |
 | Windsurf | `"Windsurf"` |
 | Zed | `"Zed"` |

--- a/Kernel/InstallMCPServer.wl
+++ b/Kernel/InstallMCPServer.wl
@@ -633,6 +633,7 @@ guessClientName[ file_? fileQ ] := Enclose[
             { __, ".amazonq", "mcp.json" }, Throw[ "AmazonQ" ],
             { __, ".aws", "amazonq", "mcp.json" }, Throw[ "AmazonQ" ],
             { __, ".junie", "mcp", "mcp.json" }, Throw[ "Junie" ],
+            { __, ".qwen", "settings.json" }, Throw[ "QwenCode" ],
             { __, ".continue", "config.yaml" }, Throw[ "Continue" ],
             { __, ".continue", "mcpservers", _ }, Throw[ "Continue" ],
             { __, ".lmstudio", "mcp.json" }, Throw[ "LMStudio" ],

--- a/Kernel/SupportedClients.wl
+++ b/Kernel/SupportedClients.wl
@@ -83,16 +83,6 @@ $supportedMCPClients = <|
         "URL"             -> "https://github.com/google-gemini/gemini-cli",
         "InstallLocation" :> { $HomeDirectory, ".gemini", "settings.json" }
     |>,
-    "QwenCode" -> <|
-        "DisplayName"     -> "Qwen Code",
-        "DefaultToolset"  -> "WolframLanguage",
-        "Aliases"         -> { "Qwen" },
-        "ConfigFormat"    -> "JSON",
-        "ConfigKey"       -> { "mcpServers" },
-        "URL"             -> "https://github.com/QwenLM/qwen-code",
-        "ProjectPath"     -> { ".qwen", "settings.json" },
-        "InstallLocation" :> { $HomeDirectory, ".qwen", "settings.json" }
-    |>,
     "Goose" -> <|
         "DisplayName"     -> "Goose",
         "DefaultToolset"  -> "Wolfram",
@@ -221,6 +211,16 @@ $supportedMCPClients = <|
         "URL"             -> "https://opencode.ai",
         "ProjectPath"     -> { "opencode.json" },
         "InstallLocation" :> { $HomeDirectory, ".config", "opencode", "opencode.json" }
+    |>,
+    "QwenCode" -> <|
+        "DisplayName"     -> "Qwen Code",
+        "DefaultToolset"  -> "WolframLanguage",
+        "Aliases"         -> { "Qwen" },
+        "ConfigFormat"    -> "JSON",
+        "ConfigKey"       -> { "mcpServers" },
+        "URL"             -> "https://github.com/QwenLM/qwen-code",
+        "ProjectPath"     -> { ".qwen", "settings.json" },
+        "InstallLocation" :> { $HomeDirectory, ".qwen", "settings.json" }
     |>,
     "VisualStudioCode" -> <|
         "DisplayName"     -> "Visual Studio Code",

--- a/Kernel/SupportedClients.wl
+++ b/Kernel/SupportedClients.wl
@@ -83,6 +83,16 @@ $supportedMCPClients = <|
         "URL"             -> "https://github.com/google-gemini/gemini-cli",
         "InstallLocation" :> { $HomeDirectory, ".gemini", "settings.json" }
     |>,
+    "QwenCode" -> <|
+        "DisplayName"     -> "Qwen Code",
+        "DefaultToolset"  -> "WolframLanguage",
+        "Aliases"         -> { "Qwen" },
+        "ConfigFormat"    -> "JSON",
+        "ConfigKey"       -> { "mcpServers" },
+        "URL"             -> "https://github.com/QwenLM/qwen-code",
+        "ProjectPath"     -> { ".qwen", "settings.json" },
+        "InstallLocation" :> { $HomeDirectory, ".qwen", "settings.json" }
+    |>,
     "Goose" -> <|
         "DisplayName"     -> "Goose",
         "DefaultToolset"  -> "Wolfram",

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ AgentTools can be installed into the following MCP client applications:
 | [LM Studio](https://lmstudio.ai) | `"LMStudio"` | No |
 | [OpenAI Codex](https://openai.com/codex) | `"Codex"` | Yes |
 | [OpenCode](https://opencode.ai) | `"OpenCode"` | Yes |
+| [Qwen Code](https://github.com/QwenLM/qwen-code) | `"QwenCode"` | Yes |
 | [Visual Studio Code](https://code.visualstudio.com) | `"VisualStudioCode"` | Yes |
 | [Windsurf](https://codeium.com/windsurf) | `"Windsurf"` | No |
 | [Zed](https://zed.dev) | `"Zed"` | Yes |

--- a/Tests/InstallMCPServer.wlt
+++ b/Tests/InstallMCPServer.wlt
@@ -3840,7 +3840,7 @@ VerificationTest[
     Length @ $SupportedMCPClients,
     21,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-Has20Clients@@Tests/InstallMCPServer.wlt:3839,1-3844,2"
+    TestID   -> "SupportedMCPClients-Has21Clients@@Tests/InstallMCPServer.wlt:3839,1-3844,2"
 ]
 
 VerificationTest[

--- a/Tests/InstallMCPServer.wlt
+++ b/Tests/InstallMCPServer.wlt
@@ -3838,14 +3838,14 @@ VerificationTest[
 
 VerificationTest[
     Length @ $SupportedMCPClients,
-    20,
+    21,
     SameTest -> Equal,
     TestID   -> "SupportedMCPClients-Has20Clients@@Tests/InstallMCPServer.wlt:3839,1-3844,2"
 ]
 
 VerificationTest[
     Keys @ $SupportedMCPClients,
-    { "AmazonQ", "Antigravity", "AugmentCode", "AugmentCodeIDE", "ClaudeCode", "ClaudeDesktop", "Cline", "Codex", "Continue", "CopilotCLI", "Cursor", "GeminiCLI", "Goose", "Junie", "Kiro", "LMStudio", "OpenCode", "VisualStudioCode", "Windsurf", "Zed" },
+    { "AmazonQ", "Antigravity", "AugmentCode", "AugmentCodeIDE", "ClaudeCode", "ClaudeDesktop", "Cline", "Codex", "Continue", "CopilotCLI", "Cursor", "GeminiCLI", "Goose", "Junie", "Kiro", "LMStudio", "OpenCode", "QwenCode", "VisualStudioCode", "Windsurf", "Zed" },
     SameTest -> Equal,
     TestID   -> "SupportedMCPClients-KeysSorted@@Tests/InstallMCPServer.wlt:3846,1-3851,2"
 ]

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -33,6 +33,7 @@ The following clients have built-in support for automatic configuration via `Ins
 | LM Studio | `"LMStudio"` | — | JSON | No | `"Wolfram"` |
 | Codex CLI | `"Codex"` | `"OpenAICodex"` | TOML | Yes | `"WolframLanguage"` |
 | OpenCode | `"OpenCode"` | — | JSON | Yes | `"WolframLanguage"` |
+| Qwen Code | `"QwenCode"` | `"Qwen"` | JSON | Yes | `"WolframLanguage"` |
 | Visual Studio Code | `"VisualStudioCode"` | `"VSCode"` | JSON | Yes | `"WolframLanguage"` |
 | Windsurf | `"Windsurf"` | `"Codeium"` | JSON | No | `"WolframLanguage"` |
 | Zed | `"Zed"` | — | JSON | Yes | `"WolframLanguage"` |
@@ -261,6 +262,19 @@ Note: Copilot CLI requires the `tools` field to specify which tools to enable. `
 | Global | `~/.gemini/settings.json` |
 
 **Format:** Same as Claude Desktop (`mcpServers` key).
+
+### Qwen Code
+
+Qwen Code is Alibaba's terminal coding agent, forked from Gemini CLI. It reads MCP servers from the `mcpServers` key of its `settings.json`, at both user and project scope.
+
+| Scope | Config Location |
+|-------|----------------|
+| Global | `~/.qwen/settings.json` |
+| Project | `.qwen/settings.json` (in project root) |
+
+**Format:** Same as Claude Desktop (`mcpServers` key).
+
+Note: Qwen Code shares Gemini CLI's config structure but, unlike Gemini CLI, also supports a project-scope `.qwen/settings.json`, so `InstallMCPServer[{"QwenCode", "/path/to/project"}]` installs a server for just that project. Qwen Code auto-migrates older `settings.json` layouts, but `mcpServers` remains a root-level key.
 
 ### Antigravity (IDE, desktop app, and CLI)
 

--- a/docs/quickstart-coding.md
+++ b/docs/quickstart-coding.md
@@ -198,6 +198,30 @@ opencode mcp list
 
 The output should indicate that the "WolframLanguage" server is connected.
 
+### Qwen Code
+
+Choose whether to install the server globally or project-level. Global installation is available in all projects, while project-level installation writes `.qwen/settings.json` in the project root.
+
+Global installation:
+
+```wl
+InstallMCPServer["QwenCode", "WolframLanguage"]
+```
+
+Project-level installation:
+
+```wl
+InstallMCPServer[{"QwenCode", "/path/to/project"}, "WolframLanguage"]
+```
+
+To verify the installation from the command line:
+
+```shell
+qwen mcp list
+```
+
+The output should indicate that the "WolframLanguage" server is configured.
+
 ### Visual Studio Code
 
 Choose whether to install the server globally or project-level. Global installation is available in all projects, while project-level installation is available only in a specific project directory.


### PR DESCRIPTION
I tried AgentTools/Wolfram MCP with Qwen Code. It works pretty well. I added relevant lines for installing Wolfram MCP to Qwen Code:

```wolfram
Quit

With[
 {dir = FileNameJoin[{"/absolute/path/to/", "AgentTools"}]},
 PacletDirectoryUnload[dir];
 PacletDataRebuild[];
 PacletDirectoryLoad[dir]
 ]

Needs["Wolfram`AgentTools`"]

InstallMCPServer["QwenCode"]
```