### PR TITLE
Support WolframLanguageEvaluator sessions under the Cloud method

### DIFF
--- a/Kernel/Tools/WolframLanguageEvaluator.wl
+++ b/Kernel/Tools/WolframLanguageEvaluator.wl
@@ -21,6 +21,9 @@ $cloudImagePermissions := If[ $imageExportMethod === "CloudPublic", "Public", "P
 $line                   = 1;
 $outputSizeLimit        = 100000;
 
+(* Chatbook version that introduced cb`$CloudSessionMX (see the Cloud Sessions section) *)
+$cloudSessionMXChatbookVersion = "2.7.11";
+
 (* Evaluator session state (plain load-time assignments, so they reset on every (re)load; see the Sessions section) *)
 $currentSessionID = None;
 $sessionStatus    = None;
@@ -142,25 +145,41 @@ evaluateWolframLanguage // endDefinition;
 
 
 evaluateWolframLanguage0 // beginDefinition;
+evaluateWolframLanguage0[ code_String, timeConstraint_Integer ] := chatbookToolEvaluate[ code, "String", timeConstraint ];
+evaluateWolframLanguage0 // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*chatbookToolEvaluate*)
+(* Shared Chatbook call behind the plain and UI evaluation paths. The session's line counter is consumed
+   here: it becomes the "Line" option (which drives the In/Out label under the in-process methods) and also
+   seeds Chatbook's own per-kernel cloud line counter, because under the "Cloud" method the option never
+   reaches the cloud evaluator kernel that produces the label (see Cloud Sessions). *)
+chatbookToolEvaluate // beginDefinition;
 (* :!CodeAnalysis::BeginBlock:: *)
 (* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
-evaluateWolframLanguage0[ code_String, timeConstraint_Integer ] :=
-    Block[ (* FIXME: Expose this as an option in WolframLanguageToolEvaluate *)
-        { Wolfram`Chatbook`Sandbox`Private`$includeDefinitions = False },
+chatbookToolEvaluate[ code_String, property_, timeConstraint_Integer ] :=
+    With[ { line = $line++ },
+        Block[
+            { (* FIXME: Expose these as options in WolframLanguageToolEvaluate *)
+                Wolfram`Chatbook`Sandbox`Private`$includeDefinitions = False,
+                Wolfram`Chatbook`Sandbox`Private`$cloudLineNumber    = line
+            },
             catchAlways @ cb`WolframLanguageToolEvaluate[
-            code,
-            "String",
-            "Line"                  -> $line++,
-            "AppendRetryNotice"     -> False,
-            "AppendURIInstructions" -> False,
-            "MaxCharacterCount"     -> $maxCharacterCount,
-            "Method"                -> getEvaluatorMethod[ ],
-            "PropagateMessages"     -> True,
-            "TimeConstraint"        -> timeConstraint
+                code,
+                property,
+                "Line"                  -> line,
+                "AppendRetryNotice"     -> False,
+                "AppendURIInstructions" -> False,
+                "MaxCharacterCount"     -> $maxCharacterCount,
+                "Method"                -> getEvaluatorMethod[ ],
+                "PropagateMessages"     -> True,
+                "TimeConstraint"        -> timeConstraint
+            ]
         ]
     ];
 (* :!CodeAnalysis::EndBlock:: *)
-evaluateWolframLanguage0 // endDefinition;
+chatbookToolEvaluate // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -302,23 +321,8 @@ evaluateWolframLanguageUI // endDefinition;
 (* ::Subsection::Closed:: *)
 (*evaluateWolframLanguageForUI*)
 evaluateWolframLanguageForUI // beginDefinition;
-(* :!CodeAnalysis::BeginBlock:: *)
-(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
 evaluateWolframLanguageForUI[ code_String, timeConstraint_Integer ] :=
-    Block[ { Wolfram`Chatbook`Sandbox`Private`$includeDefinitions = False },
-        catchAlways @ cb`WolframLanguageToolEvaluate[
-            code,
-            { "String", "Result" },
-            "Line"                  -> $line++,
-            "AppendRetryNotice"     -> False,
-            "AppendURIInstructions" -> False,
-            "MaxCharacterCount"     -> $maxCharacterCount,
-            "Method"                -> getEvaluatorMethod[ ],
-            "PropagateMessages"     -> True,
-            "TimeConstraint"        -> timeConstraint
-        ]
-    ];
-(* :!CodeAnalysis::EndBlock:: *)
+    chatbookToolEvaluate[ code, { "String", "Result" }, timeConstraint ];
 evaluateWolframLanguageForUI // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
@@ -560,7 +564,11 @@ initializePacletInLocalKernel // endDefinition;
    the session payload and passed as the "Line" option. Under the in-process "Session" method that option
    drives the In/Out label directly. Under "Local" the user's code runs in a persistent subkernel whose own
    $Line produces the label and the option does not reach it, so syncEvalKernelLine pushes $line into that
-   subkernel's $Line at each session boundary, after which the two advance in lockstep. *)
+   subkernel's $Line at each session boundary, after which the two advance in lockstep.
+
+   Under the "Cloud" method the user's code runs in a fresh, non-persistent cloud kernel on every call, so a
+   session's definitions travel in Chatbook's session byte array instead of living in any kernel, and the
+   session parses into Global` rather than an isolating context; see the Cloud Sessions subsection. *)
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
@@ -606,6 +614,121 @@ sessionFile // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*Cloud Sessions*)
+(* Under the "Cloud" method (the default when the server itself runs in the Wolfram Cloud) every evaluation
+   runs in a fresh cloud evaluator kernel that is discarded afterward, so no kernel holds a session's state
+   between calls. Chatbook 2.7.11+ bridges this with a session byte array: after each cloud evaluation it
+   stores the evaluator kernel's Global` definitions as an MX byte array in cb`$CloudSessionMX, and before
+   each one it loads whatever cb`$CloudSessionMX holds into the evaluator kernel. A cloud session therefore
+   keeps its definitions in that byte array, persisted as the "SessionMX" entry of its saved $sessionInfo and
+   pushed back into cb`$CloudSessionMX whenever the session is started, continued, or resumed (withSession
+   scopes the symbol to a single call so nothing leaks between sessions or outlives the call).
+
+   Two things differ from the in-kernel methods:
+   - Session code is parsed into Global` instead of Sessions`<id>`, because the cloud evaluator saves Global`
+     definitions only. Isolation between sessions is inherent: the evaluator kernel starts empty and loads
+     only that session's byte array.
+   - Only definitions persist. In/Out history, loaded packages, and any other kernel state are gone after
+     every call, which sessionInfoStatusText tells the AI on each call. Without a new enough Chatbook nothing
+     persists at all, and the status text says so instead. *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*cloudSessionQ*)
+cloudSessionQ // beginDefinition;
+cloudSessionQ[ ] := getEvaluatorMethod[ ] === "Cloud";
+cloudSessionQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*cloudSessionMXAvailableQ*)
+(* Whether the loaded Chatbook supports cb`$CloudSessionMX. Only a positive answer is cached: session setup
+   runs before chatbookVersionCheck gets a chance to install and load an up-to-date Chatbook, and a negative
+   answer must not outlive that upgrade. *)
+cloudSessionMXAvailableQ // beginDefinition;
+
+cloudSessionMXAvailableQ[ ] :=
+    With[ { available = cloudSessionMXAvailableQ @ Quiet @ PacletObject[ "Wolfram/Chatbook" ][ "Version" ] },
+        If[ available, cloudSessionMXAvailableQ[ ] = True ];
+        available
+    ];
+
+cloudSessionMXAvailableQ[ $cloudSessionMXChatbookVersion ] := True;
+cloudSessionMXAvailableQ[ version_String ] := TrueQ @ PacletNewerQ[ version, $cloudSessionMXChatbookVersion ];
+cloudSessionMXAvailableQ[ _ ] := False;
+
+cloudSessionMXAvailableQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*setCloudSessionMX*)
+(* Give the cloud evaluator the session's saved definitions (None: start from an empty kernel). No-op unless
+   this is a cloud session and Chatbook is new enough to honor the symbol. *)
+setCloudSessionMX // beginDefinition;
+
+setCloudSessionMX[ mx_ ] /; cloudSessionQ[ ] && cloudSessionMXAvailableQ[ ] :=
+    cb`$CloudSessionMX = Replace[ mx, Except[ _ByteArray ] -> None ];
+
+setCloudSessionMX[ _ ] := Null;
+
+setCloudSessionMX // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*getCloudSessionMX*)
+(* The session's definitions as left by the last cloud evaluation, or None when there are none to keep. *)
+getCloudSessionMX // beginDefinition;
+getCloudSessionMX[ ] := getCloudSessionMX[ cloudSessionQ[ ] && cloudSessionMXAvailableQ[ ] ];
+getCloudSessionMX[ True ] := Replace[ cb`$CloudSessionMX, Except[ _ByteArray ] -> None ];
+getCloudSessionMX[ False ] := None;
+getCloudSessionMX // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*sessionContext*)
+(* The context session code is parsed into: an isolating per-session context under the in-kernel methods,
+   Global` for a cloud session (see above). *)
+$cloudSessionContext = "Global`";
+
+sessionContext // beginDefinition;
+sessionContext[ _String ] /; cloudSessionQ[ ] := $cloudSessionContext;
+sessionContext[ id_String ] := "Sessions`" <> id <> "`";
+sessionContext // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*applySessionContext*)
+applySessionContext // beginDefinition;
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+applySessionContext[ ctx_String ] := (
+    $Context        = ctx;
+    $ContextPath    = { ctx, "System`" };
+    $ContextAliases = <| |>;
+);
+(* :!CodeAnalysis::EndBlock:: *)
+applySessionContext // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*restoreCloudSessionState*)
+(* Re-establish a cloud session's kernel-side state from its saved info when continuing or resuming it. Any
+   context changes made by the session's own evaluations happened in a discarded evaluator kernel, so a
+   cloud session always parses into Global`, whatever its info recorded (e.g. a file written under another
+   "Method"). No-op for the in-kernel methods. *)
+restoreCloudSessionState // beginDefinition;
+
+restoreCloudSessionState[ info_Association ] /; cloudSessionQ[ ] := (
+    applySessionContext @ $cloudSessionContext;
+    setCloudSessionMX @ Lookup[ info, "SessionMX", None ];
+);
+
+restoreCloudSessionState[ _ ] := Null;
+
+restoreCloudSessionState // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*Starting, Saving, and Resuming Sessions*)
 (* The *InKernel companions set up the eval-kernel-side session state ($Context, In/Out history, $Line)
    via useEvaluatorKernel and return the line seed; the outer functions update the MCP-side
@@ -640,9 +763,8 @@ startSessionInKernel // beginDefinition;
 (* :!CodeAnalysis::BeginBlock:: *)
 (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
 startSessionInKernel[ id_String ] := (
-    $Context        = "Sessions`" <> id <> "`";
-    $ContextPath    = { $Context, "System`" };
-    $ContextAliases = <| |>;
+    applySessionContext @ sessionContext @ id;
+    setCloudSessionMX @ None; (* a new cloud session starts from an empty evaluator kernel *)
     Unprotect[ In, InString, Out, MessageList ];
     DownValues[ In ]          = { };
     DownValues[ InString ]    = { };
@@ -672,7 +794,8 @@ startSessionInKernel // endDefinition;
    file-scoped $line counter persist between calls. $Context/$ContextPath/$ContextAliases are restored
    from the state captured by the last save ($sessionInfo) rather than reset to defaults, so context
    changes made by the session's own evaluations (e.g. Get prepending a package context to the path)
-   survive across calls. Returns $Failed without throwing when the kernel-side state is missing or
+   survive across calls. A cloud session additionally gets its definitions byte array back from the same
+   state (see Cloud Sessions). Returns $Failed without throwing when the kernel-side state is missing or
    belongs to a different session (e.g. the eval kernel restarted between calls); the caller then falls
    back to resuming from the session file. *)
 enterSessionContext // beginDefinition;
@@ -698,6 +821,7 @@ enterSessionContextInKernel[ id_String ] :=
             $Context        = info[ "$Context" ];
             $ContextPath    = info[ "$ContextPath" ];
             $ContextAliases = info[ "$ContextAliases" ];
+            restoreCloudSessionState @ info;
             Null,
             $Failed
         ]
@@ -767,9 +891,10 @@ saveSession[ id_String ] := Enclose[
             True | _Association,
             "Saved"
         ];
-        (* The eval kernel could not write the file itself (e.g. the "Local" sandbox kernel blocks
-           file writes) and returned its session info instead: persist it from this kernel. Such a
-           file carries no session-context definitions, only the state needed to resume metadata,
+        (* The eval kernel returned its session info instead of writing the file itself, either because
+           it could not (e.g. the "Local" sandbox kernel blocks file writes) or because this is a cloud
+           session, whose definitions travel inside that info (see Cloud Sessions): persist it from this
+           kernel. Such a file carries no session-context definitions, only the state needed to resume,
            which is all the eval kernel could capture anyway. *)
         If[ AssociationQ @ saved,
             ConfirmMatch[ writeSessionInfoFile[ First @ file, saved ], True, "SavedFallback" ]
@@ -788,21 +913,53 @@ saveSession // endDefinition;
 saveSessionInKernel // beginDefinition;
 (* :!CodeAnalysis::BeginBlock:: *)
 (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
-saveSessionInKernel[ id_String, path_String, line_Integer ] :=
+saveSessionInKernel[ id_String, path_String, line_Integer ] := (
+    $sessionInfo = makeSessionInfo[ id, line ];
+    If[ cloudSessionQ[ ],
+        (* A cloud session has no session context to dump (its definitions travel in the "SessionMX" entry
+           of the info), so its file holds only the info: hand it back for saveSession to write. *)
+        $sessionInfo,
+        dumpSessionContext @ path
+    ]
+);
+(* :!CodeAnalysis::EndBlock:: *)
+saveSessionInKernel // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*makeSessionInfo*)
+makeSessionInfo // beginDefinition;
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+makeSessionInfo[ id_String, line_Integer ] := <|
+    "SessionID"       -> id, (* lets a continuing call verify $sessionInfo is its own; see enterSessionContextInKernel *)
+    "KernelSessionID" -> $kernelSessionID, (* identifies the saving kernel process; see resumeSessionInKernel *)
+    "$Context"        -> $Context,
+    "$ContextPath"    -> $ContextPath,
+    "$ContextAliases" -> $ContextAliases,
+    "$Line"           -> $Line, (* eval kernel's $Line, kept for reference / back-compat *)
+    "$line"           -> line,  (* authoritative per-session counter that drives resume (injected by saveSession) *)
+    "In"              -> DownValues[ In ],
+    "InString"        -> DownValues[ InString ],
+    "Out"             -> DownValues[ Out ],
+    "MessageList"     -> DownValues[ MessageList ],
+    (* A cloud session's definitions live in Chatbook's session byte array rather than in any kernel (see Cloud Sessions) *)
+    If[ cloudSessionQ[ ], "SessionMX" -> getCloudSessionMX[ ], Nothing ]
+|>;
+(* :!CodeAnalysis::EndBlock:: *)
+makeSessionInfo // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*dumpSessionContext*)
+(* DumpSave the session $Context (all user symbols) plus the held $sessionInfo symbol to path. Returns True
+   on success, or the session info when the write failed so saveSession can persist that from the
+   controlling kernel. *)
+dumpSessionContext // beginDefinition;
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+dumpSessionContext[ path_String ] :=
     Module[ { tmp, written },
-        $sessionInfo = <|
-            "SessionID"       -> id, (* lets a continuing call verify $sessionInfo is its own; see enterSessionContextInKernel *)
-            "KernelSessionID" -> $kernelSessionID, (* identifies the saving kernel process; see resumeSessionInKernel *)
-            "$Context"        -> $Context,
-            "$ContextPath"    -> $ContextPath,
-            "$ContextAliases" -> $ContextAliases,
-            "$Line"           -> $Line, (* eval kernel's $Line, kept for reference / back-compat *)
-            "$line"           -> line,  (* authoritative per-session counter that drives resume (injected by saveSession) *)
-            "In"              -> DownValues[ In ],
-            "InString"        -> DownValues[ InString ],
-            "Out"             -> DownValues[ Out ],
-            "MessageList"     -> DownValues[ MessageList ]
-        |>;
         tmp = path <> "." <> CreateUUID[ ] <> ".tmp"; (* unique per attempt, so its existence proves THIS write happened *)
         (* DumpSave the session $Context (all user symbols) plus the held $sessionInfo symbol; the With
            injects the evaluated context string while DumpSave's HoldRest keeps $sessionInfo a symbol.
@@ -827,14 +984,15 @@ saveSessionInKernel[ id_String, path_String, line_Integer ] :=
         ]
     ];
 (* :!CodeAnalysis::EndBlock:: *)
-saveSessionInKernel // endDefinition;
+dumpSessionContext // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*writeSessionInfoFile*)
-(* Fallback writer for when the eval kernel cannot write files itself: persist the session info it
-   returned as the same DumpSave format resumeSessionInKernel reads (the Block gives the held
-   $sessionInfo symbol the eval kernel's value for the duration of the write). *)
+(* Writer for info-only session files (no session-context definitions): used when the eval kernel cannot
+   write files itself, and for cloud sessions, whose definitions travel inside the info (see Cloud
+   Sessions). Persists the session info as the same DumpSave format resumeSessionInKernel reads (the Block
+   gives the held $sessionInfo symbol the eval kernel's value for the duration of the write). *)
 writeSessionInfoFile // beginDefinition;
 
 writeSessionInfoFile[ path_String, info_Association ] :=
@@ -922,6 +1080,7 @@ resumeSessionInKernel[ path_String ] :=
             DownValues[ Out ]         = info[ "Out" ];
             DownValues[ MessageList ] = info[ "MessageList" ];
             Protect[ In, InString, Out, MessageList ];
+            restoreCloudSessionState @ info;
             (* The second element reports whether the file was saved by this same kernel process;
                files saved before KernelSessionID existed conservatively count as a different kernel. *)
             { line, info[ "KernelSessionID" ] === $kernelSessionID },
@@ -1105,21 +1264,25 @@ saveSessionSafe // endDefinition;
    evaluation and the save, then restored to the kernel's neutral baseline afterward. Symbols created
    during the block (the user's definitions) persist in their session context, as do the session's
    In/Out/$Line (which are not in the block), so isolation and history survive across calls while the
-   kernel is never left in a session context between calls. *)
+   kernel is never left in a session context between calls. Chatbook's cloud session byte array is scoped
+   the same way: a cloud session's definitions are pushed into it by applySession and read back by the
+   save, and never leak into another session or outlive the call (see Cloud Sessions). *)
 withSession // beginDefinition;
 withSession // Attributes = { HoldRest };
 
 withSession[ session_, eval_ ] :=
     Internal`InheritedBlock[ { $Context, $ContextPath, $ContextAliases },
-        Module[ { id, result },
-            id = applySession @ session;
-            (* applySession has set $line and the session $Context. For the "Local" method also push $line
-               into the eval subkernel's $Line at a boundary (a continued session already tracks it in
-               lockstep); no-op for in-process methods. *)
-            If[ $sessionStatus =!= "continued", syncEvalKernelLineSafe @ $line ];
-            result = eval;
-            saveSessionSafe @ id;
-            appendSessionInfo[ result, id ]
+        Block[ { cb`$CloudSessionMX = None },
+            Module[ { id, result },
+                id = applySession @ session;
+                (* applySession has set $line and the session $Context. For the "Local" method also push
+                   $line into the eval subkernel's $Line at a boundary (a continued session already tracks
+                   it in lockstep); no-op for in-process methods. *)
+                If[ $sessionStatus =!= "continued", syncEvalKernelLineSafe @ $line ];
+                result = eval;
+                saveSessionSafe @ id;
+                appendSessionInfo[ result, id ]
+            ]
         ]
     ];
 
@@ -1171,17 +1334,47 @@ sessionInfoText // endDefinition;
 (*sessionInfoStatusText*)
 sessionInfoStatusText // beginDefinition;
 
-sessionInfoStatusText[ "reused" ] := "\
-No saved state was found for the requested session ID, so a new empty session was started. ";
+sessionInfoStatusText[ status_ ] := sessionInfoStatusText[ status, cloudSessionQ[ ] ];
 
-sessionInfoStatusText[ "resumedNewKernel" ] := "\
+sessionInfoStatusText[ "reused", cloud_ ] := "\
+No saved state was found for the requested session ID, so a new empty session was started. " <>
+    sessionInfoStatusText[ "new", cloud ];
+
+sessionInfoStatusText[ "resumedNewKernel", False ] := "\
 The kernel process for this session has changed (e.g. the server restarted), so the session \
 was restored from its last saved state. Session definitions and history were restored, but other \
 kernel state (e.g. packages loaded with Get or Needs) may be missing and might need to be reloaded. ";
 
-sessionInfoStatusText[ _ ] := "";
+(* A cloud session runs in a fresh cloud kernel on every call (see Cloud Sessions), so the AI is reminded on
+   each call of what does and does not persist. *)
+sessionInfoStatusText[ status_String, True ] := cloudSessionStatusText[ status, cloudSessionMXAvailableQ[ ] ];
+
+sessionInfoStatusText[ _, _ ] := "";
 
 sessionInfoStatusText // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*cloudSessionStatusText*)
+cloudSessionStatusText // beginDefinition;
+
+(* Chatbook too old for the session byte array: nothing persists at all. *)
+cloudSessionStatusText[ _, False ] := "\
+This session runs in a non-persistent cloud kernel and cannot restore definitions from previous calls \
+(that requires Wolfram/Chatbook " <> $cloudSessionMXChatbookVersion <> " or later on the server), so each \
+call starts from an empty kernel and must include everything it needs. ";
+
+cloudSessionStatusText[ "new", True ] := "\
+This session runs in a non-persistent cloud kernel: its global definitions (variables and functions) are \
+saved after each call and restored before the next, but all other kernel state (loaded packages, In/Out \
+history, %, etc.) is lost between calls. ";
+
+cloudSessionStatusText[ _, True ] := "\
+This session runs in a non-persistent cloud kernel: its saved global definitions were restored, but all \
+other kernel state (loaded packages, In/Out history, %, etc.) does not persist between calls and must be \
+re-established in each call that needs it. ";
+
+cloudSessionStatusText // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Specs/CloudDeployment.md
+++ b/Specs/CloudDeployment.md
@@ -88,7 +88,10 @@ Explicitly out of scope for the initial implementation (see [Future Work](#futur
   object, including code-execution tools such as `WolframLanguageEvaluator`. Access control is the
   owner's responsibility, mediated entirely by API keys.
 - **Caching / persistent kernels.** Each request is a fresh, stateless evaluation
-  (see [Evaluation Model](#evaluation-model)).
+  (see [Evaluation Model](#evaluation-model)). Evaluator *sessions* nevertheless work across requests:
+  their files persist in the account's cloud user files and their definitions round-trip through
+  Chatbook's `$CloudSessionMX` (see
+  [Stateless Evaluation Model](../docs/cloud-deployment.md#stateless-evaluation-model)).
 - **Local consumption.** Making the deployed remote endpoint installable into local MCP clients
   (a URL-based `InstallMCPServer`) is a separate future effort.
 

--- a/Tests/EvaluatorSessions.wlt
+++ b/Tests/EvaluatorSessions.wlt
@@ -447,6 +447,304 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
+(*Cloud Sessions*)
+(* Under the "Cloud" method a session's definitions travel in Chatbook's session byte array
+   (Wolfram`Chatbook`$CloudSessionMX, Chatbook 2.7.11+) and the session parses into Global`; see the
+   Cloud Sessions section of Kernel/Tools/WolframLanguageEvaluator.wl. These exercise the bookkeeping
+   without a cloud: the Method tool option selects the cloud path and the Chatbook version gate is mocked. *)
+$cloudMethodOptions = <| "WolframLanguageEvaluator" -> <| "Method" -> "Cloud" |> |>;
+
+VerificationTest[
+    Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ /@
+        { "2.7.10", "2.7.11", "2.7.12", "2.8.0", "3.0.0", $Failed, None },
+    { False, True, True, True, True, False, False },
+    SameTest -> MatchQ,
+    TestID   -> "CloudSessionMXAvailableQ-VersionGate@@Tests/EvaluatorSessions.wlt:457,1-463,2"
+]
+
+VerificationTest[
+    BooleanQ @ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ[ ],
+    True,
+    TestID -> "CloudSessionMXAvailableQ-LoadedChatbook@@Tests/EvaluatorSessions.wlt:465,1-469,2"
+]
+
+VerificationTest[
+    {
+        Block[ { Wolfram`AgentTools`Common`$toolOptions = <| |> },
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionQ[ ]
+        ],
+        Block[ { Wolfram`AgentTools`Common`$toolOptions = $cloudMethodOptions },
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionQ[ ]
+        ]
+    },
+    { False, True },
+    SameTest -> MatchQ,
+    TestID   -> "CloudSessionQ-FollowsMethodOption@@Tests/EvaluatorSessions.wlt:471,1-483,2"
+]
+
+(* In-kernel methods isolate each session in its own context; a cloud session parses into Global`,
+   which is the only context the cloud evaluator's session byte array captures. *)
+VerificationTest[
+    {
+        Block[ { Wolfram`AgentTools`Common`$toolOptions = <| |> },
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionContext[ "Abc123" ]
+        ],
+        Block[ { Wolfram`AgentTools`Common`$toolOptions = $cloudMethodOptions },
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionContext[ "Abc123" ]
+        ]
+    },
+    { "Sessions`Abc123`", "Global`" },
+    SameTest -> MatchQ,
+    TestID   -> "SessionContext-CloudUsesGlobal@@Tests/EvaluatorSessions.wlt:487,1-499,2"
+]
+
+(* Starting a cloud session parses into Global` and clears the byte array so the evaluator starts empty. *)
+VerificationTest[
+    Internal`InheritedBlock[ { $Context, $ContextPath, $ContextAliases },
+        Block[
+            {
+                Wolfram`AgentTools`Common`$toolOptions = $cloudMethodOptions,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ = True &,
+                Wolfram`Chatbook`$CloudSessionMX = ByteArray[ { 1, 2, 3 } ],
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionInfo = None
+            },
+            {
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`startSessionInKernel[ "CloudStartSess" ],
+                $Context,
+                $ContextPath,
+                Wolfram`Chatbook`$CloudSessionMX,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionInfo[ "$Context" ]
+            }
+        ]
+    ],
+    { 1, "Global`", { "Global`", "System`" }, None, "Global`" },
+    SameTest -> MatchQ,
+    TestID   -> "StartSessionInKernel-CloudUsesGlobalAndClearsSessionMX@@Tests/EvaluatorSessions.wlt:502,1-523,2"
+]
+
+(* Saving a cloud session returns info-only state (nothing to dump from this kernel) that carries the
+   byte array left by the last cloud evaluation, so saveSession writes it from the controlling kernel. *)
+VerificationTest[
+    Module[ { dir, path, res },
+        dir  = FileNameJoin @ { $TemporaryDirectory, "AgentToolsCloudSave_" <> CreateUUID[ ] };
+        path = FileNameJoin @ { dir, "CloudSaveSess.mx" };
+        res  = Internal`InheritedBlock[ { $Context, $ContextPath, $ContextAliases },
+            Block[
+                {
+                    Wolfram`AgentTools`Common`$toolOptions = $cloudMethodOptions,
+                    Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ = True &,
+                    Wolfram`Chatbook`$CloudSessionMX = ByteArray[ { 4, 5, 6 } ],
+                    Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionInfo = None
+                },
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`saveSessionInKernel[ "CloudSaveSess", path, 3 ]
+            ]
+        ];
+        { res, DirectoryQ @ dir }
+    ],
+    {
+        KeyValuePattern @ { "SessionID" -> "CloudSaveSess", "$line" -> 3, "SessionMX" -> ByteArray[ { 4, 5, 6 } ] },
+        False
+    },
+    SameTest -> MatchQ,
+    TestID   -> "SaveSessionInKernel-CloudReturnsInfoWithSessionMX@@Tests/EvaluatorSessions.wlt:527,1-550,2"
+]
+
+(* Without a new enough Chatbook there is no byte array to keep; in-kernel sessions never carry one. *)
+VerificationTest[
+    {
+        Block[
+            {
+                Wolfram`AgentTools`Common`$toolOptions = $cloudMethodOptions,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ = False &,
+                Wolfram`Chatbook`$CloudSessionMX = ByteArray[ { 4, 5, 6 } ]
+            },
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`makeSessionInfo[ "CloudNoMXSess", 2 ][ "SessionMX" ]
+        ],
+        Block[ { Wolfram`AgentTools`Common`$toolOptions = <| |> },
+            KeyExistsQ[ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`makeSessionInfo[ "InKernelSess", 2 ], "SessionMX" ]
+        ]
+    },
+    { None, False },
+    SameTest -> MatchQ,
+    TestID   -> "MakeSessionInfo-SessionMXOnlyForSupportedCloudSessions@@Tests/EvaluatorSessions.wlt:553,1-570,2"
+]
+
+(* An info-only cloud session file round-trips: resuming restores the byte array for the next cloud
+   evaluation and always parses into Global`, even if the file recorded another context (e.g. one
+   written under a different Method). *)
+VerificationTest[
+    Module[ { dir, path, info, res, mx, ctx },
+        dir  = CreateDirectory @ FileNameJoin @ { $TemporaryDirectory, "AgentToolsCloudRT_" <> CreateUUID[ ] };
+        path = FileNameJoin @ { dir, "CloudRoundTrip.mx" };
+        info = <|
+            "SessionID"       -> "CloudRoundTrip",
+            "KernelSessionID" -> -42,
+            "$Context"        -> "Sessions`CloudRoundTrip`",
+            "$ContextPath"    -> { "Sessions`CloudRoundTrip`", "System`" },
+            "$ContextAliases" -> <| |>,
+            "$Line"           -> 4,
+            "$line"           -> 4,
+            "In"              -> { },
+            "InString"        -> { },
+            "Out"             -> { },
+            "MessageList"     -> { },
+            "SessionMX"       -> ByteArray[ { 7, 8, 9 } ]
+        |>;
+        Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`writeSessionInfoFile[ path, info ];
+        { res, mx, ctx } = Internal`InheritedBlock[ { $Context, $ContextPath, $ContextAliases },
+            Block[
+                {
+                    Wolfram`AgentTools`Common`$toolOptions = $cloudMethodOptions,
+                    Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ = True &,
+                    Wolfram`Chatbook`$CloudSessionMX = None,
+                    Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionInfo = None
+                },
+                {
+                    Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`resumeSessionInKernel @ path,
+                    Wolfram`Chatbook`$CloudSessionMX,
+                    $Context
+                }
+            ]
+        ];
+        Quiet @ DeleteDirectory[ dir, DeleteContents -> True ];
+        { res, mx, ctx }
+    ],
+    { { 4, False }, ByteArray[ { 7, 8, 9 } ], "Global`" },
+    SameTest -> MatchQ,
+    TestID   -> "ResumeSessionInKernel-CloudRestoresSessionMXAndGlobalContext@@Tests/EvaluatorSessions.wlt:575,1-615,2"
+]
+
+(* Continuing a live cloud session gets its byte array back from the last save's $sessionInfo. *)
+VerificationTest[
+    Internal`InheritedBlock[ { $Context, $ContextPath, $ContextAliases },
+        Block[
+            {
+                Wolfram`AgentTools`Common`$toolOptions = $cloudMethodOptions,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ = True &,
+                Wolfram`Chatbook`$CloudSessionMX = None,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$sessionInfo = <|
+                    "SessionID"       -> "CloudEnterSess",
+                    "KernelSessionID" -> 0,
+                    "$Context"        -> "Global`",
+                    "$ContextPath"    -> { "Global`", "System`" },
+                    "$ContextAliases" -> <| |>,
+                    "SessionMX"       -> ByteArray[ { 1, 1, 2 } ]
+                |>
+            },
+            {
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`enterSessionContextInKernel[ "CloudEnterSess" ],
+                Wolfram`Chatbook`$CloudSessionMX,
+                $Context
+            }
+        ]
+    ],
+    { Null, ByteArray[ { 1, 1, 2 } ], "Global`" },
+    SameTest -> MatchQ,
+    TestID   -> "EnterSessionContextInKernel-CloudRestoresSessionMX@@Tests/EvaluatorSessions.wlt:618,1-644,2"
+]
+
+(* The "Line" option never reaches the cloud evaluator kernel, so the session's line counter is also
+   pushed into Chatbook's per-kernel cloud line counter for the duration of the call. *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$line = 7,
+            Wolfram`Chatbook`WolframLanguageToolEvaluate =
+                { Wolfram`Chatbook`Sandbox`Private`$cloudLineNumber, Lookup[ { ##3 }, "Line" ] } &
+        },
+        {
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`chatbookToolEvaluate[ "1", "String", 10 ],
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$line
+        }
+    ],
+    { { 7, 7 }, 8 },
+    SameTest -> MatchQ,
+    TestID   -> "ChatbookToolEvaluate-SyncsCloudLineCounterWithSessionLine@@Tests/EvaluatorSessions.wlt:648,1-663,2"
+]
+
+(* Cloud sessions remind the AI on every call that the kernel is non-persistent... *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Common`$toolOptions = $cloudMethodOptions,
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ = True &
+        },
+        StringContainsQ[
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionInfoStatusText[ # ],
+            "non-persistent cloud kernel"
+        ] & /@ { "new", "continued", "resumed", "resumedNewKernel", "reused" }
+    ],
+    { True, True, True, True, True },
+    SameTest -> MatchQ,
+    TestID   -> "SessionInfoStatusText-CloudNoticeOnEveryStatus@@Tests/EvaluatorSessions.wlt:666,1-680,2"
+]
+
+(* ...replacing (not appending to) the in-kernel "kernel process has changed" wording... *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Common`$toolOptions = $cloudMethodOptions,
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ = True &
+        },
+        With[ { text = Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionInfoStatusText[ "resumedNewKernel" ] },
+            { StringContainsQ[ text, "kernel process for this session has changed" ], StringContainsQ[ text, "definitions were restored" ] }
+        ]
+    ],
+    { False, True },
+    SameTest -> MatchQ,
+    TestID   -> "SessionInfoStatusText-CloudReplacesKernelChangedNotice@@Tests/EvaluatorSessions.wlt:683,1-696,2"
+]
+
+(* ...while an unknown ID still gets the "No saved state" notice ahead of the cloud one. *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Common`$toolOptions = $cloudMethodOptions,
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ = True &
+        },
+        With[ { text = Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionInfoStatusText[ "reused" ] },
+            { StringContainsQ[ text, "No saved state" ], StringContainsQ[ text, "saved after each call" ] }
+        ]
+    ],
+    { True, True },
+    SameTest -> MatchQ,
+    TestID   -> "SessionInfoStatusText-CloudReusedKeepsNoSavedStateNotice@@Tests/EvaluatorSessions.wlt:699,1-712,2"
+]
+
+(* Without a new enough Chatbook the notice says definitions cannot be restored and names the version. *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Common`$toolOptions = $cloudMethodOptions,
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ = False &
+        },
+        With[ { text = Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionInfoStatusText[ "continued" ] },
+            {
+                StringContainsQ[ text, "cannot restore definitions" ],
+                StringContainsQ[ text, Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$cloudSessionMXChatbookVersion ]
+            }
+        ]
+    ],
+    { True, True },
+    SameTest -> MatchQ,
+    TestID   -> "SessionInfoStatusText-CloudWithoutChatbookSupport@@Tests/EvaluatorSessions.wlt:715,1-731,2"
+]
+
+(* In-kernel methods are unaffected. *)
+VerificationTest[
+    Block[ { Wolfram`AgentTools`Common`$toolOptions = <| |> },
+        StringContainsQ[
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`sessionInfoStatusText[ # ],
+            "cloud kernel"
+        ] & /@ { "new", "continued", "resumed", "resumedNewKernel", "reused" }
+    ],
+    { False, False, False, False, False },
+    SameTest -> MatchQ,
+    TestID   -> "SessionInfoStatusText-InKernelHasNoCloudNotice@@Tests/EvaluatorSessions.wlt:734,1-744,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
 (*Integration: end-to-end session behavior*)
 (* These invoke the real tool (non-UI path), redirecting session storage to a temporary root so the
    user's real Sessions directory is untouched. $currentSessionID is reset per test for determinism. *)
@@ -470,7 +768,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r3, "42" ]
     ],
     True,
-    TestID -> "Integration-SessionIsolation@@Tests/EvaluatorSessions.wlt:455,1-474,2"
+    TestID -> "Integration-SessionIsolation@@Tests/EvaluatorSessions.wlt:753,1-772,2"
 ]
 
 (* Re-passing the same session ID continues it: definitions persist and line numbers advance. *)
@@ -492,7 +790,7 @@ VerificationTest[
         StringContainsQ[ text, "6" ] && StringContainsQ[ text, "Out[2]" ]
     ],
     True,
-    TestID -> "Integration-ContinueSamePersistsAndAdvancesLine@@Tests/EvaluatorSessions.wlt:477,1-496,2"
+    TestID -> "Integration-ContinueSamePersistsAndAdvancesLine@@Tests/EvaluatorSessions.wlt:775,1-794,2"
 ]
 
 (* A session resumes from disk after its in-kernel symbols are gone (simulated server restart). *)
@@ -516,7 +814,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r2, "99" ]
     ],
     True,
-    TestID -> "Integration-RestartResumeFromDisk@@Tests/EvaluatorSessions.wlt:499,1-520,2"
+    TestID -> "Integration-RestartResumeFromDisk@@Tests/EvaluatorSessions.wlt:797,1-818,2"
 ]
 
 (* Every result echoes the session ID with resume instructions. *)
@@ -536,7 +834,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "session=\"AppendSession\"" ]
     ],
     True,
-    TestID -> "Integration-AppendsSessionInfo@@Tests/EvaluatorSessions.wlt:523,1-540,2"
+    TestID -> "Integration-AppendsSessionInfo@@Tests/EvaluatorSessions.wlt:821,1-838,2"
 ]
 
 (* A fresh session's first evaluation is labeled Out[1]. *)
@@ -556,7 +854,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "Out[1]" ]
     ],
     True,
-    TestID -> "Integration-FreshSessionStartsAtLineOne@@Tests/EvaluatorSessions.wlt:543,1-560,2"
+    TestID -> "Integration-FreshSessionStartsAtLineOne@@Tests/EvaluatorSessions.wlt:841,1-858,2"
 ]
 
 (* Resuming a session continues its line numbering rather than resetting it: A reaches Out[2], B
@@ -581,7 +879,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r, "Out[3]" ]
     ],
     True,
-    TestID -> "Integration-ResumeContinuesLineNumbering@@Tests/EvaluatorSessions.wlt:565,1-585,2"
+    TestID -> "Integration-ResumeContinuesLineNumbering@@Tests/EvaluatorSessions.wlt:863,1-883,2"
 ]
 
 (* An unknown / expired session ID starts a fresh session reusing that ID and says so. *)
@@ -601,7 +899,7 @@ VerificationTest[
         StringContainsQ[ text, "NeverSavedXyz" ] && StringContainsQ[ text, "No saved state" ]
     ],
     True,
-    TestID -> "Integration-UnknownIdReusedFresh@@Tests/EvaluatorSessions.wlt:588,1-605,2"
+    TestID -> "Integration-UnknownIdReusedFresh@@Tests/EvaluatorSessions.wlt:886,1-903,2"
 ]
 
 (* Context-path changes made inside a session (e.g. by Get) survive continued calls: the continuing
@@ -625,7 +923,7 @@ VerificationTest[
         StringContainsQ[ extractToolText @ r2, "{101, True}" ]
     ],
     True,
-    TestID -> "Integration-ContinuePreservesContextPath@@Tests/EvaluatorSessions.wlt:610,1-629,2"
+    TestID -> "Integration-ContinuePreservesContextPath@@Tests/EvaluatorSessions.wlt:908,1-927,2"
 ]
 
 (* Resuming a session saved by a different kernel process restores the saved state and warns that
@@ -655,7 +953,7 @@ VerificationTest[
     ],
     { True, True },
     SameTest -> MatchQ,
-    TestID   -> "Integration-ResumeFromPreviousKernelWarns@@Tests/EvaluatorSessions.wlt:634,1-659,2"
+    TestID   -> "Integration-ResumeFromPreviousKernelWarns@@Tests/EvaluatorSessions.wlt:932,1-957,2"
 ]
 
 (* Switching back to an earlier session within the same kernel process resumes silently: no
@@ -680,7 +978,7 @@ VerificationTest[
     ],
     { True, False },
     SameTest -> MatchQ,
-    TestID   -> "Integration-SameKernelResumeHasNoWarning@@Tests/EvaluatorSessions.wlt:663,1-684,2"
+    TestID   -> "Integration-SameKernelResumeHasNoWarning@@Tests/EvaluatorSessions.wlt:961,1-982,2"
 ]
 
 (* If the eval kernel loses its in-memory session state while the session is still current (e.g. the
@@ -711,7 +1009,50 @@ VerificationTest[
     ],
     { True, True, False },
     SameTest -> MatchQ,
-    TestID   -> "Integration-ContinueFallsBackToFileWhenKernelStateLost@@Tests/EvaluatorSessions.wlt:689,1-715,2"
+    TestID   -> "Integration-ContinueFallsBackToFileWhenKernelStateLost@@Tests/EvaluatorSessions.wlt:987,1-1013,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Integration: cloud sessions*)
+(* A real cloud round trip under the "Cloud" method. Needs a cloud connection and a Chatbook new enough
+   to carry the session byte array (2.7.11+); skipped otherwise. Definitions made in one call must come
+   back after a simulated server restart (the live session pointer is dropped, so the session resumes
+   from its file with the saved byte array), while another session must not see them. *)
+$cloudSessionTest = conditionalTest[
+    TrueQ @ $CloudConnected &&
+        TrueQ @ Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`cloudSessionMXAvailableQ[ ]
+];
+
+$cloudSessionTest @ VerificationTest[
+    Module[ { root, tool, r1, r2, r3, t1, t2, t3 },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsCloudSession_" <> CreateUUID[ ] };
+        tool = $DefaultMCPTools[ "WolframLanguageEvaluator" ];
+        Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath         = root,
+                Wolfram`AgentTools`Common`$clientSupportsUI = False,
+                Wolfram`AgentTools`Common`$toolOptions      = $cloudMethodOptions,
+                Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None
+            },
+            r1 = tool[ <| "code" -> "cloudSessX = 42; cloudSessF[n_] := n + cloudSessX; cloudSessX", "session" -> "CloudIntegA" |> ];
+            r2 = tool[ <| "code" -> "cloudSessF[1]", "session" -> "CloudIntegB" |> ];
+            (* Simulate a server restart: drop the live session pointer so A resumes from its file *)
+            Wolfram`AgentTools`Tools`WolframLanguageEvaluator`Private`$currentSessionID = None;
+            r3 = tool[ <| "code" -> "cloudSessF[1]", "session" -> "CloudIntegA" |> ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        { t1, t2, t3 } = extractToolText /@ { r1, r2, r3 };
+        {
+            StringContainsQ[ t1, "Out[1]= 42" ],
+            StringContainsQ[ t2, "Out[1]= cloudSessF[1]" ], (* B never saw A's definitions *)
+            StringContainsQ[ t3, "Out[2]= 43" ],
+            StringContainsQ[ t3, "non-persistent cloud kernel" ]
+        }
+    ],
+    { True, True, True, True },
+    SameTest -> MatchQ,
+    TestID   -> "Integration-CloudSessionDefinitionsSurviveRestart@@Tests/EvaluatorSessions.wlt:1027,21-1056,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/docs/cloud-deployment.md
+++ b/docs/cloud-deployment.md
@@ -310,9 +310,18 @@ The consequences, accepted for v1:
   the **deploying** account (required outright for `WolframAlphaContext`; see the
   [LLMKit table](servers.md#llmkit-requirements)). Servers built around code execution and
   Wolfram|Alpha (`WolframLanguageEvaluator`, `WolframAlpha`) are the most practical to deploy.
-- **No cross-request state or sessions.** Any client capability that must survive across requests
+- **No cross-request kernel state.** Any client capability that must survive across requests
   travels in a self-describing session ID (see [MCP Apps Support](#mcp-apps-support)), not in server
   memory.
+- **Evaluator sessions persist through files, not kernels.** The `WolframLanguageEvaluator` tool's
+  optional `session` parameter still works: session files are written to the deploying account's
+  persistent cloud user files (`$UserBaseDirectory/ApplicationData/Wolfram/AgentTools/Sessions/`).
+  Because every cloud evaluation runs in a fresh kernel, only a session's global definitions carry
+  over — Chatbook 2.7.11+ returns them after each call as an MX byte array
+  (`Wolfram`Chatbook`$CloudSessionMX`) that the server stores in the session file and hands back
+  before the next call. Loaded packages, In/Out history, and other kernel state are lost between
+  calls, and each result tells the model so (see [Sessions](tools.md#sessions)). With an older
+  Chatbook installed in the cloud account, nothing persists and the result says that instead.
 
 Caching / persistent kernels are future work.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -481,9 +481,26 @@ $myOption := toolOptionValue[ "YourTool", "OptionName" ];
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `"Method"` | String | `"Session"` | Evaluation method. `"Session"` uses the server kernel; `"Local"` spawns a separate kernel. |
+| `"Method"` | String | `Automatic` | Evaluation method. `"Session"` uses the server kernel; `"Local"` spawns a separate sandboxed kernel; `"Cloud"` runs each evaluation in a fresh Wolfram Cloud kernel. `Automatic` means `"Cloud"` when the server itself runs in the cloud (see [cloud-deployment.md](cloud-deployment.md)) and `"Session"` otherwise. |
 | `"ImageExportMethod"` | String | `None` | How to export graphics. `None`, `"Local"`, `"Cloud"`, or `"CloudPublic"`. |
 | `"TimeConstraint"` | Integer | `60` | Default time limit (seconds) when the LLM doesn't specify `timeConstraint`. The LLM can still override this per-call. |
+| `"MaxSessionCount"` | Integer | `100` | Maximum number of saved evaluator sessions to keep (oldest pruned first; the current session is always kept). |
+| `"MaxSessionBytes"` | Integer | `1073741824` | Total byte budget for saved evaluator sessions. |
+| `"MaxSessionAge"` | Quantity | `Quantity[1, "Months"]` | Saved evaluator sessions older than this are pruned. |
+
+##### Sessions
+
+The evaluator's optional `session` parameter gives each conversation an isolated, resumable session
+(its definitions, line numbers, and In/Out history). Sessions are saved under
+`$UserBaseDirectory/ApplicationData/Wolfram/AgentTools/Sessions/` after every call, so they survive
+server restarts, and every result ends with a reminder of the session ID to pass on subsequent calls.
+
+Under the `"Cloud"` method each call runs in a fresh, non-persistent cloud kernel, so only a session's
+**global definitions** persist: Chatbook 2.7.11+ returns the evaluator kernel's `` Global` `` definitions
+after each call as an MX byte array (`Wolfram`Chatbook`$CloudSessionMX`), which AgentTools stores in
+the session file and hands back before the next call. Loaded packages, In/Out history, `%`, and any
+other kernel state are lost between calls, and each result's session reminder says so (with an older
+Chatbook on the server it says that definitions cannot be restored at all).
 
 #### WolframLanguageContext
 


### PR DESCRIPTION
## Summary

For cloud-deployed MCP servers (and any server configured with `Method -> "Cloud"`), the `WolframLanguageEvaluator` tool's `session` parameter never actually carried definitions across calls: every evaluation runs in a fresh cloud kernel, Chatbook's cloud evaluator only saves the `` Global` `` context, and sessions parsed into `` Sessions`<id>` `` and saved that (empty) context from the server kernel.

This makes cloud sessions work by round-tripping definitions through Chatbook's session byte array (`$CloudSessionMX` / the `"SessionMX"` property, added in Chatbook 2.7.11):

- **Definitions persist.** After each cloud evaluation the evaluator kernel's `` Global` `` definitions are stored (as the `"SessionMX"` entry of the session's saved info) in the existing session file, and handed back via `$CloudSessionMX` before the next evaluation of that session. `withSession` scopes the symbol to a single call so nothing leaks between sessions or outlives the call.
- **Cloud sessions parse into `` Global` ``** instead of `` Sessions`<id>` `` (the only context the cloud evaluator captures). Isolation is inherent: each cloud kernel starts empty and loads only that session's byte array.
- **`Out[n]` labels follow the session.** The `"Line"` option never reaches the cloud evaluator kernel, so the new shared `chatbookToolEvaluate` also seeds Chatbook's per-kernel `$cloudLineNumber` with the session line.
- **Sensible hint.** For cloud sessions the "kernel process has changed" reminder is replaced by one saying the kernel is non-persistent: global definitions are saved and restored, but loaded packages, In/Out history, `%`, etc. are lost between calls. If the server's Chatbook is older than 2.7.11 the hint says definitions cannot be restored at all (the paclet version is checked before touching `$CloudSessionMX`; only a positive check is cached so a mid-session Chatbook upgrade is honored).
- Docs: `docs/tools.md` (Method / session options, new Sessions section), `docs/cloud-deployment.md` and `Specs/CloudDeployment.md` (which claimed no session state survives in the cloud).

Session files need no new storage backend: a cloud kernel's `$UserBaseDirectory` is the account's persistent user-files area, so the existing `$rootPath/Sessions` store already survives between requests (a deployed server had already been writing session files there).

## Test plan

- [x] `Tests/EvaluatorSessions.wlt`: 15 new unit tests for the cloud bookkeeping (version gate, `` Global` `` context, byte-array save/restore round trip, live-session restore, cloud line-counter sync, hint texts) plus a cloud-gated end-to-end test. 172/172 pass across `EvaluatorSessions.wlt`, `Tools.wlt`, and `WolframLanguageEvaluator-UI.wlt` with Chatbook 2.7.0 (cloud test skipped); 61/61 with Chatbook 2.7.11 loaded (cloud test runs).
- [x] CodeInspector clean on the changed source and test files (only the pre-existing FIXME notes remain).
- [x] Manual: `Method -> "Cloud"` from a local kernel with Chatbook 2.7.11 — definitions persist across continued calls, survive a simulated server restart (resume from file), and are isolated between sessions.
- [x] Manual: deployed an evaluator-only server with `CloudDeployMCPServer` and called `tools/call` over HTTP three times: `cloudDeployX = 321; cloudDeployF[n_] := n + cloudDeployX` → `Out[1]= 321`; same session on the next request, `cloudDeployF[1]` → `Out[2]= 322`; a different session → `cloudDeployF[1]` unevaluated. (Deployment, permissions key, and cloud session files cleaned up afterward.)

## Notes

- The public paclet server still only has Chatbook 2.7.0, so cloud accounts without 2.7.11 installed get the "cannot restore definitions" hint until it ships; `$minimumChatbookVersion` is intentionally left at 2.7.0 since the feature degrades gracefully.
- The cloud hint is appended on every call of a cloud session (each call is a new kernel); easy to make first-call-only if it proves too chatty.
- `$cloudLineNumber` is reached into the same way as the existing `$includeDefinitions`; both would be cleaner as `WolframLanguageToolEvaluate` options on the Chatbook side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYJ1uehRLCMhXoGzzo722P
