### PR TITLE
Track anonymous usage data for built-in local MCP servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@ See [building.md](docs/building.md) for detailed instructions.
   - `Server/`: MCP server implementation, split by transport so the local (stdio) and cloud (HTTP) servers share a common core
     - `Server.wl`: Aggregator that declares the server-session state shared across the subcontexts, defines the exported `$MCPEvaluationEnvironment`/`$MCPTransport` host descriptors (bound per session/request by each transport), and loads the children below
     - `Shared.wl`: Transport-agnostic core — method dispatch (`handleMethod`), tool/prompt resolution, tool evaluation and result formatting, capability negotiation (`initResponse`), server-state build (`initializeServerState`), environment-specific tool overrides (`applyToolOverrides`, driven by the `"Overrides"` tool property), and logging helpers
-    - `Local.wl`: Local stdio transport — `StartMCPServer`, the read loop (`processRequest`), tool warmup, and stdout-protecting output suppression (`superQuiet`)
+    - `Local.wl`: Local stdio transport — `StartMCPServer`, the read loop (`processRequest`), tool warmup, and stdout-protecting output suppression (`superQuiet`); calls the usage-data hooks (`initializeUsageData`, `recordUsageData`)
+    - `UsageData.wl`: [Anonymous usage data](docs/usage-data.md) for local servers — per-session state (`$mcpSessionID`, `$mcpClientInformation`, `$usageEvents`), the enabling logic (`SUBMIT_USAGE_DATA` environment variable vs. the servers' `"EnableUsageData"` property), the session file under `$rootPath/UsageData`, the hourly keep-alive task, and the locked submission of finished sessions to the usage endpoint
     - `Cloud.wl`: Cloud HTTP transport — `RunCloudMCPServer` (stateless Streamable HTTP handler), `CloudDeployMCPServer`, the full-directory-bundle deploy implementation (`cloudDeployDirectory`) behind both the `CloudDeploy` UpValue on `MCPServerObject` (the UpValue itself is defined in `MCPServerObject.wl`) and the exported `CloudDeployMCPServerBundle` that deploys `/mcp`, the landing page, `/api/info`, and the forced-`Private` admin page/API, the self-describing session-ID capability codec, server-embedding deploy helpers (including the cloud-paclet detection — `$cloudSupportPacletVersion`/`cloudAgentToolsAvailableQ` — that swaps the heavy definition-bundling payloads for light paclet-loading ones when the connected cloud account has a new-enough Wolfram/AgentTools installed), the landing-page `/api/info` metadata generator, and the owner-only `/api/admin` key-management handler (`runCloudAdminAPI`: list/create/revoke `PermissionsKey`s) (see [Cloud Deployment spec](Specs/CloudDeployment.md))
   - `SupportedClients.wl`: Registry of supported MCP clients (`$SupportedMCPClients`) and relevant utility functions
   - `ValidateAgentToolsPacletExtension.wl`: Validation of `"AgentTools"` [paclet extensions](docs/paclet-extensions.md)
@@ -104,6 +105,7 @@ See [building.md](docs/building.md) for detailed instructions.
   - `mcp-roots.md`: MCP roots handshake, working-directory propagation, and guidance for tools that resolve relative paths
   - `paclet-extensions.md`: Third-party paclet extension system for contributing tools, prompts, and servers
   - `preferences-content.md`: System preferences UI for managing deployed Wolfram toolsets
+  - `usage-data.md`: Anonymous usage data collected by the built-in local servers (`"SubmitUsageData"` option, `SUBMIT_USAGE_DATA`, storage and submission)
 
 ### MCP Documentation
 

--- a/Documentation/English/ReferencePages/Symbols/InstallMCPServer.nb
+++ b/Documentation/English/ReferencePages/Symbols/InstallMCPServer.nb
@@ -578,6 +578,15 @@ Notebook[
          },
          {
           Cell["      ", "ModInfo"],
+          "SubmitUsageData",
+          ButtonBox["Automatic", BaseStyle -> "Link"],
+          Cell[
+           "whether to share anonymous usage data with Wolfram",
+           "TableText"
+          ]
+         },
+         {
+          Cell["      ", "ModInfo"],
           "ToolOptions",
           RowBox[{"\[LeftAssociation]", "\[RightAssociation]"}],
           Cell[
@@ -621,6 +630,19 @@ Notebook[
       ],
       "Notes",
       CellID -> 373152932
+     ],
+     Cell[
+      TextData[
+       {
+        "By default, the predefined MCP servers report anonymous usage data (which application is used, which tools and prompts are called, and whether each call succeeded) to help improve them. No content, such as code, queries, arguments, or results, is ever sent. Set ",
+        Cell[BoxData["SubmitUsageData"], "InlineFormula"],
+        " to ",
+        Cell[BoxData["False"], "InlineFormula"],
+        " to opt out."
+       }
+      ],
+      "Notes",
+      CellID -> 261984873
      ]
     },
     Open

--- a/FrontEnd/Assets/AgentTools.wl
+++ b/FrontEnd/Assets/AgentTools.wl
@@ -165,7 +165,12 @@
 		"Japanese"           -> "\:30c7\:30d5\:30a9\:30eb\:30c8\:306eMCP\:30b5\:30fc\:30d0\:306e\:30ea\:30b9\:30c8\:306f\:5229\:7528\:3067\:304d\:307e\:305b\:3093\:ff0e",
 		"Korean"             -> "\:ae30\:bcf8 MCP \:c11c\:bc84 \:baa9\:b85d\:c744 \:c0ac\:c6a9\:d560 \:c218 \:c5c6\:c2b5\:b2c8\:b2e4.",
 		"Spanish"            -> "La lista de servidores MCP predeterminados no est\[AAcute] disponible."
-	|>]
+	|>],
+
+	(* TODO: localize (English only until the localization pass) *)
+	"prefsSubmitUsageData" -> "Share anonymous usage data with Wolfram to help improve these tools",
+
+	"prefsSubmitUsageDataDescription" -> "When enabled, the Wolfram tools report which AI environment is used, which tools and prompts are called, and whether each call succeeded. No content is ever sent: no code, queries, arguments, or results."
 
 },
 

--- a/Kernel/DefaultServers.wl
+++ b/Kernel/DefaultServers.wl
@@ -17,6 +17,8 @@ $defaultMCPServer = "Wolfram";
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*$DefaultMCPServers*)
+(* The built-in servers set "EnableUsageData" -> True, which enables anonymous usage tracking for their local
+   sessions unless an installation opts out via the "SubmitUsageData" option (see docs/usage-data.md). *)
 $DefaultMCPServers := WithCleanup[
     Unprotect @ $DefaultMCPServers,
     $DefaultMCPServers = MCPServerObject /@ KeySort @ AssociationMap[ Apply @ Rule, $defaultMCPServers ],
@@ -29,13 +31,14 @@ $defaultMCPServers = <| |>;
 (* ::Subsection::Closed:: *)
 (*Wolfram*)
 $defaultMCPServers[ "Wolfram" ] := <|
-    "Name"          -> "Wolfram",
-    "MCPServerName" -> "Wolfram",
-    "Location"      -> "BuiltIn",
-    "Transport"     -> "StandardInputOutput",
-    "ServerVersion" -> $pacletVersion,
-    "ObjectVersion" -> $objectVersion,
-    "LLMEvaluator"  -> <|
+    "Name"            -> "Wolfram",
+    "MCPServerName"   -> "Wolfram",
+    "Location"        -> "BuiltIn",
+    "Transport"       -> "StandardInputOutput",
+    "ServerVersion"   -> $pacletVersion,
+    "ObjectVersion"   -> $objectVersion,
+    "EnableUsageData" -> True,
+    "LLMEvaluator"    -> <|
         "Tools" -> {
             "WolframContext",
             "WolframLanguageEvaluator",
@@ -49,13 +52,14 @@ $defaultMCPServers[ "Wolfram" ] := <|
 (* ::Subsection::Closed:: *)
 (*WolframAlpha*)
 $defaultMCPServers[ "WolframAlpha" ] := <|
-    "Name"          -> "WolframAlpha",
-    "MCPServerName" -> "Wolfram",
-    "Location"      -> "BuiltIn",
-    "Transport"     -> "StandardInputOutput",
-    "ServerVersion" -> $pacletVersion,
-    "ObjectVersion" -> $objectVersion,
-    "LLMEvaluator"  -> <|
+    "Name"            -> "WolframAlpha",
+    "MCPServerName"   -> "Wolfram",
+    "Location"        -> "BuiltIn",
+    "Transport"       -> "StandardInputOutput",
+    "ServerVersion"   -> $pacletVersion,
+    "ObjectVersion"   -> $objectVersion,
+    "EnableUsageData" -> True,
+    "LLMEvaluator"    -> <|
         "Tools" -> {
             "WolframAlphaContext",
             "WolframAlpha"
@@ -68,13 +72,14 @@ $defaultMCPServers[ "WolframAlpha" ] := <|
 (* ::Subsection::Closed:: *)
 (*WolframLanguage*)
 $defaultMCPServers[ "WolframLanguage" ] := <|
-    "Name"          -> "WolframLanguage",
-    "MCPServerName" -> "Wolfram",
-    "Location"      -> "BuiltIn",
-    "Transport"     -> "StandardInputOutput",
-    "ServerVersion" -> $pacletVersion,
-    "ObjectVersion" -> $objectVersion,
-    "LLMEvaluator"  -> <|
+    "Name"            -> "WolframLanguage",
+    "MCPServerName"   -> "Wolfram",
+    "Location"        -> "BuiltIn",
+    "Transport"       -> "StandardInputOutput",
+    "ServerVersion"   -> $pacletVersion,
+    "ObjectVersion"   -> $objectVersion,
+    "EnableUsageData" -> True,
+    "LLMEvaluator"    -> <|
         "Tools" -> {
             "WolframLanguageContext",
             "WolframLanguageEvaluator",
@@ -92,13 +97,14 @@ $defaultMCPServers[ "WolframLanguage" ] := <|
 (* ::Subsection::Closed:: *)
 (*WolframPacletDevelopment*)
 $defaultMCPServers[ "WolframPacletDevelopment" ] := <|
-    "Name"          -> "WolframPacletDevelopment",
-    "MCPServerName" -> "Wolfram",
-    "Location"      -> "BuiltIn",
-    "Transport"     -> "StandardInputOutput",
-    "ServerVersion" -> $pacletVersion,
-    "ObjectVersion" -> $objectVersion,
-    "LLMEvaluator"  -> <|
+    "Name"            -> "WolframPacletDevelopment",
+    "MCPServerName"   -> "Wolfram",
+    "Location"        -> "BuiltIn",
+    "Transport"       -> "StandardInputOutput",
+    "ServerVersion"   -> $pacletVersion,
+    "ObjectVersion"   -> $objectVersion,
+    "EnableUsageData" -> True,
+    "LLMEvaluator"    -> <|
         "Tools" -> {
             "WolframLanguageContext",
             "WolframLanguageEvaluator",

--- a/Kernel/InstallMCPServer.wl
+++ b/Kernel/InstallMCPServer.wl
@@ -14,6 +14,7 @@ $enableMCPApps        = True;
 $enableLLMKit         = Automatic;
 $installToolOptions   = <| |>;
 $installMCPServerName = Automatic;
+$submitUsageData      = Automatic;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
@@ -24,7 +25,13 @@ InstallMCPServer // beginDefinition;
    - False (default): Uses the installed paclet via PacletSymbol for server startup
    - True: Uses the Scripts/StartMCPServer.wls from $thisPaclet's location (requires unbuilt paclet)
    - path_String: Uses Scripts/StartMCPServer.wls from the specified directory
-   This allows testing local changes without reinstalling the paclet. *)
+   This allows testing local changes without reinstalling the paclet.
+
+   "SubmitUsageData" option:
+   - Automatic (default): Nothing is added to the configuration; the server tracks anonymous usage data only if its
+     "EnableUsageData" property is True (as it is for the built-in servers)
+   - True/False: Sets SUBMIT_USAGE_DATA in the server's environment, which takes precedence over the property
+   See docs/usage-data.md. *)
 InstallMCPServer // Options = {
     "ApplicationName"    -> Automatic,
     "DevelopmentMode"    -> False,
@@ -32,6 +39,7 @@ InstallMCPServer // Options = {
     "EnableMCPApps"      -> True,
     "MCPServerName"      -> Automatic,
     "ProcessEnvironment" -> Automatic,
+    "SubmitUsageData"    -> Automatic,
     "ToolOptions"        -> <| |>,
     "VerifyLLMKit"       -> True
 };
@@ -56,7 +64,8 @@ InstallMCPServer[ target_File? fileQ, server0_String? pacletQualifiedNameQ, opts
                     $enableMCPApps        = OptionValue[ "EnableMCPApps" ],
                     $enableLLMKit         = OptionValue[ "EnableLLMKit" ],
                     $installToolOptions   = validateToolOptions[ OptionValue[ "ToolOptions" ], server ],
-                    $installMCPServerName = OptionValue[ "MCPServerName" ]
+                    $installMCPServerName = OptionValue[ "MCPServerName" ],
+                    $submitUsageData      = validateSubmitUsageData @ OptionValue[ "SubmitUsageData" ]
                 },
                 installMCPServer[
                     target,
@@ -77,7 +86,8 @@ InstallMCPServer[ target_File? fileQ, server0_, opts: OptionsPattern[ ] ] :=
                 $enableMCPApps        = OptionValue[ "EnableMCPApps" ],
                 $enableLLMKit         = OptionValue[ "EnableLLMKit" ],
                 $installToolOptions   = validateToolOptions[ OptionValue[ "ToolOptions" ], server ],
-                $installMCPServerName = OptionValue[ "MCPServerName" ]
+                $installMCPServerName = OptionValue[ "MCPServerName" ],
+                $submitUsageData      = validateSubmitUsageData @ OptionValue[ "SubmitUsageData" ]
             },
             installMCPServer[
                 target,
@@ -109,6 +119,14 @@ validateInstallClientName[ Automatic, file_? fileQ ] := guessClientName @ file;
 validateInstallClientName[ name_String, _ ] := toInstallName @ name;
 validateInstallClientName[ other_, _ ] := throwFailure[ "InvalidApplicationName", other ];
 validateInstallClientName // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*validateSubmitUsageData*)
+validateSubmitUsageData // beginDefinition;
+validateSubmitUsageData[ value: Automatic|True|False ] := value;
+validateSubmitUsageData[ other_ ] := throwFailure[ "InvalidSubmitUsageData", other ];
+validateSubmitUsageData // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
@@ -803,6 +821,11 @@ addEnvironmentVariables[ server0_Association, extraEnv0_Association ] := Enclose
 
         If[ $enableLLMKit === False,
             extraEnv = <| extraEnv, "LLMKIT_ENABLED" -> "false" |>
+        ];
+
+        (* An explicit "SubmitUsageData" -> True/False overrides the server's "EnableUsageData" property at startup *)
+        If[ BooleanQ @ $submitUsageData,
+            extraEnv = <| extraEnv, "SUBMIT_USAGE_DATA" -> If[ $submitUsageData, "true", "false" ] |>
         ];
 
         If[ AssociationQ @ $installToolOptions && $installToolOptions =!= <| |>,

--- a/Kernel/Messages.wl
+++ b/Kernel/Messages.wl
@@ -97,6 +97,9 @@ AgentTools::UnrecognizedToolOption         = "Warning: Unrecognized tool name in
 AgentTools::UnrecognizedToolOptionName     = "Warning: Unrecognized option \"`1`\" for tool \"`2`\" in ToolOptions.";
 AgentTools::InvalidToolOptionValue         = "Warning: Invalid value for tool \"`1`\" in ToolOptions: `2`. Expected an Association. This entry will be ignored.";
 
+(* Usage data messages *)
+AgentTools::InvalidSubmitUsageData         = "Invalid value for SubmitUsageData option: `1`. Expected True, False, or Automatic.";
+
 (* Cloud deployment messages *)
 AgentTools::CloudDeployFailed              = "Failed to deploy MCP server to the cloud: `1`.";
 AgentTools::NotCloudConnected              = "A cloud connection is required to deploy an MCP server. Use CloudConnect to sign in.";

--- a/Kernel/PreferencesContent.wl
+++ b/Kernel/PreferencesContent.wl
@@ -254,7 +254,7 @@ configureAllButton[detectedClients_, Dynamic[refresh_]] :=
 					DeployAgentTools[
 						client,
 						CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SelectedToolset", client}],
-						OverwriteTarget -> True
+						OverwriteTarget -> True, Sequence @@ usageDataDeployOptions[]
 					],
 					{client, detectedClients}
 				],
@@ -384,7 +384,7 @@ clientMenu[category_, client_, Dynamic[refresh_]] :=
 			CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SelectedToolset", client}],
 			(
 				CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SelectedToolset", client}] = #;
-				If[category === "Configured", refresh @ DeployAgentTools[client, #, OverwriteTarget -> True]]
+				If[category === "Configured", refresh @ DeployAgentTools[client, #, OverwriteTarget -> True, Sequence @@ usageDataDeployOptions[]]]
 			)&
 		]
 		,
@@ -488,7 +488,7 @@ clientButton[category_, client_, Dynamic[refresh_]] :=
 		refresh @ DeployAgentTools[
 			client,
 			CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SelectedToolset", client}],
-			OverwriteTarget -> True
+			OverwriteTarget -> True, Sequence @@ usageDataDeployOptions[]
 		]
 	]
 
@@ -658,6 +658,80 @@ dirSettingsRow[Dynamic[dirSettings_], i_, {obj_, server_, scope_, active_}] :=
 
 
 (* ::Section::Closed:: *)
+(*usageDataCheckbox*)
+
+
+(*
+	Anonymous usage data (see docs/usage-data.md) is shared by default. The opt-out made here is stored in the front
+	end's private settings next to the per-client "SelectedToolset" choices; only an explicit False opts out.
+*)
+$usageDataSettingPath = {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SubmitUsageData"};
+
+
+usageDataOptOutQ[] := Quiet[CurrentValue[$FrontEnd, $usageDataSettingPath]] === False
+
+
+(*
+	Extra InstallMCPServer options for deployments made from this panel: an opt-out is written into the client's
+	configuration as "SubmitUsageData" -> False (the SUBMIT_USAGE_DATA environment variable); otherwise nothing is
+	added and the server's own default applies.
+*)
+usageDataDeployOptions[] := If[usageDataOptOutQ[], {"SubmitUsageData" -> False}, {}]
+
+
+(*
+	Re-deploys every existing deployment of a built-in toolset so that the new setting is reflected in the clients'
+	configurations right away, preserving the other options each deployment was made with.
+*)
+applyUsageDataSetting[] :=
+	Scan[
+		redeployForUsageData,
+		Select[
+			Replace[Quiet @ DeployedAgentTools[], Except[_List] -> {}],
+			KeyExistsQ[Wolfram`AgentTools`$DefaultMCPServers, #["Toolset"]]&
+		]
+	]
+
+
+redeployForUsageData[dep_AgentToolsDeployment] :=
+	Module[{options},
+		options = DeleteCases[
+			Replace[Normal @ dep["MCP", "Options"], Except[{___Rule}] -> {}],
+			"SubmitUsageData" -> _
+		];
+		Quiet @ catchAlways @ DeployAgentTools[
+			dep["Target"],
+			dep["Toolset"],
+			OverwriteTarget -> True,
+			Sequence @@ Join[options, usageDataDeployOptions[]]
+		]
+	]
+
+
+usageDataCheckbox[] :=
+	Grid[
+		{{
+			Checkbox[
+				Dynamic[
+					CurrentValue[$FrontEnd, $usageDataSettingPath] =!= False,
+					(
+						CurrentValue[$FrontEnd, $usageDataSettingPath] = TrueQ[#];
+						(* Re-deploying can take a while, so it is queued rather than run in this preemptive evaluation *)
+						SessionSubmit @ applyUsageDataSetting[]
+					)&
+				]
+			],
+			Tooltip[
+				tr["prefsSubmitUsageData"],
+				tr["prefsSubmitUsageDataDescription"]
+			]
+		}},
+		Alignment -> {Left, Baseline},
+		Spacings -> {0.5, 0}
+	]
+
+
+(* ::Section::Closed:: *)
 (*CreatePreferencesContent*)
 
 
@@ -716,6 +790,12 @@ Deploy[
 					clientInterfaces[],
 					Alignment -> Left,
 					ImageMargins -> {{15,5},{0,0}}
+				],
+
+				Pane[
+					usageDataCheckbox[],
+					Alignment -> Left,
+					ImageMargins -> {{15,5},{0,10}}
 				]
 			},
 			ItemSize -> Scaled[1],

--- a/Kernel/Server/Local.wl
+++ b/Kernel/Server/Local.wl
@@ -73,6 +73,9 @@ startMCPServer[ obj0_MCPServerObject ] := Enclose[
                 $logFile      = logFile,
                 $toolOptions  = state[ "ToolOptions" ]
             },
+            (* Assign the session ID and, when enabled for this server, start usage tracking (see UsageData.wl) *)
+            initializeUsageData @ $currentMCPServer;
+
             While[ True,
                 If[
                     And[
@@ -202,6 +205,7 @@ processRequest[ ] :=
 
         req = <| "jsonrpc" -> "2.0", "id" -> id |>;
         response = catchAlways @ handleMethod[ method, message, req ];
+        recordUsageData[ method, message, response ];
         If[ method === "tools/list", $warmupTools = True ];
         writeLog[ "Response" -> response ];
         If[ FailureQ @ response,

--- a/Kernel/Server/Server.wl
+++ b/Kernel/Server/Server.wl
@@ -15,6 +15,14 @@ BeginPackage[ "Wolfram`AgentTools`Server`" ];
 `$toolList;
 `$warmupTask;
 
+(* Usage data (UsageData.wl): per-session tracking state and the hooks called by the local transport. *)
+`$mcpClientInformation;
+`$mcpSessionID;
+`$usageDataEnabled;
+`$usageEvents;
+`initializeUsageData;
+`recordUsageData;
+
 (* Shared catch wrapper: defined in Local.wl but also used by evaluateTool in Shared.wl,
    so it is declared here where both subcontexts can bind it. *)
 `stealthCatchTop;
@@ -56,6 +64,9 @@ $currentMCPServer = None;
 $subcontexts = {
     (* Transport-agnostic core: dispatch, tool/prompt resolution, result formatting, init *)
     "Wolfram`AgentTools`Server`Shared`",
+
+    (* Usage data: session ID, anonymous usage tracking for local servers, and submission of finished sessions *)
+    "Wolfram`AgentTools`Server`UsageData`",
 
     (* Local stdio transport: StartMCPServer, the read loop, warmup, superQuiet *)
     "Wolfram`AgentTools`Server`Local`",

--- a/Kernel/Server/UsageData.wl
+++ b/Kernel/Server/UsageData.wl
@@ -1,0 +1,493 @@
+(* ::Section::Closed:: *)
+(*Package Header*)
+BeginPackage[ "Wolfram`AgentTools`Server`UsageData`" ];
+Begin[ "`Private`" ];
+
+Needs[ "Wolfram`AgentTools`"        ];
+Needs[ "Wolfram`AgentTools`Common`" ];
+Needs[ "Wolfram`AgentTools`Server`" ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Overview*)
+(*
+    Basic, anonymous usage tracking for the local (stdio) MCP servers. See docs/usage-data.md.
+
+    What is recorded for a server session:
+      * the client information from the "initialize" request (its "params": clientInfo, protocolVersion, capabilities)
+      * one event per "tools/call" and "prompts/get" request: the tool/prompt name, whether it succeeded, and when
+    No tool arguments, prompt arguments, results, or any other content are ever recorded (see recordUsageData0).
+
+    Tracking is enabled for a session when the SUBMIT_USAGE_DATA environment variable holds a boolean (written into
+    the client's configuration by the "SubmitUsageData" option of InstallMCPServer), or -- when that variable is
+    absent -- when the server's "EnableUsageData" property is explicitly True (the built-in servers set it; see
+    DefaultServers.wl). Nothing is tracked for cloud-deployed servers.
+
+    The session's data lives in $rootPath/UsageData/<session id>.wxf. The file is rewritten whenever the data changes
+    and touched hourly by a scheduled task, so its modification time tells whether the session is still alive even
+    when the client has been idle. A server session cannot know that it is over, so submission happens later: a
+    subsequent session (of any tracked server) submits the files that have not been modified for a day to
+    $usageDataEndpoint as JSON and deletes them, under a file lock so that only one process submits at a time.
+*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Configuration*)
+$usageDataEndpoint          = "https://www.wolframcloud.com/obj/wolframai-content/api/1.0/usage";
+$usageDataSubmitTimeout     = 10;                        (* seconds allowed for each HTTP request *)
+$usageDataSubmitDelay       = Quantity[ 10, "Seconds" ]; (* delay after server start before finished sessions are submitted *)
+$usageDataKeepAliveInterval = Quantity[ 1, "Hours" ];    (* how often the current session's file is touched *)
+$usageDataStaleAge          = 24 * 3600;                 (* seconds since the last touch before a session counts as finished *)
+$usageDataMaxAge            = 30 * 24 * 3600;            (* seconds after which a session that could not be submitted is discarded *)
+$usageDataMaxEvents         = 10000;                     (* maximum number of events recorded per session *)
+$usageDataLockTimeout       = 1;                         (* seconds to wait for another process to release the submit lock *)
+$usageDataLockLifetime      = 600;                       (* seconds after which a lock left behind by a dead process is broken *)
+
+(* Session state: $mcpSessionID is assigned once per kernel session by initializeUsageData, the rest is only
+   populated while tracking is enabled. *)
+$usageDataEnabled     = False;
+$mcpSessionID         = None;
+$mcpClientInformation = Null;
+$usageDataServerName  = Null;
+$usageKeepAliveTask   = None;
+$usageSubmitTask      = None;
+
+$usageEvents := $usageEvents = Internal`Bag[ ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Paths*)
+$usageDataPath  := FileNameJoin @ { $rootPath, "UsageData" };
+$usageStatsFile := FileNameJoin @ { $usageDataPath, $mcpSessionID <> ".wxf" };
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*usageDataQuietly*)
+(* Usage tracking must never interfere with the server, so failures in it are logged and otherwise ignored. *)
+usageDataQuietly // beginDefinition;
+usageDataQuietly // Attributes = { HoldFirst };
+
+usageDataQuietly[ eval_ ] :=
+    With[ { result = Quiet @ catchAlways @ eval },
+        If[ FailureQ @ result, writeLog[ "UsageDataFailure" -> result ] ];
+        result
+    ];
+
+usageDataQuietly // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*usageDataEnabledQ*)
+(* SUBMIT_USAGE_DATA takes precedence when it holds a boolean: an explicit true also tracks custom servers and an
+   explicit false opts a built-in server out. Otherwise only servers whose "EnableUsageData" property is exactly
+   True are tracked. *)
+usageDataEnabledQ // beginDefinition;
+usageDataEnabledQ[ obj_ ] := usageDataEnabledQ[ obj, booleanEnvironment[ "SUBMIT_USAGE_DATA" ] ];
+usageDataEnabledQ[ _, enabled: True|False ] := enabled;
+usageDataEnabledQ[ obj_MCPServerObject, None ] := obj[ "EnableUsageData" ] === True;
+usageDataEnabledQ[ _, None ] := False;
+usageDataEnabledQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*booleanEnvironment*)
+booleanEnvironment // beginDefinition;
+booleanEnvironment[ name_String ] := booleanString @ Environment @ name;
+booleanEnvironment // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*booleanString*)
+booleanString // beginDefinition;
+
+booleanString[ value_String ] :=
+    Switch[ ToLowerCase @ StringTrim @ value,
+        "true"  | "yes" | "on"  | "1", True,
+        "false" | "no"  | "off" | "0", False,
+        _                            , None
+    ];
+
+booleanString[ _ ] := None;
+
+booleanString // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*initializeUsageData*)
+(* Called once by the local transport after the server state has been built. Always assigns a fresh $mcpSessionID;
+   when tracking is enabled for the server it also starts the keep-alive task and schedules the submission of
+   finished sessions. Returns whether tracking is enabled. *)
+initializeUsageData // beginDefinition;
+initializeUsageData[ obj_ ] := usageDataQuietly @ initializeUsageData0 @ obj;
+initializeUsageData // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*initializeUsageData0*)
+initializeUsageData0 // beginDefinition;
+
+initializeUsageData0[ obj_ ] := Enclose[
+    Module[ { enabled },
+        stopUsageDataTasks[ ];
+        $usageDataEnabled     = False;
+        $mcpSessionID         = ConfirmBy[ CreateUUID[ ], StringQ, "SessionID" ];
+        $mcpClientInformation = Null;
+        $usageEvents          = Internal`Bag[ ];
+        $usageDataServerName  = Replace[ obj[ "Name" ], Except[ _String ] -> Null ];
+        enabled = ConfirmMatch[ usageDataEnabledQ @ obj, True|False, "Enabled" ];
+        writeLog[ "UsageData" -> <| "SessionID" -> $mcpSessionID, "Enabled" -> enabled |> ];
+        If[ enabled, startUsageDataTasks[ ] ];
+        $usageDataEnabled = enabled
+    ],
+    throwInternalFailure
+];
+
+initializeUsageData0 // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*startUsageDataTasks*)
+startUsageDataTasks // beginDefinition;
+
+startUsageDataTasks[ ] :=
+    With[ { interval = $usageDataKeepAliveInterval, delay = $usageDataSubmitDelay },
+        $usageKeepAliveTask = SessionSubmit @ ScheduledTask[ usageDataQuietly @ touchUsageStatsFile[ ], interval ];
+        $usageSubmitTask = SessionSubmit @ ScheduledTask[ usageDataQuietly @ submitUsageData[ ], { delay }, AutoRemove -> True ];
+        Null
+    ];
+
+startUsageDataTasks // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*stopUsageDataTasks*)
+stopUsageDataTasks // beginDefinition;
+
+stopUsageDataTasks[ ] := (
+    Scan[ removeUsageDataTask, { $usageKeepAliveTask, $usageSubmitTask } ];
+    $usageKeepAliveTask = None;
+    $usageSubmitTask    = None;
+);
+
+stopUsageDataTasks // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*removeUsageDataTask*)
+removeUsageDataTask // beginDefinition;
+removeUsageDataTask[ task_TaskObject ] := Quiet @ TaskRemove @ task;
+removeUsageDataTask[ _ ] := Null;
+removeUsageDataTask // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*recordUsageData*)
+(* Called by the local read loop for every request once it has been handled. A no-op unless tracking is enabled. *)
+recordUsageData // beginDefinition;
+recordUsageData[ method_, msg_, response_ ] /; $usageDataEnabled := usageDataQuietly @ recordUsageData0[ method, msg, response ];
+recordUsageData[ _, _, _ ] := Null;
+recordUsageData // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*recordUsageData0*)
+(* Only the requested name is taken from a message, and only when it names one of the server's tools/prompts, so a
+   made-up name cannot smuggle arbitrary text into the data. Arguments are never looked at. *)
+recordUsageData0 // beginDefinition;
+
+recordUsageData0[ "initialize", msg_Association, _ ] :=
+    setClientInformation @ msg;
+
+recordUsageData0[ "tools/call", msg_Association, response_ ] :=
+    recordUsageEvent[ "ToolCall", requestedName[ msg, $llmTools ], toolCallSuccessQ @ response ];
+
+recordUsageData0[ "prompts/get", msg_Association, response_ ] :=
+    recordUsageEvent[ "PromptGet", requestedName[ msg, $promptLookup ], responseSuccessQ @ response ];
+
+recordUsageData0[ _, _, _ ] :=
+    Null;
+
+recordUsageData0 // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*requestedName*)
+requestedName // beginDefinition;
+requestedName[ msg_Association, known_ ] := requestedName[ msg[ "params", "name" ], known ];
+requestedName[ name_String, known_Association ] /; KeyExistsQ[ known, name ] := name;
+requestedName[ _, _ ] := Null;
+requestedName // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*responseSuccessQ*)
+(* The response as produced by handleMethod: a JSON-RPC result or error, or a Failure for an internal error. *)
+responseSuccessQ // beginDefinition;
+responseSuccessQ[ KeyValuePattern[ "error" -> _ ] ] := False;
+responseSuccessQ[ KeyValuePattern[ "result" -> _ ] ] := True;
+responseSuccessQ[ _ ] := False;
+responseSuccessQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*toolCallSuccessQ*)
+(* Tool errors are reported inside a successful JSON-RPC result via "isError". *)
+toolCallSuccessQ // beginDefinition;
+toolCallSuccessQ[ KeyValuePattern[ "result" -> KeyValuePattern[ "isError" -> True ] ] ] := False;
+toolCallSuccessQ[ response_ ] := responseSuccessQ @ response;
+toolCallSuccessQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*setClientInformation*)
+setClientInformation // beginDefinition;
+
+setClientInformation[ msg_Association ] := (
+    $mcpClientInformation = Replace[ msg[ "params" ], Except[ _Association ] -> Null ];
+    writeUsageDataFile[ ]
+);
+
+setClientInformation // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*recordUsageEvent*)
+recordUsageEvent // beginDefinition;
+
+recordUsageEvent[ type_String, name: _String|Null, success: True|False ] /;
+    Internal`BagLength @ $usageEvents < $usageDataMaxEvents := (
+        Internal`StuffBag[
+            $usageEvents,
+            <| "Type" -> type, "Name" -> name, "Success" -> success, "Timestamp" -> AbsoluteTime[ TimeZone -> 0 ] |>
+        ];
+        writeUsageDataFile[ ]
+    );
+
+(* Event limit reached: keep the session's data as is *)
+recordUsageEvent[ _String, _String|Null, True|False ] := Null;
+
+recordUsageEvent // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Session File*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*usageDataPayload*)
+(* The data stored in the session file, and later submitted as JSON. *)
+usageDataPayload // beginDefinition;
+
+usageDataPayload[ ] := <|
+    "MCPSessionID"      -> $mcpSessionID,
+    "ServerName"        -> $usageDataServerName,
+    "ClientInformation" -> $mcpClientInformation,
+    "Events"            -> Internal`BagPart[ $usageEvents, All ],
+    "PacletVersion"     -> $pacletVersion,
+    "WolframVersion"    -> $Version,
+    "SystemID"          -> $SystemID,
+    "LastUpdated"       -> AbsoluteTime[ TimeZone -> 0 ]
+|>;
+
+usageDataPayload // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*usageDataJSON*)
+usageDataJSON // beginDefinition;
+usageDataJSON[ payload_Association ] := Developer`WriteRawJSONString[ payload, "Compact" -> True ];
+usageDataJSON // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*writeUsageDataFile*)
+(* The file is rewritten in full whenever the session's data changes. *)
+writeUsageDataFile // beginDefinition;
+
+writeUsageDataFile[ ] := writeUsageDataFile @ $usageStatsFile;
+
+writeUsageDataFile[ file_String ] := Enclose[
+    ConfirmBy[ writeWXFFile[ file, usageDataPayload[ ] ], FileExistsQ, "Write" ],
+    throwInternalFailure
+];
+
+writeUsageDataFile // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*touchUsageStatsFile*)
+(* Keeps the modification time of the current session's file current while the session is alive, so an idle session
+   is not mistaken for a finished one. Does nothing before the file has been written. *)
+touchUsageStatsFile // beginDefinition;
+touchUsageStatsFile[ ] := touchUsageStatsFile @ $usageStatsFile;
+touchUsageStatsFile[ file_String ] /; FileExistsQ @ file := (SetFileDate @ file; file);
+touchUsageStatsFile[ _ ] := Null;
+touchUsageStatsFile // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Submission*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*submitUsageData*)
+(* Submits the files of finished sessions (see staleUsageFileQ) and deletes them afterward. Runs under a file lock
+   so that concurrently starting servers do not submit the same file twice; when another process holds the lock,
+   this one simply skips its turn. Returns the files that were submitted or discarded. *)
+submitUsageData // beginDefinition;
+
+submitUsageData[ ] := submitUsageData @ $usageDataPath;
+
+submitUsageData[ dir_String ] /; ! DirectoryQ @ dir := { };
+
+submitUsageData[ dir_String ] := Enclose[
+    Module[ { lock, result },
+        lock = ConfirmBy[ FileNameJoin @ { dir, "Submit.lock" }, StringQ, "Lock" ];
+        result = With[ { timeout = $usageDataLockTimeout, lifetime = $usageDataLockLifetime },
+            WithLock[
+                File @ lock,
+                submitStaleUsageFiles @ dir,
+                TimeConstraint  -> timeout,
+                PersistenceTime -> lifetime
+            ]
+        ];
+        If[ ListQ @ result,
+            result,
+            writeLog[ "UsageDataSubmitSkipped" -> result ];
+            { }
+        ]
+    ],
+    throwInternalFailure
+];
+
+submitUsageData // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*submitStaleUsageFiles*)
+submitStaleUsageFiles // beginDefinition;
+
+submitStaleUsageFiles[ dir_String ] := Enclose[
+    Catch @ Module[ { files, processed = { } },
+        files = ConfirmMatch[ staleUsageFiles @ dir, { ___String }, "Files" ];
+        Scan[
+            Function[ file,
+                If[ MatchQ[ submitUsageFile @ file, "Submitted"|"Discarded" ],
+                    AppendTo[ processed, file ],
+                    (* A failed submission is most likely a connectivity problem that would affect the remaining
+                       files too, so stop here; they will be tried again in a later session *)
+                    Throw @ processed
+                ]
+            ],
+            files
+        ];
+        processed
+    ],
+    throwInternalFailure
+];
+
+submitStaleUsageFiles // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*staleUsageFiles*)
+(* Oldest first *)
+staleUsageFiles // beginDefinition;
+staleUsageFiles[ dir_String ] := ReverseSortBy[ Select[ FileNames[ "*.wxf", dir ], staleUsageFileQ ], fileAge ];
+staleUsageFiles // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*staleUsageFileQ*)
+(* A session is considered finished once its file has not been touched for $usageDataStaleAge seconds. The current
+   session's own file is never stale. *)
+staleUsageFileQ // beginDefinition;
+staleUsageFileQ[ file_String ] := ! currentUsageFileQ @ file && TrueQ[ fileAge @ file > $usageDataStaleAge ];
+staleUsageFileQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*currentUsageFileQ*)
+currentUsageFileQ // beginDefinition;
+currentUsageFileQ[ file_String ] := StringQ @ $mcpSessionID && FileBaseName @ file === $mcpSessionID;
+currentUsageFileQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*fileAge*)
+(* Seconds since the file was last modified *)
+fileAge // beginDefinition;
+fileAge[ file_String ] := UnixTime[ ] - UnixTime @ FileDate[ file, "Modification" ];
+fileAge // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*submitUsageFile*)
+submitUsageFile // beginDefinition;
+
+submitUsageFile[ file_String ] := Enclose[
+    Catch @ Module[ { data },
+
+        (* Sessions that could not be submitted for a long time (e.g. from a machine that has been offline) are dropped *)
+        If[ TrueQ[ fileAge @ file > $usageDataMaxAge ], Throw @ discardUsageFile[ file, "Expired" ] ];
+
+        (* Files that cannot be read cannot be submitted either *)
+        data = Quiet @ readWXFFile @ file;
+        If[ ! AssociationQ @ data, Throw @ discardUsageFile[ file, "Unreadable" ] ];
+
+        If[ TrueQ @ submitUsagePayload @ data,
+            Quiet @ DeleteFile @ file;
+            writeLog[ "UsageDataSubmitted" -> file ];
+            "Submitted",
+            writeLog[ "UsageDataSubmitFailed" -> file ];
+            "Failed"
+        ]
+    ],
+    throwInternalFailure
+];
+
+submitUsageFile // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*discardUsageFile*)
+discardUsageFile // beginDefinition;
+
+discardUsageFile[ file_String, reason_String ] := (
+    Quiet @ DeleteFile @ file;
+    writeLog[ "UsageDataDiscarded" -> <| "File" -> file, "Reason" -> reason |> ];
+    "Discarded"
+);
+
+discardUsageFile // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*submitUsagePayload*)
+(* POSTs one session's data as JSON. Returns True when the endpoint accepted it. *)
+submitUsagePayload // beginDefinition;
+
+submitUsagePayload[ payload_Association ] := Enclose[
+    Module[ { json, request, response },
+        json = ConfirmBy[ usageDataJSON @ payload, StringQ, "JSON" ];
+        request = HTTPRequest[
+            $usageDataEndpoint,
+            <| "Method" -> "POST", "ContentType" -> "application/json", "Body" -> json |>
+        ];
+        response = Quiet @ URLRead[ request, TimeConstraint -> $usageDataSubmitTimeout ];
+        MatchQ[ response, _HTTPResponse ] && TrueQ[ 200 <= response[ "StatusCode" ] < 300 ]
+    ],
+    throwInternalFailure
+];
+
+submitUsagePayload // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Package Footer*)
+addToMXInitialization[
+    Null
+];
+
+End[ ];
+EndPackage[ ];

--- a/Specs/UsageData.md
+++ b/Specs/UsageData.md
@@ -1,0 +1,107 @@
+# Usage Data — Design Specification
+
+## Overview
+
+Basic, anonymous usage tracking for the built-in local MCP servers, so that we can learn which MCP clients people use (to prioritize client support) and which tools and prompts get used (to understand feature usage). Nothing about the *content* of a session is ever recorded.
+
+User-facing documentation: [docs/usage-data.md](../docs/usage-data.md).
+
+## Goals
+
+- Record, per local server session, the client information from `initialize` and one event per `tools/call` and `prompts/get` request (name, success, timestamp).
+- Never record tool or prompt arguments, results, or any other content.
+- Enabled by default for the built-in servers; easy to opt out, both programmatically and from the preferences UI.
+- Submit each session's data once, after the session is over, without hitting the endpoint on every request.
+- Never interfere with the server: tracking failures are invisible to the client.
+- No tracking for cloud-deployed servers (stateless per request) and none from the test suite.
+
+## What Gets Tracked
+
+Client information: the `params` of the `initialize` request (`clientInfo`, `protocolVersion`, `capabilities`).
+
+Events, for `tools/call` and `prompts/get` only:
+
+```wl
+<| "Type" -> "ToolCall" | "PromptGet", "Name" -> name | Null, "Success" -> True | False, "Timestamp" -> AbsoluteTime[ TimeZone -> 0 ] |>
+```
+
+- `Name` is the requested name only if the server actually has a tool/prompt of that name; otherwise `Null`. A hallucinated name is arbitrary model-generated text and must not be recorded.
+- `Success` is `False` for a tool result with `"isError" -> True`, a JSON-RPC error response, or an internal failure.
+
+## When to Track
+
+- `InstallMCPServer` gets a `"SubmitUsageData"` option (default `Automatic`). `True`/`False` write `SUBMIT_USAGE_DATA=true|false` into the server's environment in the MCP configuration; `Automatic` writes nothing. Other values fail with `InvalidSubmitUsageData`. `DeployAgentTools` forwards the option like every other `InstallMCPServer` option and records it with the deployment.
+- The built-in servers get `"EnableUsageData" -> True` in their metadata.
+- At server start: if `SUBMIT_USAGE_DATA` holds a boolean, it wins (an explicit `True` also tracks custom servers, an explicit `False` opts a built-in server out); otherwise the server's `"EnableUsageData"` property must be exactly `True`.
+- `CreatePreferencesContent` shows a checkbox (checked by default) whose state is stored in `CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SubmitUsageData"}]`. Checked adds nothing to deployments (`Automatic`); unchecked adds `"SubmitUsageData" -> False`. Toggling re-deploys every existing deployment of a built-in toolset, preserving its other options, so the change takes effect without re-configuring each client; the re-deployment runs as a session task rather than in the checkbox's preemptive evaluation.
+- Development-mode servers are tracked like any other built-in server. Test servers are not: `GetMCPEnvironment` sets `SUBMIT_USAGE_DATA=false`.
+
+## How It Is Tracked
+
+Session state (`` Wolfram`AgentTools`Server` `` context, defined in `Kernel/Server/UsageData.wl`):
+
+| Symbol | Value |
+|--------|-------|
+| `$mcpSessionID` | A UUID assigned by `initializeUsageData` when the local server starts; persists for the kernel session |
+| `$mcpClientInformation` | `Null` until `initialize` is received, then `msg["params"]` |
+| `$usageEvents` | An `` Internal`Bag `` of events |
+| `$usageDataEnabled` | Whether this session is tracked |
+
+The session file is `$rootPath/UsageData/<$mcpSessionID>.wxf`, holding
+
+```wl
+<|
+    "MCPSessionID"      -> $mcpSessionID,
+    "ServerName"        -> name,
+    "ClientInformation" -> $mcpClientInformation,
+    "Events"            -> Internal`BagPart[ $usageEvents, All ],
+    "PacletVersion"     -> $pacletVersion,
+    "WolframVersion"    -> $Version,
+    "SystemID"          -> $SystemID,
+    "LastUpdated"       -> AbsoluteTime[ TimeZone -> 0 ]
+|>
+```
+
+The file is overwritten whenever the client information is set or an event is added. Events are capped at 10,000 per session.
+
+Hooks in the local transport (`Kernel/Server/Local.wl`): `initializeUsageData @ $currentMCPServer` once the server state is built, and `recordUsageData[ method, message, response ]` in `processRequest` after each request has been handled. Both are no-ops when tracking is disabled, and both are wrapped in `usageDataQuietly` (`Quiet @ catchAlways`, logging failures to `Log.wl`) so that nothing can propagate to the read loop.
+
+## Where and When It Is Sent
+
+Endpoint: `https://www.wolframcloud.com/obj/wolframai-content/api/1.0/usage`, POST with the session data as a JSON body (`Content-Type: application/json`). A 2xx status means accepted. (The endpoint currently only checks that the body is JSON.)
+
+We cannot know when a session's last message has arrived, so sessions are submitted by later sessions:
+
+- The session file's modification time doubles as the liveness signal. Because a client can be idle for a long time, a `SessionSubmit@ScheduledTask` in the server kernel touches the file (`SetFileDate`) every hour. Scheduled tasks do fire while the kernel is blocked in `InputString[""]` on stdin (verified for both the `wolfram -run` and the `wolframscript -f` launch styles).
+- A file that has not been modified for 24 hours belongs to a finished session. Ten seconds after a tracked server starts, a one-shot task submits all such files (oldest first) and deletes each one the endpoint accepts.
+- `WithLock[ File[ "UsageData/Submit.lock" ], ..., TimeConstraint -> 1, PersistenceTime -> 600 ]` ensures only one process submits/deletes at a time; a process that cannot get the lock within a second skips its turn, and a stale lock from a dead process is broken after ten minutes.
+- A failed submission keeps the file and stops the batch (the failure is most likely connectivity, which would affect the remaining files too). Files older than 30 days and unreadable files are discarded without submission, so that a permanently offline machine does not accumulate files forever.
+- Untracked sessions never submit, delete, or create files.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `Kernel/Server/UsageData.wl` | New: configuration, session state, `usageDataEnabledQ`, `initializeUsageData`, `recordUsageData`, session file, keep-alive task, locked submission |
+| `Kernel/Server/Server.wl` | Declare the shared session symbols and hooks; load the new subcontext |
+| `Kernel/Server/Local.wl` | Call the hooks |
+| `Kernel/DefaultServers.wl` | `"EnableUsageData" -> True` on the four built-in servers |
+| `Kernel/InstallMCPServer.wl` | `"SubmitUsageData"` option, validation, `SUBMIT_USAGE_DATA` in `addEnvironmentVariables` |
+| `Kernel/Messages.wl` | `InvalidSubmitUsageData` |
+| `Kernel/PreferencesContent.wl` | Checkbox, setting helpers, re-deployment; deployments from the panel pass the opt-out |
+| `FrontEnd/Assets/AgentTools.wl` | `prefsSubmitUsageData` and `prefsSubmitUsageDataDescription` strings (English only until localized) |
+| `Tests/UsageData.wlt` | Unit tests (enabling logic, recording, payload/JSON, keep-alive, staleness, locked submission with a stubbed HTTP call) and server integration tests |
+| `Tests/InstallMCPServer.wlt`, `Tests/MCPServerObject.wlt`, `Tests/PreferencesContent.wlt` | Option, property, and panel tests |
+| `Tests/MCPServerTestUtilities.wl` | `SUBMIT_USAGE_DATA=false` for test servers; `"Environment"` option of `StartMCPTestServer` |
+| `docs/usage-data.md` and related docs | Documentation |
+
+## Testing
+
+- `usageDataEnabledQ`: property vs. environment precedence, non-boolean values ignored.
+- `initializeUsageData`: session ID always assigned; tasks only when enabled; never fails startup.
+- `recordUsageData`: client information, tool/prompt events, success/failure cases, unknown names recorded as `Null`, no arguments or results in the file, other methods ignored, disabled sessions record nothing, event cap, failure isolation.
+- Payload JSON round trip.
+- Keep-alive touch, stale-file detection (current session excluded).
+- Submission with a stubbed `submitUsagePayload`: finished sessions submitted oldest first and deleted; fresh session kept; expired and unreadable files discarded; failure stops the batch; held lock skips; nonexistent directory.
+- HTTP: unreachable endpoint returns `False`; the development endpoint accepts a JSON body (skipped on GitHub Actions).
+- Integration (skipped when running as a script, like `StartMCPServer.wlt`): a real dev-mode server with `SUBMIT_USAGE_DATA=true` writes the expected file; one with the default test environment writes nothing.

--- a/Tests/InstallMCPServer.wlt
+++ b/Tests/InstallMCPServer.wlt
@@ -300,6 +300,118 @@ VerificationTest[
     TestID   -> "InstallMCPServer-EnableLLMKitAutomaticAbsent@@Tests/InstallMCPServer.wlt:296,1-301,2"
 ]
 
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*SubmitUsageData Option*)
+
+(* "SubmitUsageData" -> True/False injects SUBMIT_USAGE_DATA into the server's env block, which takes precedence
+   over the server's "EnableUsageData" property at startup (see docs/usage-data.md). The default, Automatic, adds
+   nothing, so the property decides: built-in servers track anonymous usage data, custom servers do not. *)
+installUsageDataEnv[ server_MCPServerObject, opts___ ] := Module[ { configFile, configName, env },
+    configFile = File @ FileNameJoin @ { $TemporaryDirectory, StringJoin[ "mcp_usage_", CreateUUID[], ".json" ] };
+    configName = Replace[ server[ "MCPServerName" ], Except[ _String ] :> server[ "Name" ] ];
+    InstallMCPServer[ configFile, server, opts, "VerifyLLMKit" -> False ];
+    env = Developer`ReadRawJSONString[ ReadString @ First @ configFile ][ "mcpServers", configName, "env" ];
+    Quiet @ DeleteFile @ First @ configFile;
+    Lookup[ env, "SUBMIT_USAGE_DATA", Missing[ "Absent" ] ]
+];
+
+installUsageDataEnv[ opts___ ] := Module[ { server, result },
+    server = CreateMCPServer[
+        StringJoin[ "TestServer_UsageData_", CreateUUID[] ],
+        LLMConfiguration @ <| "Tools" -> { LLMTool[ "PrimeFinder", { "n" -> "Integer" }, Prime[ #n ] & ] } |>
+    ];
+    result = installUsageDataEnv[ server, opts ];
+    DeleteObject[ server ];
+    result
+];
+
+VerificationTest[
+    MemberQ[ Keys @ Options @ InstallMCPServer, "SubmitUsageData" ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "InstallMCPServer-SubmitUsageDataOptionExists@@Tests/InstallMCPServer.wlt:329,1-334,2"
+]
+
+VerificationTest[
+    OptionValue[ InstallMCPServer, "SubmitUsageData" ],
+    Automatic,
+    SameTest -> SameQ,
+    TestID   -> "InstallMCPServer-SubmitUsageDataDefaultAutomatic@@Tests/InstallMCPServer.wlt:336,1-341,2"
+]
+
+VerificationTest[
+    installUsageDataEnv[ "SubmitUsageData" -> False ],
+    "false",
+    SameTest -> SameQ,
+    TestID   -> "InstallMCPServer-SubmitUsageDataFalseInjectsEnv@@Tests/InstallMCPServer.wlt:343,1-348,2"
+]
+
+VerificationTest[
+    installUsageDataEnv[ "SubmitUsageData" -> True ],
+    "true",
+    SameTest -> SameQ,
+    TestID   -> "InstallMCPServer-SubmitUsageDataTrueInjectsEnv@@Tests/InstallMCPServer.wlt:350,1-355,2"
+]
+
+VerificationTest[
+    installUsageDataEnv[ ],
+    Missing[ "Absent" ],
+    SameTest -> SameQ,
+    TestID   -> "InstallMCPServer-SubmitUsageDataDefaultAbsent@@Tests/InstallMCPServer.wlt:357,1-362,2"
+]
+
+VerificationTest[
+    installUsageDataEnv[ "SubmitUsageData" -> Automatic ],
+    Missing[ "Absent" ],
+    SameTest -> SameQ,
+    TestID   -> "InstallMCPServer-SubmitUsageDataAutomaticAbsent@@Tests/InstallMCPServer.wlt:364,1-369,2"
+]
+
+(* Built-in servers go through the same path: an opt-out lands in the config, the default adds nothing *)
+VerificationTest[
+    installUsageDataEnv[ MCPServerObject[ "WolframLanguage" ], "SubmitUsageData" -> False ],
+    "false",
+    SameTest -> SameQ,
+    TestID   -> "InstallMCPServer-SubmitUsageDataFalseBuiltIn@@Tests/InstallMCPServer.wlt:372,1-377,2"
+]
+
+VerificationTest[
+    installUsageDataEnv[ MCPServerObject[ "WolframLanguage" ] ],
+    Missing[ "Absent" ],
+    SameTest -> SameQ,
+    TestID   -> "InstallMCPServer-SubmitUsageDataDefaultBuiltInAbsent@@Tests/InstallMCPServer.wlt:379,1-384,2"
+]
+
+VerificationTest[
+    Module[ { configFile, result },
+        configFile = File @ FileNameJoin @ { $TemporaryDirectory, StringJoin[ "mcp_usage_", CreateUUID[], ".json" ] };
+        result = InstallMCPServer[ configFile, "WolframLanguage", "SubmitUsageData" -> "yes", "VerifyLLMKit" -> False ];
+        Quiet @ DeleteFile @ First @ configFile;
+        result
+    ],
+    _Failure,
+    { InstallMCPServer::InvalidSubmitUsageData },
+    SameTest -> MatchQ,
+    TestID   -> "InstallMCPServer-SubmitUsageDataInvalidValue@@Tests/InstallMCPServer.wlt:386,1-397,2"
+]
+
+(* DeployAgentTools forwards the option and records it with the deployment *)
+VerificationTest[
+    Module[ { configFile, dep, env, options },
+        configFile = File @ FileNameJoin @ { $TemporaryDirectory, StringJoin[ "mcp_usage_deploy_", CreateUUID[], ".json" ] };
+        dep = DeployAgentTools[ configFile, "WolframLanguage", "ApplicationName" -> "ClaudeCode", "SubmitUsageData" -> False, "VerifyLLMKit" -> False ];
+        env = Developer`ReadRawJSONString[ ReadString @ First @ configFile ][ "mcpServers", "Wolfram", "env" ];
+        options = dep[ "MCP", "Options" ];
+        DeleteObject[ dep ];
+        Quiet @ DeleteFile @ First @ configFile;
+        { Lookup[ env, "SUBMIT_USAGE_DATA", Missing[ "Absent" ] ], Lookup[ options, "SubmitUsageData", Missing[ "Absent" ] ] }
+    ],
+    { "false", False },
+    SameTest -> SameQ,
+    TestID   -> "DeployAgentTools-SubmitUsageDataForwarded@@Tests/InstallMCPServer.wlt:400,1-413,2"
+]
+
 (* "EnableLLMKit" -> False must also skip the install-time LLMKit requirement check, so a server with
    an LLMKit-required tool installs without a subscription failure and without consulting the
    subscription status. Verified at the unit level: the guard returns None before llmKitSubscribedQ
@@ -325,7 +437,7 @@ VerificationTest[
     ],
     { None, False },
     SameTest -> SameQ,
-    TestID   -> "CheckLLMKitRequirements-DisabledSkipsCheck@@Tests/InstallMCPServer.wlt:309,1-329,2"
+    TestID   -> "CheckLLMKitRequirements-DisabledSkipsCheck@@Tests/InstallMCPServer.wlt:421,1-441,2"
 ]
 (* :!CodeAnalysis::EndBlock:: *)
 
@@ -340,7 +452,7 @@ VerificationTest[
     installResult = InstallMCPServer[configFile, server],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-FromAssociation@@Tests/InstallMCPServer.wlt:335,1-344,2"
+    TestID   -> "InstallMCPServer-FromAssociation@@Tests/InstallMCPServer.wlt:447,1-456,2"
 ]
 
 VerificationTest[
@@ -348,7 +460,7 @@ VerificationTest[
     KeyExistsQ[jsonContent, "mcpServers"] && KeyExistsQ[jsonContent["mcpServers"], name],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-VerifyAssociationServer@@Tests/InstallMCPServer.wlt:346,1-352,2"
+    TestID   -> "InstallMCPServer-VerifyAssociationServer@@Tests/InstallMCPServer.wlt:458,1-464,2"
 ]
 
 VerificationTest[
@@ -357,7 +469,7 @@ VerificationTest[
     cleanupTestFiles[configFile],
     {Null},
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-CleanupAssociation@@Tests/InstallMCPServer.wlt:354,1-361,2"
+    TestID   -> "InstallMCPServer-CleanupAssociation@@Tests/InstallMCPServer.wlt:466,1-473,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -370,7 +482,7 @@ VerificationTest[
     installResult = InstallMCPServer[configFile, "WolframLanguage"],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-ClaudeCodeLike@@Tests/InstallMCPServer.wlt:366,1-374,2"
+    TestID   -> "InstallMCPServer-ClaudeCodeLike@@Tests/InstallMCPServer.wlt:478,1-486,2"
 ]
 
 VerificationTest[
@@ -382,7 +494,7 @@ VerificationTest[
     jsonContent["numStartups"] === 1,
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-PreservesOtherData@@Tests/InstallMCPServer.wlt:376,1-386,2"
+    TestID   -> "InstallMCPServer-PreservesOtherData@@Tests/InstallMCPServer.wlt:488,1-498,2"
 ]
 
 VerificationTest[
@@ -393,7 +505,7 @@ VerificationTest[
     KeyExistsQ[jsonContent["mcpServers"], "Wolfram"],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-MultipleBuiltInOverwrite@@Tests/InstallMCPServer.wlt:388,1-397,2"
+    TestID   -> "InstallMCPServer-MultipleBuiltInOverwrite@@Tests/InstallMCPServer.wlt:500,1-509,2"
 ]
 
 VerificationTest[
@@ -401,7 +513,7 @@ VerificationTest[
     cleanupTestFiles[configFile],
     {Null},
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-CleanupClaudeCodeLike@@Tests/InstallMCPServer.wlt:399,1-405,2"
+    TestID   -> "InstallMCPServer-CleanupClaudeCodeLike@@Tests/InstallMCPServer.wlt:511,1-517,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -414,7 +526,7 @@ VerificationTest[
     _Failure,
     {InstallMCPServer::InvalidMCPConfiguration},
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-InvalidJSON@@Tests/InstallMCPServer.wlt:410,1-418,2"
+    TestID   -> "InstallMCPServer-InvalidJSON@@Tests/InstallMCPServer.wlt:522,1-530,2"
 ]
 
 VerificationTest[
@@ -424,14 +536,14 @@ VerificationTest[
     _Failure,
     {InstallMCPServer::MCPServerNotFound},
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-NonExistentServer@@Tests/InstallMCPServer.wlt:420,1-428,2"
+    TestID   -> "InstallMCPServer-NonExistentServer@@Tests/InstallMCPServer.wlt:532,1-540,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[configFile],
     {Null},
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-CleanupErrorTests@@Tests/InstallMCPServer.wlt:430,1-435,2"
+    TestID   -> "InstallMCPServer-CleanupErrorTests@@Tests/InstallMCPServer.wlt:542,1-547,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -445,35 +557,35 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Antigravity", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Antigravity-Windows@@Tests/InstallMCPServer.wlt:444,1-449,2"
+    TestID   -> "InstallLocation-Antigravity-Windows@@Tests/InstallMCPServer.wlt:556,1-561,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Antigravity", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Antigravity-MacOSX@@Tests/InstallMCPServer.wlt:451,1-456,2"
+    TestID   -> "InstallLocation-Antigravity-MacOSX@@Tests/InstallMCPServer.wlt:563,1-568,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Antigravity", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Antigravity-Unix@@Tests/InstallMCPServer.wlt:458,1-463,2"
+    TestID   -> "InstallLocation-Antigravity-Unix@@Tests/InstallMCPServer.wlt:570,1-575,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "Antigravity" ],
     "Antigravity",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-Antigravity@@Tests/InstallMCPServer.wlt:465,1-470,2"
+    TestID   -> "InstallDisplayName-Antigravity@@Tests/InstallMCPServer.wlt:577,1-582,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "GoogleAntigravity" ],
     "Antigravity",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-GoogleAntigravity@@Tests/InstallMCPServer.wlt:472,1-477,2"
+    TestID   -> "ToInstallName-GoogleAntigravity@@Tests/InstallMCPServer.wlt:584,1-589,2"
 ]
 
 (* Antigravity install path detection: when the 2.0 installer migrates a pre-2.0 IDE
@@ -497,7 +609,7 @@ VerificationTest[
         "mcp_config.json", FileNameJoin @ { "antigravity", "mcp_config.json" }
     },
     SameTest -> Equal,
-    TestID   -> "AntigravityInstallLocation-MigratedVsFresh@@Tests/InstallMCPServer.wlt:483,1-501,2"
+    TestID   -> "AntigravityInstallLocation-MigratedVsFresh@@Tests/InstallMCPServer.wlt:595,1-613,2"
 ]
 
 (* "AntigravityCLI" and "GoogleAntigravityCLI" are aliases of the unified "Antigravity"
@@ -508,14 +620,14 @@ VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "AntigravityCLI" ],
     "Antigravity",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-AntigravityCLI@@Tests/InstallMCPServer.wlt:507,1-512,2"
+    TestID   -> "ToInstallName-AntigravityCLI@@Tests/InstallMCPServer.wlt:619,1-624,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "GoogleAntigravityCLI" ],
     "Antigravity",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-GoogleAntigravityCLI@@Tests/InstallMCPServer.wlt:514,1-519,2"
+    TestID   -> "ToInstallName-GoogleAntigravityCLI@@Tests/InstallMCPServer.wlt:626,1-631,2"
 ]
 
 (* installLocation alias-resolves internally, so the CLI alias yields the same _File as
@@ -525,7 +637,7 @@ VerificationTest[
         Wolfram`AgentTools`Common`installLocation[ "Antigravity", "Windows" ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallLocation-AntigravityCLI-AliasMatchesCanonical@@Tests/InstallMCPServer.wlt:523,1-529,2"
+    TestID   -> "InstallLocation-AntigravityCLI-AliasMatchesCanonical@@Tests/InstallMCPServer.wlt:635,1-641,2"
 ]
 
 (* The unified entry has project support (the CLI's workspace path .agents/mcp_config.json),
@@ -534,7 +646,7 @@ VerificationTest[
     TrueQ @ $SupportedMCPClients[ "Antigravity", "ProjectSupport" ],
     True,
     SameTest -> Equal,
-    TestID   -> "Antigravity-HasProjectSupport@@Tests/InstallMCPServer.wlt:533,1-538,2"
+    TestID   -> "Antigravity-HasProjectSupport@@Tests/InstallMCPServer.wlt:645,1-650,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -550,7 +662,7 @@ VerificationTest[
     ],
     ".mcp.json",
     SameTest -> Equal,
-    TestID   -> "ProjectInstallLocation-ClaudeCode@@Tests/InstallMCPServer.wlt:545,1-554,2"
+    TestID   -> "ProjectInstallLocation-ClaudeCode@@Tests/InstallMCPServer.wlt:657,1-666,2"
 ]
 
 VerificationTest[
@@ -560,7 +672,7 @@ VerificationTest[
     ],
     ".mcp.json",
     SameTest -> Equal,
-    TestID   -> "ProjectInstallLocation-ClaudeCode-FileWrapper@@Tests/InstallMCPServer.wlt:556,1-564,2"
+    TestID   -> "ProjectInstallLocation-ClaudeCode-FileWrapper@@Tests/InstallMCPServer.wlt:668,1-676,2"
 ]
 
 VerificationTest[
@@ -571,7 +683,7 @@ VerificationTest[
     ],
     "opencode.json",
     SameTest -> Equal,
-    TestID   -> "ProjectInstallLocation-OpenCode@@Tests/InstallMCPServer.wlt:566,1-575,2"
+    TestID   -> "ProjectInstallLocation-OpenCode@@Tests/InstallMCPServer.wlt:678,1-687,2"
 ]
 
 VerificationTest[
@@ -582,7 +694,7 @@ VerificationTest[
     ],
     FileNameJoin @ { ".codex", "config.toml" },
     SameTest -> Equal,
-    TestID   -> "ProjectInstallLocation-Codex@@Tests/InstallMCPServer.wlt:577,1-586,2"
+    TestID   -> "ProjectInstallLocation-Codex@@Tests/InstallMCPServer.wlt:689,1-698,2"
 ]
 
 (* Workspace install for the unified Antigravity entry goes to .agents/mcp_config.json
@@ -597,7 +709,7 @@ VerificationTest[
     ],
     FileNameJoin @ { ".agents", "mcp_config.json" },
     SameTest -> Equal,
-    TestID   -> "ProjectInstallLocation-Antigravity@@Tests/InstallMCPServer.wlt:592,1-601,2"
+    TestID   -> "ProjectInstallLocation-Antigravity@@Tests/InstallMCPServer.wlt:704,1-713,2"
 ]
 
 VerificationTest[
@@ -608,7 +720,7 @@ VerificationTest[
     ],
     FileNameJoin @ { ".vscode", "mcp.json" },
     SameTest -> Equal,
-    TestID   -> "ProjectInstallLocation-VisualStudioCode@@Tests/InstallMCPServer.wlt:603,1-612,2"
+    TestID   -> "ProjectInstallLocation-VisualStudioCode@@Tests/InstallMCPServer.wlt:715,1-724,2"
 ]
 
 VerificationTest[
@@ -618,7 +730,7 @@ VerificationTest[
     _Failure,
     { AgentTools::InvalidProjectDirectory },
     SameTest -> MatchQ,
-    TestID   -> "ProjectInstallLocation-InvalidDirectory-Symbol@@Tests/InstallMCPServer.wlt:614,1-622,2"
+    TestID   -> "ProjectInstallLocation-InvalidDirectory-Symbol@@Tests/InstallMCPServer.wlt:726,1-734,2"
 ]
 
 VerificationTest[
@@ -628,7 +740,7 @@ VerificationTest[
     _Failure,
     { AgentTools::InvalidProjectDirectory },
     SameTest -> MatchQ,
-    TestID   -> "ProjectInstallLocation-InvalidDirectory-Integer@@Tests/InstallMCPServer.wlt:624,1-632,2"
+    TestID   -> "ProjectInstallLocation-InvalidDirectory-Integer@@Tests/InstallMCPServer.wlt:736,1-744,2"
 ]
 
 VerificationTest[
@@ -636,7 +748,7 @@ VerificationTest[
     _Failure,
     { InstallMCPServer::InvalidProjectDirectory },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-InvalidProjectDirectory@@Tests/InstallMCPServer.wlt:634,1-640,2"
+    TestID   -> "InstallMCPServer-InvalidProjectDirectory@@Tests/InstallMCPServer.wlt:746,1-752,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -646,7 +758,7 @@ VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`makeDevelopmentArgs[ DirectoryName[ $TestFileName, 2 ] ],
     { "-script", _String? FileExistsQ, "-noinit", "-noprompt" },
     SameTest -> MatchQ,
-    TestID   -> "MakeDevelopmentArgs-ValidPath@@Tests/InstallMCPServer.wlt:645,1-650,2"
+    TestID   -> "MakeDevelopmentArgs-ValidPath@@Tests/InstallMCPServer.wlt:757,1-762,2"
 ]
 
 VerificationTest[
@@ -656,7 +768,7 @@ VerificationTest[
     Failure[ "InstallMCPServer::DevelopmentModeUnavailable", _ ],
     { InstallMCPServer::DevelopmentModeUnavailable },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-DevelopmentMode-InvalidPath@@Tests/InstallMCPServer.wlt:652,1-660,2"
+    TestID   -> "InstallMCPServer-DevelopmentMode-InvalidPath@@Tests/InstallMCPServer.wlt:764,1-772,2"
 ]
 
 VerificationTest[
@@ -665,7 +777,7 @@ VerificationTest[
     Failure[ "InstallMCPServer::InvalidDevelopmentMode", _ ],
     { InstallMCPServer::InvalidDevelopmentMode },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-DevelopmentMode-InvalidValue@@Tests/InstallMCPServer.wlt:662,1-669,2"
+    TestID   -> "InstallMCPServer-DevelopmentMode-InvalidValue@@Tests/InstallMCPServer.wlt:774,1-781,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -674,7 +786,7 @@ VerificationTest[
 VerificationTest[
     MemberQ[ Keys @ Options @ InstallMCPServer, "DevelopmentMode" ],
     True,
-    TestID -> "DevelopmentMode-OptionExists@@Tests/InstallMCPServer.wlt:674,1-678,2"
+    TestID -> "DevelopmentMode-OptionExists@@Tests/InstallMCPServer.wlt:786,1-790,2"
 ]
 
 VerificationTest[
@@ -682,7 +794,7 @@ VerificationTest[
     InstallMCPServer[ configFile, "DevelopmentMode" -> DirectoryName[ $TestFileName, 2 ], "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-DevelopmentMode-Success@@Tests/InstallMCPServer.wlt:680,1-686,2"
+    TestID   -> "InstallMCPServer-DevelopmentMode-Success@@Tests/InstallMCPServer.wlt:792,1-798,2"
 ]
 
 VerificationTest[
@@ -690,14 +802,14 @@ VerificationTest[
     json[ "mcpServers", "Wolfram", "args" ],
     { "-script", _String, "-noinit", "-noprompt" },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-DevelopmentMode-Args@@Tests/InstallMCPServer.wlt:688,1-694,2"
+    TestID   -> "InstallMCPServer-DevelopmentMode-Args@@Tests/InstallMCPServer.wlt:800,1-806,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ configFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-DevelopmentMode-Cleanup@@Tests/InstallMCPServer.wlt:696,1-701,2"
+    TestID   -> "InstallMCPServer-DevelopmentMode-Cleanup@@Tests/InstallMCPServer.wlt:808,1-813,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -716,21 +828,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Codex", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Codex-Windows@@Tests/InstallMCPServer.wlt:715,1-720,2"
+    TestID   -> "InstallLocation-Codex-Windows@@Tests/InstallMCPServer.wlt:827,1-832,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Codex", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Codex-MacOSX@@Tests/InstallMCPServer.wlt:722,1-727,2"
+    TestID   -> "InstallLocation-Codex-MacOSX@@Tests/InstallMCPServer.wlt:834,1-839,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Codex", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Codex-Unix@@Tests/InstallMCPServer.wlt:729,1-734,2"
+    TestID   -> "InstallLocation-Codex-Unix@@Tests/InstallMCPServer.wlt:841,1-846,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -740,21 +852,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "OpenAICodex" ],
     "Codex",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-OpenAICodex@@Tests/InstallMCPServer.wlt:739,1-744,2"
+    TestID   -> "ToInstallName-OpenAICodex@@Tests/InstallMCPServer.wlt:851,1-856,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Codex" ],
     "Codex",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-Codex@@Tests/InstallMCPServer.wlt:746,1-751,2"
+    TestID   -> "ToInstallName-Codex@@Tests/InstallMCPServer.wlt:858,1-863,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "Codex" ],
     "Codex CLI",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-Codex@@Tests/InstallMCPServer.wlt:753,1-758,2"
+    TestID   -> "InstallDisplayName-Codex@@Tests/InstallMCPServer.wlt:865,1-870,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -765,7 +877,7 @@ VerificationTest[
     toml[ "Data" ],
     <| |>,
     SameTest -> Equal,
-    TestID   -> "ReadTOMLFile-NonExistent@@Tests/InstallMCPServer.wlt:763,1-769,2"
+    TestID   -> "ReadTOMLFile-NonExistent@@Tests/InstallMCPServer.wlt:875,1-881,2"
 ]
 
 VerificationTest[
@@ -780,7 +892,7 @@ VerificationTest[
     ],
     <| "key" -> "value", "number" -> 42, "enabled" -> True |>,
     SameTest -> Equal,
-    TestID   -> "ReadTOMLFile-BasicParsing@@Tests/InstallMCPServer.wlt:771,1-784,2"
+    TestID   -> "ReadTOMLFile-BasicParsing@@Tests/InstallMCPServer.wlt:883,1-896,2"
 ]
 
 VerificationTest[
@@ -800,7 +912,7 @@ VerificationTest[
         "enabled" -> True
     |>,
     SameTest -> Equal,
-    TestID   -> "ReadTOMLFile-MCPServerSection@@Tests/InstallMCPServer.wlt:786,1-804,2"
+    TestID   -> "ReadTOMLFile-MCPServerSection@@Tests/InstallMCPServer.wlt:898,1-916,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -812,14 +924,14 @@ VerificationTest[
     installResult = InstallMCPServer[ codexConfigFile, "WolframLanguage", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Codex-Basic@@Tests/InstallMCPServer.wlt:809,1-816,2"
+    TestID   -> "InstallMCPServer-Codex-Basic@@Tests/InstallMCPServer.wlt:921,1-928,2"
 ]
 
 VerificationTest[
     FileExistsQ[ codexConfigFile ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Codex-FileExists@@Tests/InstallMCPServer.wlt:818,1-823,2"
+    TestID   -> "InstallMCPServer-Codex-FileExists@@Tests/InstallMCPServer.wlt:930,1-935,2"
 ]
 
 VerificationTest[
@@ -830,7 +942,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Codex-VerifyContent@@Tests/InstallMCPServer.wlt:825,1-834,2"
+    TestID   -> "InstallMCPServer-Codex-VerifyContent@@Tests/InstallMCPServer.wlt:937,1-946,2"
 ]
 
 VerificationTest[
@@ -840,7 +952,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Codex-VerifySectionFormat@@Tests/InstallMCPServer.wlt:836,1-844,2"
+    TestID   -> "InstallMCPServer-Codex-VerifySectionFormat@@Tests/InstallMCPServer.wlt:948,1-956,2"
 ]
 
 VerificationTest[
@@ -848,7 +960,7 @@ VerificationTest[
     uninstallResult = UninstallMCPServer[ codexConfigFile, "WolframLanguage" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Codex-Basic@@Tests/InstallMCPServer.wlt:846,1-852,2"
+    TestID   -> "UninstallMCPServer-Codex-Basic@@Tests/InstallMCPServer.wlt:958,1-964,2"
 ]
 
 VerificationTest[
@@ -858,14 +970,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-Codex-VerifyRemoval@@Tests/InstallMCPServer.wlt:854,1-862,2"
+    TestID   -> "UninstallMCPServer-Codex-VerifyRemoval@@Tests/InstallMCPServer.wlt:966,1-974,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ codexConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Codex-Cleanup@@Tests/InstallMCPServer.wlt:864,1-869,2"
+    TestID   -> "InstallMCPServer-Codex-Cleanup@@Tests/InstallMCPServer.wlt:976,1-981,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -878,7 +990,7 @@ VerificationTest[
     InstallMCPServer[ codexConfigFile, "WolframLanguage", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Codex-MultipleServers@@Tests/InstallMCPServer.wlt:874,1-882,2"
+    TestID   -> "InstallMCPServer-Codex-MultipleServers@@Tests/InstallMCPServer.wlt:986,1-994,2"
 ]
 
 VerificationTest[
@@ -889,14 +1001,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Codex-VerifyMultipleBuiltInShareKey@@Tests/InstallMCPServer.wlt:884,1-893,2"
+    TestID   -> "InstallMCPServer-Codex-VerifyMultipleBuiltInShareKey@@Tests/InstallMCPServer.wlt:996,1-1005,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ codexConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Codex-MultipleServers-Cleanup@@Tests/InstallMCPServer.wlt:895,1-900,2"
+    TestID   -> "InstallMCPServer-Codex-MultipleServers-Cleanup@@Tests/InstallMCPServer.wlt:1007,1-1012,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -913,7 +1025,7 @@ VerificationTest[
     InstallMCPServer[ codexConfigFile, "WolframLanguage", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Codex-PreserveExisting@@Tests/InstallMCPServer.wlt:905,1-917,2"
+    TestID   -> "InstallMCPServer-Codex-PreserveExisting@@Tests/InstallMCPServer.wlt:1017,1-1029,2"
 ]
 
 VerificationTest[
@@ -925,14 +1037,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Codex-VerifyPreserved@@Tests/InstallMCPServer.wlt:919,1-929,2"
+    TestID   -> "InstallMCPServer-Codex-VerifyPreserved@@Tests/InstallMCPServer.wlt:1031,1-1041,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ codexConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Codex-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:931,1-936,2"
+    TestID   -> "InstallMCPServer-Codex-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:1043,1-1048,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -951,7 +1063,7 @@ VerificationTest[
         "enabled" -> True
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToCodexFormat-Basic@@Tests/InstallMCPServer.wlt:941,1-955,2"
+    TestID   -> "ConvertToCodexFormat-Basic@@Tests/InstallMCPServer.wlt:1053,1-1067,2"
 ]
 
 VerificationTest[
@@ -960,7 +1072,7 @@ VerificationTest[
     |>,
     <| "command" -> "wolfram", "enabled" -> True |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToCodexFormat-MinimalConfig@@Tests/InstallMCPServer.wlt:957,1-964,2"
+    TestID   -> "ConvertToCodexFormat-MinimalConfig@@Tests/InstallMCPServer.wlt:1069,1-1076,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -976,14 +1088,14 @@ VerificationTest[
     ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Codex-ProjectInstall@@Tests/InstallMCPServer.wlt:969,1-980,2"
+    TestID   -> "InstallMCPServer-Codex-ProjectInstall@@Tests/InstallMCPServer.wlt:1081,1-1092,2"
 ]
 
 VerificationTest[
     FileExistsQ @ codexProjectConfigFile,
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Codex-ProjectConfigExists@@Tests/InstallMCPServer.wlt:982,1-987,2"
+    TestID   -> "InstallMCPServer-Codex-ProjectConfigExists@@Tests/InstallMCPServer.wlt:1094,1-1099,2"
 ]
 
 VerificationTest[
@@ -993,14 +1105,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Codex-ProjectVerifyContent@@Tests/InstallMCPServer.wlt:989,1-997,2"
+    TestID   -> "InstallMCPServer-Codex-ProjectVerifyContent@@Tests/InstallMCPServer.wlt:1101,1-1109,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ { "Codex", codexProjectDir }, "WolframLanguage" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Codex-ProjectInstall@@Tests/InstallMCPServer.wlt:999,1-1004,2"
+    TestID   -> "UninstallMCPServer-Codex-ProjectInstall@@Tests/InstallMCPServer.wlt:1111,1-1116,2"
 ]
 
 VerificationTest[
@@ -1010,7 +1122,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-Codex-ProjectVerifyRemoval@@Tests/InstallMCPServer.wlt:1006,1-1014,2"
+    TestID   -> "UninstallMCPServer-Codex-ProjectVerifyRemoval@@Tests/InstallMCPServer.wlt:1118,1-1126,2"
 ]
 
 VerificationTest[
@@ -1024,7 +1136,7 @@ VerificationTest[
     Null,
     Null,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Codex-ProjectCleanup@@Tests/InstallMCPServer.wlt:1016,1-1028,2"
+    TestID   -> "InstallMCPServer-Codex-ProjectCleanup@@Tests/InstallMCPServer.wlt:1128,1-1140,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1043,21 +1155,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Goose", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Goose-Windows@@Tests/InstallMCPServer.wlt:1042,1-1047,2"
+    TestID   -> "InstallLocation-Goose-Windows@@Tests/InstallMCPServer.wlt:1154,1-1159,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Goose", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Goose-MacOSX@@Tests/InstallMCPServer.wlt:1049,1-1054,2"
+    TestID   -> "InstallLocation-Goose-MacOSX@@Tests/InstallMCPServer.wlt:1161,1-1166,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Goose", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Goose-Unix@@Tests/InstallMCPServer.wlt:1056,1-1061,2"
+    TestID   -> "InstallLocation-Goose-Unix@@Tests/InstallMCPServer.wlt:1168,1-1173,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1067,7 +1179,7 @@ VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "Goose" ],
     "Goose",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-Goose@@Tests/InstallMCPServer.wlt:1066,1-1071,2"
+    TestID   -> "InstallDisplayName-Goose@@Tests/InstallMCPServer.wlt:1178,1-1183,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1088,7 +1200,7 @@ VerificationTest[
         "timeout" -> 300
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToGooseFormat-Basic@@Tests/InstallMCPServer.wlt:1076,1-1092,2"
+    TestID   -> "ConvertToGooseFormat-Basic@@Tests/InstallMCPServer.wlt:1188,1-1204,2"
 ]
 
 VerificationTest[
@@ -1102,7 +1214,7 @@ VerificationTest[
         "timeout" -> 300
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToGooseFormat-MinimalConfig@@Tests/InstallMCPServer.wlt:1094,1-1106,2"
+    TestID   -> "ConvertToGooseFormat-MinimalConfig@@Tests/InstallMCPServer.wlt:1206,1-1218,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1113,14 +1225,14 @@ VerificationTest[
     installResult = InstallMCPServer[ gooseConfigFile, "WolframLanguage", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Goose-Basic@@Tests/InstallMCPServer.wlt:1111,1-1117,2"
+    TestID   -> "InstallMCPServer-Goose-Basic@@Tests/InstallMCPServer.wlt:1223,1-1229,2"
 ]
 
 VerificationTest[
     FileExistsQ @ gooseConfigFile,
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Goose-FileExists@@Tests/InstallMCPServer.wlt:1119,1-1124,2"
+    TestID   -> "InstallMCPServer-Goose-FileExists@@Tests/InstallMCPServer.wlt:1231,1-1236,2"
 ]
 
 VerificationTest[
@@ -1132,7 +1244,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Goose-VerifyContent@@Tests/InstallMCPServer.wlt:1126,1-1136,2"
+    TestID   -> "InstallMCPServer-Goose-VerifyContent@@Tests/InstallMCPServer.wlt:1238,1-1248,2"
 ]
 
 VerificationTest[
@@ -1146,7 +1258,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Goose-VerifyAllFields@@Tests/InstallMCPServer.wlt:1138,1-1150,2"
+    TestID   -> "InstallMCPServer-Goose-VerifyAllFields@@Tests/InstallMCPServer.wlt:1250,1-1262,2"
 ]
 
 VerificationTest[
@@ -1160,7 +1272,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Goose-VerifyFieldValues@@Tests/InstallMCPServer.wlt:1152,1-1164,2"
+    TestID   -> "InstallMCPServer-Goose-VerifyFieldValues@@Tests/InstallMCPServer.wlt:1264,1-1276,2"
 ]
 
 VerificationTest[
@@ -1172,14 +1284,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Goose-VerifyLiteralYAML@@Tests/InstallMCPServer.wlt:1166,1-1176,2"
+    TestID   -> "InstallMCPServer-Goose-VerifyLiteralYAML@@Tests/InstallMCPServer.wlt:1278,1-1288,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ gooseConfigFile, "WolframLanguage" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Goose-Basic@@Tests/InstallMCPServer.wlt:1178,1-1183,2"
+    TestID   -> "UninstallMCPServer-Goose-Basic@@Tests/InstallMCPServer.wlt:1290,1-1295,2"
 ]
 
 VerificationTest[
@@ -1189,14 +1301,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-Goose-VerifyRemoval@@Tests/InstallMCPServer.wlt:1185,1-1193,2"
+    TestID   -> "UninstallMCPServer-Goose-VerifyRemoval@@Tests/InstallMCPServer.wlt:1297,1-1305,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ gooseConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Goose-Cleanup@@Tests/InstallMCPServer.wlt:1195,1-1200,2"
+    TestID   -> "InstallMCPServer-Goose-Cleanup@@Tests/InstallMCPServer.wlt:1307,1-1312,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1208,7 +1320,7 @@ VerificationTest[
     InstallMCPServer[ gooseConfigFile, "WolframLanguage", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Goose-MultipleServers@@Tests/InstallMCPServer.wlt:1205,1-1212,2"
+    TestID   -> "InstallMCPServer-Goose-MultipleServers@@Tests/InstallMCPServer.wlt:1317,1-1324,2"
 ]
 
 VerificationTest[
@@ -1219,14 +1331,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Goose-VerifyMultipleBuiltInShareKey@@Tests/InstallMCPServer.wlt:1214,1-1223,2"
+    TestID   -> "InstallMCPServer-Goose-VerifyMultipleBuiltInShareKey@@Tests/InstallMCPServer.wlt:1326,1-1335,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ gooseConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Goose-MultipleServers-Cleanup@@Tests/InstallMCPServer.wlt:1225,1-1230,2"
+    TestID   -> "InstallMCPServer-Goose-MultipleServers-Cleanup@@Tests/InstallMCPServer.wlt:1337,1-1342,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1245,7 +1357,7 @@ VerificationTest[
     InstallMCPServer[ gooseConfigFile, "WolframLanguage", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Goose-PreserveExisting@@Tests/InstallMCPServer.wlt:1235,1-1249,2"
+    TestID   -> "InstallMCPServer-Goose-PreserveExisting@@Tests/InstallMCPServer.wlt:1347,1-1361,2"
 ]
 
 VerificationTest[
@@ -1256,14 +1368,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Goose-VerifyPreserved@@Tests/InstallMCPServer.wlt:1251,1-1260,2"
+    TestID   -> "InstallMCPServer-Goose-VerifyPreserved@@Tests/InstallMCPServer.wlt:1363,1-1372,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ gooseConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Goose-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:1262,1-1267,2"
+    TestID   -> "InstallMCPServer-Goose-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:1374,1-1379,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1281,7 +1393,7 @@ VerificationTest[
     _Failure,
     { InstallMCPServer::InvalidMCPConfiguration },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Goose-RefusesUnparseableYAML@@Tests/InstallMCPServer.wlt:1272,1-1285,2"
+    TestID   -> "InstallMCPServer-Goose-RefusesUnparseableYAML@@Tests/InstallMCPServer.wlt:1384,1-1397,2"
 ]
 
 VerificationTest[
@@ -1292,14 +1404,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Goose-PreservesUnparseableYAML@@Tests/InstallMCPServer.wlt:1287,1-1296,2"
+    TestID   -> "InstallMCPServer-Goose-PreservesUnparseableYAML@@Tests/InstallMCPServer.wlt:1399,1-1408,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ gooseConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Goose-RefusesUnparseableYAML-Cleanup@@Tests/InstallMCPServer.wlt:1298,1-1303,2"
+    TestID   -> "InstallMCPServer-Goose-RefusesUnparseableYAML-Cleanup@@Tests/InstallMCPServer.wlt:1410,1-1415,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1316,7 +1428,7 @@ VerificationTest[
     _Failure,
     { UninstallMCPServer::InvalidMCPConfiguration },
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Goose-RefusesUnparseableYAML@@Tests/InstallMCPServer.wlt:1308,1-1320,2"
+    TestID   -> "UninstallMCPServer-Goose-RefusesUnparseableYAML@@Tests/InstallMCPServer.wlt:1420,1-1432,2"
 ]
 
 VerificationTest[
@@ -1327,14 +1439,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-Goose-PreservesUnparseableYAML@@Tests/InstallMCPServer.wlt:1322,1-1331,2"
+    TestID   -> "UninstallMCPServer-Goose-PreservesUnparseableYAML@@Tests/InstallMCPServer.wlt:1434,1-1443,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ gooseConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Goose-RefusesUnparseableYAML-Cleanup@@Tests/InstallMCPServer.wlt:1333,1-1338,2"
+    TestID   -> "UninstallMCPServer-Goose-RefusesUnparseableYAML-Cleanup@@Tests/InstallMCPServer.wlt:1445,1-1450,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1349,7 +1461,7 @@ VerificationTest[
     _Failure,
     { AgentTools::UnsupportedMCPClientProject },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Goose-NoProjectSupport@@Tests/InstallMCPServer.wlt:1343,1-1353,2"
+    TestID   -> "InstallMCPServer-Goose-NoProjectSupport@@Tests/InstallMCPServer.wlt:1455,1-1465,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1368,21 +1480,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Continue", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Continue-Windows@@Tests/InstallMCPServer.wlt:1367,1-1372,2"
+    TestID   -> "InstallLocation-Continue-Windows@@Tests/InstallMCPServer.wlt:1479,1-1484,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Continue", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Continue-MacOSX@@Tests/InstallMCPServer.wlt:1374,1-1379,2"
+    TestID   -> "InstallLocation-Continue-MacOSX@@Tests/InstallMCPServer.wlt:1486,1-1491,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Continue", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Continue-Unix@@Tests/InstallMCPServer.wlt:1381,1-1386,2"
+    TestID   -> "InstallLocation-Continue-Unix@@Tests/InstallMCPServer.wlt:1493,1-1498,2"
 ]
 
 (* Continue's user-scope path is .continue/config.yaml under $HomeDirectory on every OS *)
@@ -1394,7 +1506,7 @@ VerificationTest[
     ],
     { ".continue", "config.yaml" },
     SameTest -> Equal,
-    TestID   -> "InstallLocation-Continue-PathShape@@Tests/InstallMCPServer.wlt:1389,1-1398,2"
+    TestID   -> "InstallLocation-Continue-PathShape@@Tests/InstallMCPServer.wlt:1501,1-1510,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1404,14 +1516,14 @@ VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Continue" ],
     "Continue",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-Continue@@Tests/InstallMCPServer.wlt:1403,1-1408,2"
+    TestID   -> "ToInstallName-Continue@@Tests/InstallMCPServer.wlt:1515,1-1520,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "Continue" ],
     "Continue",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-Continue@@Tests/InstallMCPServer.wlt:1410,1-1415,2"
+    TestID   -> "InstallDisplayName-Continue@@Tests/InstallMCPServer.wlt:1522,1-1527,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1432,7 +1544,7 @@ VerificationTest[
         "env" -> <| "KEY" -> "value" |>
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToContinueFormat-Basic@@Tests/InstallMCPServer.wlt:1422,1-1436,2"
+    TestID   -> "ConvertToContinueFormat-Basic@@Tests/InstallMCPServer.wlt:1534,1-1548,2"
 ]
 
 (* Empty args and env are omitted *)
@@ -1444,7 +1556,7 @@ VerificationTest[
     |>,
     <| "command" -> "wolfram" |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToContinueFormat-OmitsEmpty@@Tests/InstallMCPServer.wlt:1439,1-1448,2"
+    TestID   -> "ConvertToContinueFormat-OmitsEmpty@@Tests/InstallMCPServer.wlt:1551,1-1560,2"
 ]
 
 (* Converter does NOT set the "name" field -- the install flow prepends it after conversion *)
@@ -1455,7 +1567,7 @@ VerificationTest[
     ],
     False,
     SameTest -> Equal,
-    TestID   -> "ConvertToContinueFormat-NoNameField@@Tests/InstallMCPServer.wlt:1451,1-1459,2"
+    TestID   -> "ConvertToContinueFormat-NoNameField@@Tests/InstallMCPServer.wlt:1563,1-1571,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1468,7 +1580,7 @@ VerificationTest[
         FileNameJoin @ { $TemporaryDirectory, "continue_noexist_" <> CreateUUID[] <> ".yaml" },
     <| |>,
     SameTest -> Equal,
-    TestID   -> "ReadExistingContinueConfig-NonExistent@@Tests/InstallMCPServer.wlt:1466,1-1472,2"
+    TestID   -> "ReadExistingContinueConfig-NonExistent@@Tests/InstallMCPServer.wlt:1578,1-1584,2"
 ]
 
 (* Valid YAML with mcpServers array is returned as an Association *)
@@ -1487,7 +1599,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "ReadExistingContinueConfig-ValidYAML@@Tests/InstallMCPServer.wlt:1475,1-1491,2"
+    TestID   -> "ReadExistingContinueConfig-ValidYAML@@Tests/InstallMCPServer.wlt:1587,1-1603,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1503,14 +1615,14 @@ VerificationTest[
     ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Continue-Basic@@Tests/InstallMCPServer.wlt:1496,1-1507,2"
+    TestID   -> "InstallMCPServer-Continue-Basic@@Tests/InstallMCPServer.wlt:1608,1-1619,2"
 ]
 
 VerificationTest[
     FileExistsQ[ continueConfigFile ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Continue-FileExists@@Tests/InstallMCPServer.wlt:1509,1-1514,2"
+    TestID   -> "InstallMCPServer-Continue-FileExists@@Tests/InstallMCPServer.wlt:1621,1-1626,2"
 ]
 
 (* Root is an Association with mcpServers as an array *)
@@ -1523,7 +1635,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Continue-RootShape@@Tests/InstallMCPServer.wlt:1517,1-1527,2"
+    TestID   -> "InstallMCPServer-Continue-RootShape@@Tests/InstallMCPServer.wlt:1629,1-1639,2"
 ]
 
 (* The single entry has inline name + command + args + env *)
@@ -1538,7 +1650,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Continue-EntryShape@@Tests/InstallMCPServer.wlt:1530,1-1542,2"
+    TestID   -> "InstallMCPServer-Continue-EntryShape@@Tests/InstallMCPServer.wlt:1642,1-1654,2"
 ]
 
 (* Continue REQUIRES name / version / schema at the top of every config.yaml -- including
@@ -1553,7 +1665,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Continue-Global-RequiredMetadata@@Tests/InstallMCPServer.wlt:1547,1-1557,2"
+    TestID   -> "InstallMCPServer-Continue-Global-RequiredMetadata@@Tests/InstallMCPServer.wlt:1659,1-1669,2"
 ]
 
 (* Continue uses the standard server fields -- no Cline disabled/autoApprove, no Copilot tools *)
@@ -1568,7 +1680,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Continue-StandardFormat@@Tests/InstallMCPServer.wlt:1560,1-1572,2"
+    TestID   -> "InstallMCPServer-Continue-StandardFormat@@Tests/InstallMCPServer.wlt:1672,1-1684,2"
 ]
 
 (* Idempotent re-install: array stays length 1 *)
@@ -1581,7 +1693,7 @@ VerificationTest[
     ],
     1,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Continue-Idempotent@@Tests/InstallMCPServer.wlt:1575,1-1585,2"
+    TestID   -> "InstallMCPServer-Continue-Idempotent@@Tests/InstallMCPServer.wlt:1687,1-1697,2"
 ]
 
 (* Second, differently-named server is appended, not replaced *)
@@ -1595,14 +1707,14 @@ VerificationTest[
     ],
     { "Wolfram", "WolframAlphaExtra" },
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Continue-MultiServer@@Tests/InstallMCPServer.wlt:1588,1-1599,2"
+    TestID   -> "InstallMCPServer-Continue-MultiServer@@Tests/InstallMCPServer.wlt:1700,1-1711,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ continueConfigFile, "WolframLanguage", "ApplicationName" -> "Continue" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Continue-Basic@@Tests/InstallMCPServer.wlt:1601,1-1606,2"
+    TestID   -> "UninstallMCPServer-Continue-Basic@@Tests/InstallMCPServer.wlt:1713,1-1718,2"
 ]
 
 (* After removing WolframLanguage, only WolframAlphaExtra remains *)
@@ -1614,7 +1726,7 @@ VerificationTest[
     ],
     { "WolframAlphaExtra" },
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-Continue-VerifyRemoval@@Tests/InstallMCPServer.wlt:1609,1-1618,2"
+    TestID   -> "UninstallMCPServer-Continue-VerifyRemoval@@Tests/InstallMCPServer.wlt:1721,1-1730,2"
 ]
 
 (* Uninstalling a name that isn't in the array returns NotInstalled *)
@@ -1622,14 +1734,14 @@ VerificationTest[
     UninstallMCPServer[ continueConfigFile, "WolframLanguage", "ApplicationName" -> "Continue" ],
     Missing[ "NotInstalled", _ ],
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Continue-NotInstalled@@Tests/InstallMCPServer.wlt:1621,1-1626,2"
+    TestID   -> "UninstallMCPServer-Continue-NotInstalled@@Tests/InstallMCPServer.wlt:1733,1-1738,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ continueConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Continue-Cleanup@@Tests/InstallMCPServer.wlt:1628,1-1633,2"
+    TestID   -> "InstallMCPServer-Continue-Cleanup@@Tests/InstallMCPServer.wlt:1740,1-1745,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1667,7 +1779,7 @@ VerificationTest[
     ],
     { True, True, True, "Wolfram", True, "v1", True, 1 },
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Continue-ProjectLevel@@Tests/InstallMCPServer.wlt:1640,1-1671,2"
+    TestID   -> "InstallMCPServer-Continue-ProjectLevel@@Tests/InstallMCPServer.wlt:1752,1-1783,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1708,7 +1820,7 @@ VerificationTest[
     ],
     { "My Continue Config", { <| "name" -> "gpt-4", "provider" -> "openai" |> }, { "Be concise." }, True, 1, True, "v1" },
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Continue-PreservesUnrelatedKeys@@Tests/InstallMCPServer.wlt:1681,1-1712,2"
+    TestID   -> "InstallMCPServer-Continue-PreservesUnrelatedKeys@@Tests/InstallMCPServer.wlt:1793,1-1824,2"
 ]
 
 (* Fresh global config.yaml (no pre-existing user keys) gets the "Local Config" default
@@ -1725,7 +1837,7 @@ VerificationTest[
     ],
     "Local Config",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Continue-Global-DefaultName@@Tests/InstallMCPServer.wlt:1716,1-1729,2"
+    TestID   -> "InstallMCPServer-Continue-Global-DefaultName@@Tests/InstallMCPServer.wlt:1828,1-1841,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1747,7 +1859,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "GuessClientName-Continue-GlobalPath@@Tests/InstallMCPServer.wlt:1736,1-1751,2"
+    TestID   -> "GuessClientName-Continue-GlobalPath@@Tests/InstallMCPServer.wlt:1848,1-1863,2"
 ]
 
 (* File at .continue/mcpServers/<X>.yaml is auto-detected as Continue *)
@@ -1768,7 +1880,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "GuessClientName-Continue-ProjectPath@@Tests/InstallMCPServer.wlt:1754,1-1772,2"
+    TestID   -> "GuessClientName-Continue-ProjectPath@@Tests/InstallMCPServer.wlt:1866,1-1884,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1778,42 +1890,42 @@ VerificationTest[
     $SupportedMCPClients[ "Continue", "DisplayName" ],
     "Continue",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ContinueDisplayName@@Tests/InstallMCPServer.wlt:1777,1-1782,2"
+    TestID   -> "SupportedMCPClients-ContinueDisplayName@@Tests/InstallMCPServer.wlt:1889,1-1894,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Continue", "ConfigFormat" ],
     "YAML",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ContinueConfigFormat@@Tests/InstallMCPServer.wlt:1784,1-1789,2"
+    TestID   -> "SupportedMCPClients-ContinueConfigFormat@@Tests/InstallMCPServer.wlt:1896,1-1901,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Continue", "ConfigKey" ],
     { "mcpServers" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ContinueConfigKey@@Tests/InstallMCPServer.wlt:1791,1-1796,2"
+    TestID   -> "SupportedMCPClients-ContinueConfigKey@@Tests/InstallMCPServer.wlt:1903,1-1908,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Continue", "ProjectSupport" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ContinueProjectSupport@@Tests/InstallMCPServer.wlt:1798,1-1803,2"
+    TestID   -> "SupportedMCPClients-ContinueProjectSupport@@Tests/InstallMCPServer.wlt:1910,1-1915,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Continue", "DefaultToolset" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ContinueDefaultToolset@@Tests/InstallMCPServer.wlt:1805,1-1810,2"
+    TestID   -> "SupportedMCPClients-ContinueDefaultToolset@@Tests/InstallMCPServer.wlt:1917,1-1922,2"
 ]
 
 VerificationTest[
     StringStartsQ[ $SupportedMCPClients[ "Continue", "URL" ], "https://" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ContinueURL@@Tests/InstallMCPServer.wlt:1812,1-1817,2"
+    TestID   -> "SupportedMCPClients-ContinueURL@@Tests/InstallMCPServer.wlt:1924,1-1929,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1827,21 +1939,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "CopilotCLI", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-CopilotCLI-Windows@@Tests/InstallMCPServer.wlt:1826,1-1831,2"
+    TestID   -> "InstallLocation-CopilotCLI-Windows@@Tests/InstallMCPServer.wlt:1938,1-1943,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "CopilotCLI", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-CopilotCLI-MacOSX@@Tests/InstallMCPServer.wlt:1833,1-1838,2"
+    TestID   -> "InstallLocation-CopilotCLI-MacOSX@@Tests/InstallMCPServer.wlt:1945,1-1950,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "CopilotCLI", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-CopilotCLI-Unix@@Tests/InstallMCPServer.wlt:1840,1-1845,2"
+    TestID   -> "InstallLocation-CopilotCLI-Unix@@Tests/InstallMCPServer.wlt:1952,1-1957,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1851,21 +1963,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Copilot" ],
     "CopilotCLI",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-Copilot@@Tests/InstallMCPServer.wlt:1850,1-1855,2"
+    TestID   -> "ToInstallName-Copilot@@Tests/InstallMCPServer.wlt:1962,1-1967,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "CopilotCLI" ],
     "CopilotCLI",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-CopilotCLI@@Tests/InstallMCPServer.wlt:1857,1-1862,2"
+    TestID   -> "ToInstallName-CopilotCLI@@Tests/InstallMCPServer.wlt:1969,1-1974,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "CopilotCLI" ],
     "Copilot CLI",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-CopilotCLI@@Tests/InstallMCPServer.wlt:1864,1-1869,2"
+    TestID   -> "InstallDisplayName-CopilotCLI@@Tests/InstallMCPServer.wlt:1976,1-1981,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1884,7 +1996,7 @@ VerificationTest[
         "tools" -> { "*" }
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToCopilotCLIFormat-Basic@@Tests/InstallMCPServer.wlt:1874,1-1888,2"
+    TestID   -> "ConvertToCopilotCLIFormat-Basic@@Tests/InstallMCPServer.wlt:1986,1-2000,2"
 ]
 
 VerificationTest[
@@ -1893,7 +2005,7 @@ VerificationTest[
     |>,
     <| "command" -> "wolfram", "tools" -> { "*" } |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToCopilotCLIFormat-MinimalConfig@@Tests/InstallMCPServer.wlt:1890,1-1897,2"
+    TestID   -> "ConvertToCopilotCLIFormat-MinimalConfig@@Tests/InstallMCPServer.wlt:2002,1-2009,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1907,21 +2019,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Windsurf", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Windsurf-Windows@@Tests/InstallMCPServer.wlt:1906,1-1911,2"
+    TestID   -> "InstallLocation-Windsurf-Windows@@Tests/InstallMCPServer.wlt:2018,1-2023,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Windsurf", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Windsurf-MacOSX@@Tests/InstallMCPServer.wlt:1913,1-1918,2"
+    TestID   -> "InstallLocation-Windsurf-MacOSX@@Tests/InstallMCPServer.wlt:2025,1-2030,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Windsurf", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Windsurf-Unix@@Tests/InstallMCPServer.wlt:1920,1-1925,2"
+    TestID   -> "InstallLocation-Windsurf-Unix@@Tests/InstallMCPServer.wlt:2032,1-2037,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1931,21 +2043,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Codeium" ],
     "Windsurf",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-Codeium@@Tests/InstallMCPServer.wlt:1930,1-1935,2"
+    TestID   -> "ToInstallName-Codeium@@Tests/InstallMCPServer.wlt:2042,1-2047,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Windsurf" ],
     "Windsurf",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-Windsurf@@Tests/InstallMCPServer.wlt:1937,1-1942,2"
+    TestID   -> "ToInstallName-Windsurf@@Tests/InstallMCPServer.wlt:2049,1-2054,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "Windsurf" ],
     "Windsurf",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-Windsurf@@Tests/InstallMCPServer.wlt:1944,1-1949,2"
+    TestID   -> "InstallDisplayName-Windsurf@@Tests/InstallMCPServer.wlt:2056,1-2061,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1959,21 +2071,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Cline", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Cline-Windows@@Tests/InstallMCPServer.wlt:1958,1-1963,2"
+    TestID   -> "InstallLocation-Cline-Windows@@Tests/InstallMCPServer.wlt:2070,1-2075,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Cline", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Cline-MacOSX@@Tests/InstallMCPServer.wlt:1965,1-1970,2"
+    TestID   -> "InstallLocation-Cline-MacOSX@@Tests/InstallMCPServer.wlt:2077,1-2082,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Cline", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Cline-Unix@@Tests/InstallMCPServer.wlt:1972,1-1977,2"
+    TestID   -> "InstallLocation-Cline-Unix@@Tests/InstallMCPServer.wlt:2084,1-2089,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -1983,14 +2095,14 @@ VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Cline" ],
     "Cline",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-Cline@@Tests/InstallMCPServer.wlt:1982,1-1987,2"
+    TestID   -> "ToInstallName-Cline@@Tests/InstallMCPServer.wlt:2094,1-2099,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "Cline" ],
     "Cline",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-Cline@@Tests/InstallMCPServer.wlt:1989,1-1994,2"
+    TestID   -> "InstallDisplayName-Cline@@Tests/InstallMCPServer.wlt:2101,1-2106,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2010,7 +2122,7 @@ VerificationTest[
         "autoApprove" -> { }
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToClineFormat-Basic@@Tests/InstallMCPServer.wlt:1999,1-2014,2"
+    TestID   -> "ConvertToClineFormat-Basic@@Tests/InstallMCPServer.wlt:2111,1-2126,2"
 ]
 
 VerificationTest[
@@ -2019,7 +2131,7 @@ VerificationTest[
     |>,
     <| "command" -> "wolfram", "disabled" -> False, "autoApprove" -> { } |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToClineFormat-MinimalConfig@@Tests/InstallMCPServer.wlt:2016,1-2023,2"
+    TestID   -> "ConvertToClineFormat-MinimalConfig@@Tests/InstallMCPServer.wlt:2128,1-2135,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2030,14 +2142,14 @@ VerificationTest[
     installResult = InstallMCPServer[ clineConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "Cline" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Cline-Basic@@Tests/InstallMCPServer.wlt:2028,1-2034,2"
+    TestID   -> "InstallMCPServer-Cline-Basic@@Tests/InstallMCPServer.wlt:2140,1-2146,2"
 ]
 
 VerificationTest[
     FileExistsQ[ clineConfigFile ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Cline-FileExists@@Tests/InstallMCPServer.wlt:2036,1-2041,2"
+    TestID   -> "InstallMCPServer-Cline-FileExists@@Tests/InstallMCPServer.wlt:2148,1-2153,2"
 ]
 
 VerificationTest[
@@ -2047,7 +2159,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Cline-VerifyContent@@Tests/InstallMCPServer.wlt:2043,1-2051,2"
+    TestID   -> "InstallMCPServer-Cline-VerifyContent@@Tests/InstallMCPServer.wlt:2155,1-2163,2"
 ]
 
 VerificationTest[
@@ -2059,14 +2171,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Cline-VerifyClineFields@@Tests/InstallMCPServer.wlt:2053,1-2063,2"
+    TestID   -> "InstallMCPServer-Cline-VerifyClineFields@@Tests/InstallMCPServer.wlt:2165,1-2175,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ clineConfigFile, "WolframLanguage", "ApplicationName" -> "Cline" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Cline-Basic@@Tests/InstallMCPServer.wlt:2065,1-2070,2"
+    TestID   -> "UninstallMCPServer-Cline-Basic@@Tests/InstallMCPServer.wlt:2177,1-2182,2"
 ]
 
 VerificationTest[
@@ -2076,14 +2188,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-Cline-VerifyRemoval@@Tests/InstallMCPServer.wlt:2072,1-2080,2"
+    TestID   -> "UninstallMCPServer-Cline-VerifyRemoval@@Tests/InstallMCPServer.wlt:2184,1-2192,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ clineConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Cline-Cleanup@@Tests/InstallMCPServer.wlt:2082,1-2087,2"
+    TestID   -> "InstallMCPServer-Cline-Cleanup@@Tests/InstallMCPServer.wlt:2194,1-2199,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2094,14 +2206,14 @@ VerificationTest[
     installResult = InstallMCPServer[ windsurfConfigFile, "WolframLanguage", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Windsurf-Basic@@Tests/InstallMCPServer.wlt:2092,1-2098,2"
+    TestID   -> "InstallMCPServer-Windsurf-Basic@@Tests/InstallMCPServer.wlt:2204,1-2210,2"
 ]
 
 VerificationTest[
     FileExistsQ[ windsurfConfigFile ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Windsurf-FileExists@@Tests/InstallMCPServer.wlt:2100,1-2105,2"
+    TestID   -> "InstallMCPServer-Windsurf-FileExists@@Tests/InstallMCPServer.wlt:2212,1-2217,2"
 ]
 
 VerificationTest[
@@ -2111,14 +2223,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Windsurf-VerifyContent@@Tests/InstallMCPServer.wlt:2107,1-2115,2"
+    TestID   -> "InstallMCPServer-Windsurf-VerifyContent@@Tests/InstallMCPServer.wlt:2219,1-2227,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ windsurfConfigFile, "WolframLanguage" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Windsurf-Basic@@Tests/InstallMCPServer.wlt:2117,1-2122,2"
+    TestID   -> "UninstallMCPServer-Windsurf-Basic@@Tests/InstallMCPServer.wlt:2229,1-2234,2"
 ]
 
 VerificationTest[
@@ -2128,14 +2240,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-Windsurf-VerifyRemoval@@Tests/InstallMCPServer.wlt:2124,1-2132,2"
+    TestID   -> "UninstallMCPServer-Windsurf-VerifyRemoval@@Tests/InstallMCPServer.wlt:2236,1-2244,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ windsurfConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Windsurf-Cleanup@@Tests/InstallMCPServer.wlt:2134,1-2139,2"
+    TestID   -> "InstallMCPServer-Windsurf-Cleanup@@Tests/InstallMCPServer.wlt:2246,1-2251,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2149,21 +2261,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "AugmentCode", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-AugmentCode-Windows@@Tests/InstallMCPServer.wlt:2148,1-2153,2"
+    TestID   -> "InstallLocation-AugmentCode-Windows@@Tests/InstallMCPServer.wlt:2260,1-2265,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "AugmentCode", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-AugmentCode-MacOSX@@Tests/InstallMCPServer.wlt:2155,1-2160,2"
+    TestID   -> "InstallLocation-AugmentCode-MacOSX@@Tests/InstallMCPServer.wlt:2267,1-2272,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "AugmentCode", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-AugmentCode-Unix@@Tests/InstallMCPServer.wlt:2162,1-2167,2"
+    TestID   -> "InstallLocation-AugmentCode-Unix@@Tests/InstallMCPServer.wlt:2274,1-2279,2"
 ]
 
 (* Install location path must end with .augment/settings.json on all platforms *)
@@ -2175,7 +2287,7 @@ VerificationTest[
     ],
     { ".augment", "settings.json" },
     SameTest -> Equal,
-    TestID   -> "InstallLocation-AugmentCode-PathShape@@Tests/InstallMCPServer.wlt:2170,1-2179,2"
+    TestID   -> "InstallLocation-AugmentCode-PathShape@@Tests/InstallMCPServer.wlt:2282,1-2291,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2185,28 +2297,28 @@ VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "AugmentCode" ],
     "AugmentCode",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-AugmentCode@@Tests/InstallMCPServer.wlt:2184,1-2189,2"
+    TestID   -> "ToInstallName-AugmentCode@@Tests/InstallMCPServer.wlt:2296,1-2301,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Auggie" ],
     "AugmentCode",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-Auggie@@Tests/InstallMCPServer.wlt:2191,1-2196,2"
+    TestID   -> "ToInstallName-Auggie@@Tests/InstallMCPServer.wlt:2303,1-2308,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Augment" ],
     "AugmentCode",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-Augment@@Tests/InstallMCPServer.wlt:2198,1-2203,2"
+    TestID   -> "ToInstallName-Augment@@Tests/InstallMCPServer.wlt:2310,1-2315,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "AugmentCode" ],
     "Augment Code",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-AugmentCode@@Tests/InstallMCPServer.wlt:2205,1-2210,2"
+    TestID   -> "InstallDisplayName-AugmentCode@@Tests/InstallMCPServer.wlt:2317,1-2322,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2217,14 +2329,14 @@ VerificationTest[
     installResult = InstallMCPServer[ augmentConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "AugmentCode" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-AugmentCode-Basic@@Tests/InstallMCPServer.wlt:2215,1-2221,2"
+    TestID   -> "InstallMCPServer-AugmentCode-Basic@@Tests/InstallMCPServer.wlt:2327,1-2333,2"
 ]
 
 VerificationTest[
     FileExistsQ[ augmentConfigFile ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AugmentCode-FileExists@@Tests/InstallMCPServer.wlt:2223,1-2228,2"
+    TestID   -> "InstallMCPServer-AugmentCode-FileExists@@Tests/InstallMCPServer.wlt:2335,1-2340,2"
 ]
 
 VerificationTest[
@@ -2234,7 +2346,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AugmentCode-VerifyContent@@Tests/InstallMCPServer.wlt:2230,1-2238,2"
+    TestID   -> "InstallMCPServer-AugmentCode-VerifyContent@@Tests/InstallMCPServer.wlt:2342,1-2350,2"
 ]
 
 (* AugmentCode uses the standard mcpServers format: no Cline-style disabled/autoApprove fields
@@ -2250,14 +2362,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AugmentCode-StandardFormat@@Tests/InstallMCPServer.wlt:2242,1-2254,2"
+    TestID   -> "InstallMCPServer-AugmentCode-StandardFormat@@Tests/InstallMCPServer.wlt:2354,1-2366,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ augmentConfigFile, "WolframLanguage", "ApplicationName" -> "AugmentCode" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-AugmentCode-Basic@@Tests/InstallMCPServer.wlt:2256,1-2261,2"
+    TestID   -> "UninstallMCPServer-AugmentCode-Basic@@Tests/InstallMCPServer.wlt:2368,1-2373,2"
 ]
 
 VerificationTest[
@@ -2267,14 +2379,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-AugmentCode-VerifyRemoval@@Tests/InstallMCPServer.wlt:2263,1-2271,2"
+    TestID   -> "UninstallMCPServer-AugmentCode-VerifyRemoval@@Tests/InstallMCPServer.wlt:2375,1-2383,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ augmentConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-AugmentCode-Cleanup@@Tests/InstallMCPServer.wlt:2273,1-2278,2"
+    TestID   -> "InstallMCPServer-AugmentCode-Cleanup@@Tests/InstallMCPServer.wlt:2385,1-2390,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2297,7 +2409,7 @@ VerificationTest[
         "env" -> <| "KEY" -> "value" |>
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToAugmentCodeFormat-NonWindows@@Tests/InstallMCPServer.wlt:2285,1-2301,2"
+    TestID   -> "ConvertToAugmentCodeFormat-NonWindows@@Tests/InstallMCPServer.wlt:2397,1-2413,2"
 ]
 
 (* Non-Windows with a space-containing command: still unchanged *)
@@ -2308,7 +2420,7 @@ VerificationTest[
     ],
     <| "command" -> "/Applications/Wolfram Desktop.app/Contents/MacOS/wolfram" |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToAugmentCodeFormat-NonWindows-WithSpaces@@Tests/InstallMCPServer.wlt:2304,1-2312,2"
+    TestID   -> "ConvertToAugmentCodeFormat-NonWindows-WithSpaces@@Tests/InstallMCPServer.wlt:2416,1-2424,2"
 ]
 
 (* Windows with a space-free command: unchanged (no short-path lookup needed) *)
@@ -2325,7 +2437,7 @@ VerificationTest[
         "args" -> { "-run", "test" }
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToAugmentCodeFormat-Windows-NoSpaces@@Tests/InstallMCPServer.wlt:2315,1-2329,2"
+    TestID   -> "ConvertToAugmentCodeFormat-Windows-NoSpaces@@Tests/InstallMCPServer.wlt:2427,1-2441,2"
 ]
 
 (* Missing command: converter should not error *)
@@ -2336,7 +2448,7 @@ VerificationTest[
     ],
     <| "args" -> { "-run", "test" } |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToAugmentCodeFormat-MissingCommand@@Tests/InstallMCPServer.wlt:2332,1-2340,2"
+    TestID   -> "ConvertToAugmentCodeFormat-MissingCommand@@Tests/InstallMCPServer.wlt:2444,1-2452,2"
 ]
 
 (* Windows with a space-containing path to a non-existent file: falls back to the
@@ -2348,7 +2460,7 @@ VerificationTest[
     ],
     <| "command" -> "C:\\Does Not Exist\\wolfram.exe" |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToAugmentCodeFormat-Windows-NonExistentPath@@Tests/InstallMCPServer.wlt:2344,1-2352,2"
+    TestID   -> "ConvertToAugmentCodeFormat-Windows-NonExistentPath@@Tests/InstallMCPServer.wlt:2456,1-2464,2"
 ]
 
 (* 1-arg form dispatches to 2-arg form using $OperatingSystem *)
@@ -2358,7 +2470,7 @@ VerificationTest[
     |>,
     <| "command" -> "/no/spaces/here" |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToAugmentCodeFormat-OneArgForm@@Tests/InstallMCPServer.wlt:2355,1-2362,2"
+    TestID   -> "ConvertToAugmentCodeFormat-OneArgForm@@Tests/InstallMCPServer.wlt:2467,1-2474,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2372,21 +2484,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "AugmentCodeIDE", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-AugmentCodeIDE-Windows@@Tests/InstallMCPServer.wlt:2371,1-2376,2"
+    TestID   -> "InstallLocation-AugmentCodeIDE-Windows@@Tests/InstallMCPServer.wlt:2483,1-2488,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "AugmentCodeIDE", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-AugmentCodeIDE-MacOSX@@Tests/InstallMCPServer.wlt:2378,1-2383,2"
+    TestID   -> "InstallLocation-AugmentCodeIDE-MacOSX@@Tests/InstallMCPServer.wlt:2490,1-2495,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "AugmentCodeIDE", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-AugmentCodeIDE-Unix@@Tests/InstallMCPServer.wlt:2385,1-2390,2"
+    TestID   -> "InstallLocation-AugmentCodeIDE-Unix@@Tests/InstallMCPServer.wlt:2497,1-2502,2"
 ]
 
 (* Install location must end with augment.vscode-augment/augment-global-state/mcpServers.json on all platforms *)
@@ -2398,7 +2510,7 @@ VerificationTest[
     ],
     { "augment.vscode-augment", "augment-global-state", "mcpServers.json" },
     SameTest -> Equal,
-    TestID   -> "InstallLocation-AugmentCodeIDE-PathShape@@Tests/InstallMCPServer.wlt:2393,1-2402,2"
+    TestID   -> "InstallLocation-AugmentCodeIDE-PathShape@@Tests/InstallMCPServer.wlt:2505,1-2514,2"
 ]
 
 (* Install locations for AugmentCode (CLI) and AugmentCodeIDE must differ *)
@@ -2407,7 +2519,7 @@ VerificationTest[
         Wolfram`AgentTools`Common`installLocation[ "AugmentCodeIDE", $OperatingSystem ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallLocation-AugmentCode-vs-AugmentCodeIDE-Distinct@@Tests/InstallMCPServer.wlt:2405,1-2411,2"
+    TestID   -> "InstallLocation-AugmentCode-vs-AugmentCodeIDE-Distinct@@Tests/InstallMCPServer.wlt:2517,1-2523,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2417,28 +2529,28 @@ VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "AugmentCodeIDE" ],
     "AugmentCodeIDE",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-AugmentCodeIDE@@Tests/InstallMCPServer.wlt:2416,1-2421,2"
+    TestID   -> "ToInstallName-AugmentCodeIDE@@Tests/InstallMCPServer.wlt:2528,1-2533,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "AugmentIDE" ],
     "AugmentCodeIDE",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-AugmentIDE@@Tests/InstallMCPServer.wlt:2423,1-2428,2"
+    TestID   -> "ToInstallName-AugmentIDE@@Tests/InstallMCPServer.wlt:2535,1-2540,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "AuggieIDE" ],
     "AugmentCodeIDE",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-AuggieIDE@@Tests/InstallMCPServer.wlt:2430,1-2435,2"
+    TestID   -> "ToInstallName-AuggieIDE@@Tests/InstallMCPServer.wlt:2542,1-2547,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "AugmentCodeIDE" ],
     "Augment Code IDE",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-AugmentCodeIDE@@Tests/InstallMCPServer.wlt:2437,1-2442,2"
+    TestID   -> "InstallDisplayName-AugmentCodeIDE@@Tests/InstallMCPServer.wlt:2549,1-2554,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2449,14 +2561,14 @@ VerificationTest[
     installResult = InstallMCPServer[ augmentIDEConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "AugmentCodeIDE" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-AugmentCodeIDE-Basic@@Tests/InstallMCPServer.wlt:2447,1-2453,2"
+    TestID   -> "InstallMCPServer-AugmentCodeIDE-Basic@@Tests/InstallMCPServer.wlt:2559,1-2565,2"
 ]
 
 VerificationTest[
     FileExistsQ[ augmentIDEConfigFile ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AugmentCodeIDE-FileExists@@Tests/InstallMCPServer.wlt:2455,1-2460,2"
+    TestID   -> "InstallMCPServer-AugmentCodeIDE-FileExists@@Tests/InstallMCPServer.wlt:2567,1-2572,2"
 ]
 
 (* The file root is a JSON array, not an object *)
@@ -2467,7 +2579,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AugmentCodeIDE-RootIsArray@@Tests/InstallMCPServer.wlt:2463,1-2471,2"
+    TestID   -> "InstallMCPServer-AugmentCodeIDE-RootIsArray@@Tests/InstallMCPServer.wlt:2575,1-2583,2"
 ]
 
 (* Verify the Wolfram server entry is present with the required array-entry fields *)
@@ -2482,7 +2594,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AugmentCodeIDE-EntryShape@@Tests/InstallMCPServer.wlt:2474,1-2486,2"
+    TestID   -> "InstallMCPServer-AugmentCodeIDE-EntryShape@@Tests/InstallMCPServer.wlt:2586,1-2598,2"
 ]
 
 (* Installing the same server a second time should upsert (not duplicate) *)
@@ -2495,7 +2607,7 @@ VerificationTest[
     ],
     1,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AugmentCodeIDE-Idempotent@@Tests/InstallMCPServer.wlt:2489,1-2499,2"
+    TestID   -> "InstallMCPServer-AugmentCodeIDE-Idempotent@@Tests/InstallMCPServer.wlt:2601,1-2611,2"
 ]
 
 (* A second, differently-named server is appended (not replaced) *)
@@ -2508,14 +2620,14 @@ VerificationTest[
     ],
     { "Wolfram", "WolframAlphaExtra" },
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AugmentCodeIDE-MultiServer@@Tests/InstallMCPServer.wlt:2502,1-2512,2"
+    TestID   -> "InstallMCPServer-AugmentCodeIDE-MultiServer@@Tests/InstallMCPServer.wlt:2614,1-2624,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ augmentIDEConfigFile, "WolframLanguage", "ApplicationName" -> "AugmentCodeIDE" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-AugmentCodeIDE-Basic@@Tests/InstallMCPServer.wlt:2514,1-2519,2"
+    TestID   -> "UninstallMCPServer-AugmentCodeIDE-Basic@@Tests/InstallMCPServer.wlt:2626,1-2631,2"
 ]
 
 VerificationTest[
@@ -2526,7 +2638,7 @@ VerificationTest[
     ],
     0,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-AugmentCodeIDE-VerifyRemoval@@Tests/InstallMCPServer.wlt:2521,1-2530,2"
+    TestID   -> "UninstallMCPServer-AugmentCodeIDE-VerifyRemoval@@Tests/InstallMCPServer.wlt:2633,1-2642,2"
 ]
 
 (* Uninstalling the other entry as well leaves an empty array, not a removed file *)
@@ -2535,7 +2647,7 @@ VerificationTest[
     Import[ augmentIDEConfigFile, "RawJSON" ],
     { },
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-AugmentCodeIDE-EmptiesToArray@@Tests/InstallMCPServer.wlt:2533,1-2539,2"
+    TestID   -> "UninstallMCPServer-AugmentCodeIDE-EmptiesToArray@@Tests/InstallMCPServer.wlt:2645,1-2651,2"
 ]
 
 (* Uninstalling a server that isn't installed returns NotInstalled, not an error *)
@@ -2543,14 +2655,14 @@ VerificationTest[
     UninstallMCPServer[ augmentIDEConfigFile, "WolframLanguage", "ApplicationName" -> "AugmentCodeIDE" ],
     Missing[ "NotInstalled", _ ],
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-AugmentCodeIDE-NotInstalled@@Tests/InstallMCPServer.wlt:2542,1-2547,2"
+    TestID   -> "UninstallMCPServer-AugmentCodeIDE-NotInstalled@@Tests/InstallMCPServer.wlt:2654,1-2659,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ augmentIDEConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-AugmentCodeIDE-Cleanup@@Tests/InstallMCPServer.wlt:2549,1-2554,2"
+    TestID   -> "InstallMCPServer-AugmentCodeIDE-Cleanup@@Tests/InstallMCPServer.wlt:2661,1-2666,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2574,7 +2686,7 @@ VerificationTest[
         "env" -> <| "KEY" -> "value" |>
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToAugmentCodeIDEFormat-Basic@@Tests/InstallMCPServer.wlt:2561,1-2578,2"
+    TestID   -> "ConvertToAugmentCodeIDEFormat-Basic@@Tests/InstallMCPServer.wlt:2673,1-2690,2"
 ]
 
 (* Non-Windows with a space-containing path: does NOT apply short-path coercion *)
@@ -2588,7 +2700,7 @@ VerificationTest[
         "command" -> "/Applications/Wolfram Desktop.app/Contents/MacOS/wolfram"
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToAugmentCodeIDEFormat-NonWindows-WithSpaces@@Tests/InstallMCPServer.wlt:2581,1-2592,2"
+    TestID   -> "ConvertToAugmentCodeIDEFormat-NonWindows-WithSpaces@@Tests/InstallMCPServer.wlt:2693,1-2704,2"
 ]
 
 (* Windows with a space-free command: unchanged *)
@@ -2603,7 +2715,7 @@ VerificationTest[
         "args" -> { "-run" }
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToAugmentCodeIDEFormat-Windows-NoSpaces@@Tests/InstallMCPServer.wlt:2595,1-2607,2"
+    TestID   -> "ConvertToAugmentCodeIDEFormat-Windows-NoSpaces@@Tests/InstallMCPServer.wlt:2707,1-2719,2"
 ]
 
 (* Missing command: converter should not error, just omit "command" *)
@@ -2617,7 +2729,7 @@ VerificationTest[
         "args" -> { "-run" }
     |>,
     SameTest -> Equal,
-    TestID   -> "ConvertToAugmentCodeIDEFormat-MissingCommand@@Tests/InstallMCPServer.wlt:2610,1-2621,2"
+    TestID   -> "ConvertToAugmentCodeIDEFormat-MissingCommand@@Tests/InstallMCPServer.wlt:2722,1-2733,2"
 ]
 
 (* Converter does NOT set the "name" field - the install flow prepends it after conversion *)
@@ -2631,7 +2743,7 @@ VerificationTest[
     ],
     False,
     SameTest -> Equal,
-    TestID   -> "ConvertToAugmentCodeIDEFormat-NoNameField@@Tests/InstallMCPServer.wlt:2624,1-2635,2"
+    TestID   -> "ConvertToAugmentCodeIDEFormat-NoNameField@@Tests/InstallMCPServer.wlt:2736,1-2747,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2644,7 +2756,7 @@ VerificationTest[
         FileNameJoin @ { $TemporaryDirectory, "ide_noexist_" <> CreateUUID[] <> ".json" },
     { },
     SameTest -> Equal,
-    TestID   -> "ReadExistingAugmentCodeIDEConfig-NonExistent@@Tests/InstallMCPServer.wlt:2642,1-2648,2"
+    TestID   -> "ReadExistingAugmentCodeIDEConfig-NonExistent@@Tests/InstallMCPServer.wlt:2754,1-2760,2"
 ]
 
 (* Empty file returns empty list *)
@@ -2659,7 +2771,7 @@ VerificationTest[
     ],
     { },
     SameTest -> Equal,
-    TestID   -> "ReadExistingAugmentCodeIDEConfig-EmptyFile@@Tests/InstallMCPServer.wlt:2651,1-2663,2"
+    TestID   -> "ReadExistingAugmentCodeIDEConfig-EmptyFile@@Tests/InstallMCPServer.wlt:2763,1-2775,2"
 ]
 
 (* File with a valid array is returned as-is *)
@@ -2675,7 +2787,7 @@ VerificationTest[
     ],
     { <| "name" -> "X", "type" -> "stdio" |> },
     SameTest -> Equal,
-    TestID   -> "ReadExistingAugmentCodeIDEConfig-ValidArray@@Tests/InstallMCPServer.wlt:2666,1-2679,2"
+    TestID   -> "ReadExistingAugmentCodeIDEConfig-ValidArray@@Tests/InstallMCPServer.wlt:2778,1-2791,2"
 ]
 
 (* File with a non-list top level issues InvalidMCPConfiguration when installing.
@@ -2693,7 +2805,7 @@ VerificationTest[
     ],
     _Failure,
     SameTest -> MatchQ,
-    TestID   -> "ReadExistingAugmentCodeIDEConfig-NonListRoot@@Tests/InstallMCPServer.wlt:2684,1-2697,2"
+    TestID   -> "ReadExistingAugmentCodeIDEConfig-NonListRoot@@Tests/InstallMCPServer.wlt:2796,1-2809,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2720,7 +2832,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "GuessClientName-AugmentCodeIDE-PathMatch@@Tests/InstallMCPServer.wlt:2706,1-2724,2"
+    TestID   -> "GuessClientName-AugmentCodeIDE-PathMatch@@Tests/InstallMCPServer.wlt:2818,1-2836,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2730,21 +2842,21 @@ VerificationTest[
     $SupportedMCPClients[ "AugmentCodeIDE", "DisplayName" ],
     "Augment Code IDE",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeIDEDisplayName@@Tests/InstallMCPServer.wlt:2729,1-2734,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeIDEDisplayName@@Tests/InstallMCPServer.wlt:2841,1-2846,2"
 ]
 
 VerificationTest[
     Sort @ $SupportedMCPClients[ "AugmentCodeIDE", "Aliases" ],
     Sort @ { "AugmentIDE", "AuggieIDE" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeIDEAliases@@Tests/InstallMCPServer.wlt:2736,1-2741,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeIDEAliases@@Tests/InstallMCPServer.wlt:2848,1-2853,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "AugmentCodeIDE", "ConfigFormat" ],
     "JSON",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeIDEConfigFormat@@Tests/InstallMCPServer.wlt:2743,1-2748,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeIDEConfigFormat@@Tests/InstallMCPServer.wlt:2855,1-2860,2"
 ]
 
 (* Empty ConfigKey signals the root of the file is an array, not a keyed object *)
@@ -2752,21 +2864,21 @@ VerificationTest[
     $SupportedMCPClients[ "AugmentCodeIDE", "ConfigKey" ],
     { },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeIDEConfigKey@@Tests/InstallMCPServer.wlt:2751,1-2756,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeIDEConfigKey@@Tests/InstallMCPServer.wlt:2863,1-2868,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "AugmentCodeIDE", "ProjectSupport" ],
     False,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeIDEProjectSupport@@Tests/InstallMCPServer.wlt:2758,1-2763,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeIDEProjectSupport@@Tests/InstallMCPServer.wlt:2870,1-2875,2"
 ]
 
 VerificationTest[
     StringStartsQ[ $SupportedMCPClients[ "AugmentCodeIDE", "URL" ], "https://" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeIDEURL@@Tests/InstallMCPServer.wlt:2765,1-2770,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeIDEURL@@Tests/InstallMCPServer.wlt:2877,1-2882,2"
 ]
 
 (* AugmentCode (CLI) and AugmentCodeIDE (VS Code) must be distinct entries with distinct display names *)
@@ -2775,7 +2887,7 @@ VerificationTest[
         $SupportedMCPClients[ "AugmentCodeIDE", "DisplayName" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCode-vs-AugmentCodeIDE-Distinct@@Tests/InstallMCPServer.wlt:2773,1-2779,2"
+    TestID   -> "SupportedMCPClients-AugmentCode-vs-AugmentCodeIDE-Distinct@@Tests/InstallMCPServer.wlt:2885,1-2891,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2789,7 +2901,7 @@ VerificationTest[
     ],
     _String? (! StringContainsQ[ #, "~" ] &),
     SameTest -> MatchQ,
-    TestID   -> "ToWindowsShortPath-NonExistent@@Tests/InstallMCPServer.wlt:2786,1-2793,2"
+    TestID   -> "ToWindowsShortPath-NonExistent@@Tests/InstallMCPServer.wlt:2898,1-2905,2"
 ]
 
 (* Space-free existing path on Windows: result equals the input (no short form needed).
@@ -2800,7 +2912,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "ToWindowsShortPath-ReturnsString@@Tests/InstallMCPServer.wlt:2797,1-2804,2"
+    TestID   -> "ToWindowsShortPath-ReturnsString@@Tests/InstallMCPServer.wlt:2909,1-2916,2"
 ]
 
 (* Windows-only: the wolfram.exe short path should not contain spaces when the
@@ -2815,7 +2927,7 @@ If[ $OperatingSystem === "Windows",
         ],
         True,
         SameTest -> Equal,
-        TestID   -> "ToWindowsShortPath-WolframExe@@Tests/InstallMCPServer.wlt:2809,5-2819,6"
+        TestID   -> "ToWindowsShortPath-WolframExe@@Tests/InstallMCPServer.wlt:2921,5-2931,6"
     ]
 ]
 
@@ -2826,42 +2938,42 @@ VerificationTest[
     $SupportedMCPClients[ "AugmentCode", "DisplayName" ],
     "Augment Code",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeDisplayName@@Tests/InstallMCPServer.wlt:2825,1-2830,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeDisplayName@@Tests/InstallMCPServer.wlt:2937,1-2942,2"
 ]
 
 VerificationTest[
     Sort @ $SupportedMCPClients[ "AugmentCode", "Aliases" ],
     Sort @ { "Auggie", "Augment" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeAliases@@Tests/InstallMCPServer.wlt:2832,1-2837,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeAliases@@Tests/InstallMCPServer.wlt:2944,1-2949,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "AugmentCode", "ConfigFormat" ],
     "JSON",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeConfigFormat@@Tests/InstallMCPServer.wlt:2839,1-2844,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeConfigFormat@@Tests/InstallMCPServer.wlt:2951,1-2956,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "AugmentCode", "ConfigKey" ],
     { "mcpServers" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeConfigKey@@Tests/InstallMCPServer.wlt:2846,1-2851,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeConfigKey@@Tests/InstallMCPServer.wlt:2958,1-2963,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "AugmentCode", "ProjectSupport" ],
     False,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeProjectSupport@@Tests/InstallMCPServer.wlt:2853,1-2858,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeProjectSupport@@Tests/InstallMCPServer.wlt:2965,1-2970,2"
 ]
 
 VerificationTest[
     StringStartsQ[ $SupportedMCPClients[ "AugmentCode", "URL" ], "https://" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AugmentCodeURL@@Tests/InstallMCPServer.wlt:2860,1-2865,2"
+    TestID   -> "SupportedMCPClients-AugmentCodeURL@@Tests/InstallMCPServer.wlt:2972,1-2977,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2875,21 +2987,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Zed", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Zed-Windows@@Tests/InstallMCPServer.wlt:2874,1-2879,2"
+    TestID   -> "InstallLocation-Zed-Windows@@Tests/InstallMCPServer.wlt:2986,1-2991,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Zed", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Zed-MacOSX@@Tests/InstallMCPServer.wlt:2881,1-2886,2"
+    TestID   -> "InstallLocation-Zed-MacOSX@@Tests/InstallMCPServer.wlt:2993,1-2998,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Zed", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Zed-Unix@@Tests/InstallMCPServer.wlt:2888,1-2893,2"
+    TestID   -> "InstallLocation-Zed-Unix@@Tests/InstallMCPServer.wlt:3000,1-3005,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2899,14 +3011,14 @@ VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Zed" ],
     "Zed",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-Zed@@Tests/InstallMCPServer.wlt:2898,1-2903,2"
+    TestID   -> "ToInstallName-Zed@@Tests/InstallMCPServer.wlt:3010,1-3015,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "Zed" ],
     "Zed",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-Zed@@Tests/InstallMCPServer.wlt:2905,1-2910,2"
+    TestID   -> "InstallDisplayName-Zed@@Tests/InstallMCPServer.wlt:3017,1-3022,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2920,7 +3032,7 @@ VerificationTest[
     ],
     FileNameJoin @ { ".zed", "settings.json" },
     SameTest -> Equal,
-    TestID   -> "ProjectInstallLocation-Zed@@Tests/InstallMCPServer.wlt:2915,1-2924,2"
+    TestID   -> "ProjectInstallLocation-Zed@@Tests/InstallMCPServer.wlt:3027,1-3036,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2931,14 +3043,14 @@ VerificationTest[
     installResult = InstallMCPServer[ zedConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "Zed" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Zed-Basic@@Tests/InstallMCPServer.wlt:2929,1-2935,2"
+    TestID   -> "InstallMCPServer-Zed-Basic@@Tests/InstallMCPServer.wlt:3041,1-3047,2"
 ]
 
 VerificationTest[
     FileExistsQ[ zedConfigFile ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Zed-FileExists@@Tests/InstallMCPServer.wlt:2937,1-2942,2"
+    TestID   -> "InstallMCPServer-Zed-FileExists@@Tests/InstallMCPServer.wlt:3049,1-3054,2"
 ]
 
 VerificationTest[
@@ -2948,7 +3060,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Zed-VerifyContent@@Tests/InstallMCPServer.wlt:2944,1-2952,2"
+    TestID   -> "InstallMCPServer-Zed-VerifyContent@@Tests/InstallMCPServer.wlt:3056,1-3064,2"
 ]
 
 VerificationTest[
@@ -2959,14 +3071,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Zed-VerifyServerFields@@Tests/InstallMCPServer.wlt:2954,1-2963,2"
+    TestID   -> "InstallMCPServer-Zed-VerifyServerFields@@Tests/InstallMCPServer.wlt:3066,1-3075,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ zedConfigFile, "WolframLanguage", "ApplicationName" -> "Zed" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Zed-Basic@@Tests/InstallMCPServer.wlt:2965,1-2970,2"
+    TestID   -> "UninstallMCPServer-Zed-Basic@@Tests/InstallMCPServer.wlt:3077,1-3082,2"
 ]
 
 VerificationTest[
@@ -2976,14 +3088,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-Zed-VerifyRemoval@@Tests/InstallMCPServer.wlt:2972,1-2980,2"
+    TestID   -> "UninstallMCPServer-Zed-VerifyRemoval@@Tests/InstallMCPServer.wlt:3084,1-3092,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ zedConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Zed-Cleanup@@Tests/InstallMCPServer.wlt:2982,1-2987,2"
+    TestID   -> "InstallMCPServer-Zed-Cleanup@@Tests/InstallMCPServer.wlt:3094,1-3099,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -2995,7 +3107,7 @@ VerificationTest[
     installResult = InstallMCPServer[ zedConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "Zed" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Zed-PreserveExisting@@Tests/InstallMCPServer.wlt:2992,1-2999,2"
+    TestID   -> "InstallMCPServer-Zed-PreserveExisting@@Tests/InstallMCPServer.wlt:3104,1-3111,2"
 ]
 
 VerificationTest[
@@ -3006,14 +3118,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Zed-VerifyPreserved@@Tests/InstallMCPServer.wlt:3001,1-3010,2"
+    TestID   -> "InstallMCPServer-Zed-VerifyPreserved@@Tests/InstallMCPServer.wlt:3113,1-3122,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ zedConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Zed-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:3012,1-3017,2"
+    TestID   -> "InstallMCPServer-Zed-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:3124,1-3129,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3027,21 +3139,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Junie", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Junie-Windows@@Tests/InstallMCPServer.wlt:3026,1-3031,2"
+    TestID   -> "InstallLocation-Junie-Windows@@Tests/InstallMCPServer.wlt:3138,1-3143,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Junie", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Junie-MacOSX@@Tests/InstallMCPServer.wlt:3033,1-3038,2"
+    TestID   -> "InstallLocation-Junie-MacOSX@@Tests/InstallMCPServer.wlt:3145,1-3150,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Junie", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Junie-Unix@@Tests/InstallMCPServer.wlt:3040,1-3045,2"
+    TestID   -> "InstallLocation-Junie-Unix@@Tests/InstallMCPServer.wlt:3152,1-3157,2"
 ]
 
 (* Junie's user-scope path is .junie/mcp/mcp.json under $HomeDirectory on every OS *)
@@ -3053,7 +3165,7 @@ VerificationTest[
     ],
     { ".junie", "mcp", "mcp.json" },
     SameTest -> Equal,
-    TestID   -> "InstallLocation-Junie-PathShape@@Tests/InstallMCPServer.wlt:3048,1-3057,2"
+    TestID   -> "InstallLocation-Junie-PathShape@@Tests/InstallMCPServer.wlt:3160,1-3169,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3063,21 +3175,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Junie" ],
     "Junie",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-Junie@@Tests/InstallMCPServer.wlt:3062,1-3067,2"
+    TestID   -> "ToInstallName-Junie@@Tests/InstallMCPServer.wlt:3174,1-3179,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "JetBrainsJunie" ],
     "Junie",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-JetBrainsJunie@@Tests/InstallMCPServer.wlt:3069,1-3074,2"
+    TestID   -> "ToInstallName-JetBrainsJunie@@Tests/InstallMCPServer.wlt:3181,1-3186,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "Junie" ],
     "Junie",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-Junie@@Tests/InstallMCPServer.wlt:3076,1-3081,2"
+    TestID   -> "InstallDisplayName-Junie@@Tests/InstallMCPServer.wlt:3188,1-3193,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3088,14 +3200,14 @@ VerificationTest[
     installResult = InstallMCPServer[ junieConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "Junie" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Junie-Basic@@Tests/InstallMCPServer.wlt:3086,1-3092,2"
+    TestID   -> "InstallMCPServer-Junie-Basic@@Tests/InstallMCPServer.wlt:3198,1-3204,2"
 ]
 
 VerificationTest[
     FileExistsQ[ junieConfigFile ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Junie-FileExists@@Tests/InstallMCPServer.wlt:3094,1-3099,2"
+    TestID   -> "InstallMCPServer-Junie-FileExists@@Tests/InstallMCPServer.wlt:3206,1-3211,2"
 ]
 
 VerificationTest[
@@ -3105,7 +3217,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Junie-VerifyContent@@Tests/InstallMCPServer.wlt:3101,1-3109,2"
+    TestID   -> "InstallMCPServer-Junie-VerifyContent@@Tests/InstallMCPServer.wlt:3213,1-3221,2"
 ]
 
 (* Junie uses the standard mcpServers format: no Cline-style disabled/autoApprove fields,
@@ -3122,14 +3234,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Junie-StandardFormat@@Tests/InstallMCPServer.wlt:3113,1-3126,2"
+    TestID   -> "InstallMCPServer-Junie-StandardFormat@@Tests/InstallMCPServer.wlt:3225,1-3238,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ junieConfigFile, "WolframLanguage", "ApplicationName" -> "Junie" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Junie-Basic@@Tests/InstallMCPServer.wlt:3128,1-3133,2"
+    TestID   -> "UninstallMCPServer-Junie-Basic@@Tests/InstallMCPServer.wlt:3240,1-3245,2"
 ]
 
 VerificationTest[
@@ -3139,14 +3251,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-Junie-VerifyRemoval@@Tests/InstallMCPServer.wlt:3135,1-3143,2"
+    TestID   -> "UninstallMCPServer-Junie-VerifyRemoval@@Tests/InstallMCPServer.wlt:3247,1-3255,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ junieConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Junie-Cleanup@@Tests/InstallMCPServer.wlt:3145,1-3150,2"
+    TestID   -> "InstallMCPServer-Junie-Cleanup@@Tests/InstallMCPServer.wlt:3257,1-3262,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3165,7 +3277,7 @@ VerificationTest[
     ],
     { True, True },
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Junie-ProjectLevel@@Tests/InstallMCPServer.wlt:3155,1-3169,2"
+    TestID   -> "InstallMCPServer-Junie-ProjectLevel@@Tests/InstallMCPServer.wlt:3267,1-3281,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3189,7 +3301,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "GuessClientName-Junie-PathMatch@@Tests/InstallMCPServer.wlt:3177,1-3193,2"
+    TestID   -> "GuessClientName-Junie-PathMatch@@Tests/InstallMCPServer.wlt:3289,1-3305,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3199,42 +3311,42 @@ VerificationTest[
     $SupportedMCPClients[ "Junie", "DisplayName" ],
     "Junie",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-JunieDisplayName@@Tests/InstallMCPServer.wlt:3198,1-3203,2"
+    TestID   -> "SupportedMCPClients-JunieDisplayName@@Tests/InstallMCPServer.wlt:3310,1-3315,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Junie", "Aliases" ],
     { "JetBrainsJunie" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-JunieAliases@@Tests/InstallMCPServer.wlt:3205,1-3210,2"
+    TestID   -> "SupportedMCPClients-JunieAliases@@Tests/InstallMCPServer.wlt:3317,1-3322,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Junie", "ConfigFormat" ],
     "JSON",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-JunieConfigFormat@@Tests/InstallMCPServer.wlt:3212,1-3217,2"
+    TestID   -> "SupportedMCPClients-JunieConfigFormat@@Tests/InstallMCPServer.wlt:3324,1-3329,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Junie", "ConfigKey" ],
     { "mcpServers" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-JunieConfigKey@@Tests/InstallMCPServer.wlt:3219,1-3224,2"
+    TestID   -> "SupportedMCPClients-JunieConfigKey@@Tests/InstallMCPServer.wlt:3331,1-3336,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Junie", "ProjectSupport" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-JunieProjectSupport@@Tests/InstallMCPServer.wlt:3226,1-3231,2"
+    TestID   -> "SupportedMCPClients-JunieProjectSupport@@Tests/InstallMCPServer.wlt:3338,1-3343,2"
 ]
 
 VerificationTest[
     StringStartsQ[ $SupportedMCPClients[ "Junie", "URL" ], "https://" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-JunieURL@@Tests/InstallMCPServer.wlt:3233,1-3238,2"
+    TestID   -> "SupportedMCPClients-JunieURL@@Tests/InstallMCPServer.wlt:3345,1-3350,2"
 ]
 
 (* Junie is a coding agent - default toolset is WolframLanguage (matches Cursor, ClaudeCode, etc.) *)
@@ -3242,7 +3354,7 @@ VerificationTest[
     $SupportedMCPClients[ "Junie", "DefaultToolset" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-JunieDefaultToolset@@Tests/InstallMCPServer.wlt:3241,1-3246,2"
+    TestID   -> "SupportedMCPClients-JunieDefaultToolset@@Tests/InstallMCPServer.wlt:3353,1-3358,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3260,7 +3372,7 @@ VerificationTest[
     ],
     "KimiCode",
     SameTest -> Equal,
-    TestID   -> "GuessClientName-KimiCode-Direct@@Tests/InstallMCPServer.wlt:3257,1-3264,2"
+    TestID   -> "GuessClientName-KimiCode-Direct@@Tests/InstallMCPServer.wlt:3369,1-3376,2"
 ]
 
 (* File at .kimi/mcp.json under any directory should be detected as Kimi Code when
@@ -3279,7 +3391,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "GuessClientName-KimiCode-PathMatch@@Tests/InstallMCPServer.wlt:3268,1-3283,2"
+    TestID   -> "GuessClientName-KimiCode-PathMatch@@Tests/InstallMCPServer.wlt:3380,1-3395,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3294,35 +3406,35 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Kiro", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Kiro-Windows@@Tests/InstallMCPServer.wlt:3293,1-3298,2"
+    TestID   -> "InstallLocation-Kiro-Windows@@Tests/InstallMCPServer.wlt:3405,1-3410,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Kiro", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Kiro-MacOSX@@Tests/InstallMCPServer.wlt:3300,1-3305,2"
+    TestID   -> "InstallLocation-Kiro-MacOSX@@Tests/InstallMCPServer.wlt:3412,1-3417,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "Kiro", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-Kiro-Unix@@Tests/InstallMCPServer.wlt:3307,1-3312,2"
+    TestID   -> "InstallLocation-Kiro-Unix@@Tests/InstallMCPServer.wlt:3419,1-3424,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "Kiro" ],
     "Kiro",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-Kiro@@Tests/InstallMCPServer.wlt:3314,1-3319,2"
+    TestID   -> "InstallDisplayName-Kiro@@Tests/InstallMCPServer.wlt:3426,1-3431,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Kiro" ],
     "Kiro",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-Kiro@@Tests/InstallMCPServer.wlt:3321,1-3326,2"
+    TestID   -> "ToInstallName-Kiro@@Tests/InstallMCPServer.wlt:3433,1-3438,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3336,7 +3448,7 @@ VerificationTest[
     ],
     FileNameJoin @ { ".kiro", "settings", "mcp.json" },
     SameTest -> Equal,
-    TestID   -> "ProjectInstallLocation-Kiro@@Tests/InstallMCPServer.wlt:3331,1-3340,2"
+    TestID   -> "ProjectInstallLocation-Kiro@@Tests/InstallMCPServer.wlt:3443,1-3452,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3347,14 +3459,14 @@ VerificationTest[
     installResult = InstallMCPServer[ kiroConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "Kiro" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Kiro-Basic@@Tests/InstallMCPServer.wlt:3345,1-3351,2"
+    TestID   -> "InstallMCPServer-Kiro-Basic@@Tests/InstallMCPServer.wlt:3457,1-3463,2"
 ]
 
 VerificationTest[
     FileExistsQ[ kiroConfigFile ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Kiro-FileExists@@Tests/InstallMCPServer.wlt:3353,1-3358,2"
+    TestID   -> "InstallMCPServer-Kiro-FileExists@@Tests/InstallMCPServer.wlt:3465,1-3470,2"
 ]
 
 VerificationTest[
@@ -3364,7 +3476,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Kiro-VerifyContent@@Tests/InstallMCPServer.wlt:3360,1-3368,2"
+    TestID   -> "InstallMCPServer-Kiro-VerifyContent@@Tests/InstallMCPServer.wlt:3472,1-3480,2"
 ]
 
 VerificationTest[
@@ -3376,14 +3488,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Kiro-VerifyKiroFields@@Tests/InstallMCPServer.wlt:3370,1-3380,2"
+    TestID   -> "InstallMCPServer-Kiro-VerifyKiroFields@@Tests/InstallMCPServer.wlt:3482,1-3492,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ kiroConfigFile, "WolframLanguage", "ApplicationName" -> "Kiro" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-Kiro-Basic@@Tests/InstallMCPServer.wlt:3382,1-3387,2"
+    TestID   -> "UninstallMCPServer-Kiro-Basic@@Tests/InstallMCPServer.wlt:3494,1-3499,2"
 ]
 
 VerificationTest[
@@ -3393,14 +3505,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-Kiro-VerifyRemoval@@Tests/InstallMCPServer.wlt:3389,1-3397,2"
+    TestID   -> "UninstallMCPServer-Kiro-VerifyRemoval@@Tests/InstallMCPServer.wlt:3501,1-3509,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ kiroConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Kiro-Cleanup@@Tests/InstallMCPServer.wlt:3399,1-3404,2"
+    TestID   -> "InstallMCPServer-Kiro-Cleanup@@Tests/InstallMCPServer.wlt:3511,1-3516,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3412,7 +3524,7 @@ VerificationTest[
     installResult = InstallMCPServer[ kiroConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "Kiro" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Kiro-PreserveExisting@@Tests/InstallMCPServer.wlt:3409,1-3416,2"
+    TestID   -> "InstallMCPServer-Kiro-PreserveExisting@@Tests/InstallMCPServer.wlt:3521,1-3528,2"
 ]
 
 VerificationTest[
@@ -3423,14 +3535,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Kiro-VerifyPreserved@@Tests/InstallMCPServer.wlt:3418,1-3427,2"
+    TestID   -> "InstallMCPServer-Kiro-VerifyPreserved@@Tests/InstallMCPServer.wlt:3530,1-3539,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ kiroConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-Kiro-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:3429,1-3434,2"
+    TestID   -> "InstallMCPServer-Kiro-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:3541,1-3546,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3444,21 +3556,21 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "LMStudio", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-LMStudio-Windows@@Tests/InstallMCPServer.wlt:3443,1-3448,2"
+    TestID   -> "InstallLocation-LMStudio-Windows@@Tests/InstallMCPServer.wlt:3555,1-3560,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "LMStudio", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-LMStudio-MacOSX@@Tests/InstallMCPServer.wlt:3450,1-3455,2"
+    TestID   -> "InstallLocation-LMStudio-MacOSX@@Tests/InstallMCPServer.wlt:3562,1-3567,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "LMStudio", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-LMStudio-Unix@@Tests/InstallMCPServer.wlt:3457,1-3462,2"
+    TestID   -> "InstallLocation-LMStudio-Unix@@Tests/InstallMCPServer.wlt:3569,1-3574,2"
 ]
 
 (* LM Studio's path is .lmstudio/mcp.json under $HomeDirectory on every OS *)
@@ -3470,7 +3582,7 @@ VerificationTest[
     ],
     { ".lmstudio", "mcp.json" },
     SameTest -> Equal,
-    TestID   -> "InstallLocation-LMStudio-PathShape@@Tests/InstallMCPServer.wlt:3465,1-3474,2"
+    TestID   -> "InstallLocation-LMStudio-PathShape@@Tests/InstallMCPServer.wlt:3577,1-3586,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3480,14 +3592,14 @@ VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "LMStudio" ],
     "LMStudio",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-LMStudio@@Tests/InstallMCPServer.wlt:3479,1-3484,2"
+    TestID   -> "ToInstallName-LMStudio@@Tests/InstallMCPServer.wlt:3591,1-3596,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "LMStudio" ],
     "LM Studio",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-LMStudio@@Tests/InstallMCPServer.wlt:3486,1-3491,2"
+    TestID   -> "InstallDisplayName-LMStudio@@Tests/InstallMCPServer.wlt:3598,1-3603,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3498,14 +3610,14 @@ VerificationTest[
     installResult = InstallMCPServer[ lmStudioConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "LMStudio" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-LMStudio-Basic@@Tests/InstallMCPServer.wlt:3496,1-3502,2"
+    TestID   -> "InstallMCPServer-LMStudio-Basic@@Tests/InstallMCPServer.wlt:3608,1-3614,2"
 ]
 
 VerificationTest[
     FileExistsQ[ lmStudioConfigFile ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-LMStudio-FileExists@@Tests/InstallMCPServer.wlt:3504,1-3509,2"
+    TestID   -> "InstallMCPServer-LMStudio-FileExists@@Tests/InstallMCPServer.wlt:3616,1-3621,2"
 ]
 
 VerificationTest[
@@ -3515,7 +3627,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-LMStudio-VerifyContent@@Tests/InstallMCPServer.wlt:3511,1-3519,2"
+    TestID   -> "InstallMCPServer-LMStudio-VerifyContent@@Tests/InstallMCPServer.wlt:3623,1-3631,2"
 ]
 
 (* LM Studio uses the standard mcpServers format (Cursor notation): no Cline-style
@@ -3532,14 +3644,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-LMStudio-StandardFormat@@Tests/InstallMCPServer.wlt:3523,1-3536,2"
+    TestID   -> "InstallMCPServer-LMStudio-StandardFormat@@Tests/InstallMCPServer.wlt:3635,1-3648,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ lmStudioConfigFile, "WolframLanguage", "ApplicationName" -> "LMStudio" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-LMStudio-Basic@@Tests/InstallMCPServer.wlt:3538,1-3543,2"
+    TestID   -> "UninstallMCPServer-LMStudio-Basic@@Tests/InstallMCPServer.wlt:3650,1-3655,2"
 ]
 
 VerificationTest[
@@ -3549,14 +3661,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-LMStudio-VerifyRemoval@@Tests/InstallMCPServer.wlt:3545,1-3553,2"
+    TestID   -> "UninstallMCPServer-LMStudio-VerifyRemoval@@Tests/InstallMCPServer.wlt:3657,1-3665,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ lmStudioConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-LMStudio-Cleanup@@Tests/InstallMCPServer.wlt:3555,1-3560,2"
+    TestID   -> "InstallMCPServer-LMStudio-Cleanup@@Tests/InstallMCPServer.wlt:3667,1-3672,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3575,14 +3687,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-LMStudio-PreserveExisting@@Tests/InstallMCPServer.wlt:3567,1-3579,2"
+    TestID   -> "InstallMCPServer-LMStudio-PreserveExisting@@Tests/InstallMCPServer.wlt:3679,1-3691,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ lmStudioPreserveFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-LMStudio-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:3581,1-3586,2"
+    TestID   -> "InstallMCPServer-LMStudio-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:3693,1-3698,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3604,7 +3716,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "GuessClientName-LMStudio-PathMatch@@Tests/InstallMCPServer.wlt:3593,1-3608,2"
+    TestID   -> "GuessClientName-LMStudio-PathMatch@@Tests/InstallMCPServer.wlt:3705,1-3720,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3614,28 +3726,28 @@ VerificationTest[
     $SupportedMCPClients[ "LMStudio", "DisplayName" ],
     "LM Studio",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-LMStudioDisplayName@@Tests/InstallMCPServer.wlt:3613,1-3618,2"
+    TestID   -> "SupportedMCPClients-LMStudioDisplayName@@Tests/InstallMCPServer.wlt:3725,1-3730,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "LMStudio", "ConfigFormat" ],
     "JSON",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-LMStudioConfigFormat@@Tests/InstallMCPServer.wlt:3620,1-3625,2"
+    TestID   -> "SupportedMCPClients-LMStudioConfigFormat@@Tests/InstallMCPServer.wlt:3732,1-3737,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "LMStudio", "ConfigKey" ],
     { "mcpServers" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-LMStudioConfigKey@@Tests/InstallMCPServer.wlt:3627,1-3632,2"
+    TestID   -> "SupportedMCPClients-LMStudioConfigKey@@Tests/InstallMCPServer.wlt:3739,1-3744,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "LMStudio", "ProjectSupport" ],
     False,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-LMStudioProjectSupport@@Tests/InstallMCPServer.wlt:3634,1-3639,2"
+    TestID   -> "SupportedMCPClients-LMStudioProjectSupport@@Tests/InstallMCPServer.wlt:3746,1-3751,2"
 ]
 
 (* LM Studio is a chat-first client, so its default toolset is "Wolfram" (like Claude Desktop / Goose) *)
@@ -3643,14 +3755,14 @@ VerificationTest[
     $SupportedMCPClients[ "LMStudio", "DefaultToolset" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-LMStudioDefaultToolset@@Tests/InstallMCPServer.wlt:3642,1-3647,2"
+    TestID   -> "SupportedMCPClients-LMStudioDefaultToolset@@Tests/InstallMCPServer.wlt:3754,1-3759,2"
 ]
 
 VerificationTest[
     StringStartsQ[ $SupportedMCPClients[ "LMStudio", "URL" ], "https://" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-LMStudioURL@@Tests/InstallMCPServer.wlt:3649,1-3654,2"
+    TestID   -> "SupportedMCPClients-LMStudioURL@@Tests/InstallMCPServer.wlt:3761,1-3766,2"
 ]
 
 (* Confirm the chat-client default flows through defaultToolsetForTarget *)
@@ -3658,7 +3770,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`defaultToolsetForTarget[ "LMStudio" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-LMStudio@@Tests/InstallMCPServer.wlt:3657,1-3662,2"
+    TestID   -> "DefaultToolsetForTarget-LMStudio@@Tests/InstallMCPServer.wlt:3769,1-3774,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3673,56 +3785,56 @@ VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "AmazonQ", "Windows" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-AmazonQ-Windows@@Tests/InstallMCPServer.wlt:3672,1-3677,2"
+    TestID   -> "InstallLocation-AmazonQ-Windows@@Tests/InstallMCPServer.wlt:3784,1-3789,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "AmazonQ", "MacOSX" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-AmazonQ-MacOSX@@Tests/InstallMCPServer.wlt:3679,1-3684,2"
+    TestID   -> "InstallLocation-AmazonQ-MacOSX@@Tests/InstallMCPServer.wlt:3791,1-3796,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`installLocation[ "AmazonQ", "Unix" ],
     _File,
     SameTest -> MatchQ,
-    TestID   -> "InstallLocation-AmazonQ-Unix@@Tests/InstallMCPServer.wlt:3686,1-3691,2"
+    TestID   -> "InstallLocation-AmazonQ-Unix@@Tests/InstallMCPServer.wlt:3798,1-3803,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`installDisplayName[ "AmazonQ" ],
     "Amazon Q Developer",
     SameTest -> Equal,
-    TestID   -> "InstallDisplayName-AmazonQ@@Tests/InstallMCPServer.wlt:3693,1-3698,2"
+    TestID   -> "InstallDisplayName-AmazonQ@@Tests/InstallMCPServer.wlt:3805,1-3810,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "AmazonQ" ],
     "AmazonQ",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-AmazonQ@@Tests/InstallMCPServer.wlt:3700,1-3705,2"
+    TestID   -> "ToInstallName-AmazonQ@@Tests/InstallMCPServer.wlt:3812,1-3817,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "AmazonQDeveloper" ],
     "AmazonQ",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-AmazonQ-Alias-AmazonQDeveloper@@Tests/InstallMCPServer.wlt:3707,1-3712,2"
+    TestID   -> "ToInstallName-AmazonQ-Alias-AmazonQDeveloper@@Tests/InstallMCPServer.wlt:3819,1-3824,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "Q" ],
     "AmazonQ",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-AmazonQ-Alias-Q@@Tests/InstallMCPServer.wlt:3714,1-3719,2"
+    TestID   -> "ToInstallName-AmazonQ-Alias-Q@@Tests/InstallMCPServer.wlt:3826,1-3831,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`Common`toInstallName[ "QDeveloper" ],
     "AmazonQ",
     SameTest -> Equal,
-    TestID   -> "ToInstallName-AmazonQ-Alias-QDeveloper@@Tests/InstallMCPServer.wlt:3721,1-3726,2"
+    TestID   -> "ToInstallName-AmazonQ-Alias-QDeveloper@@Tests/InstallMCPServer.wlt:3833,1-3838,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3736,7 +3848,7 @@ VerificationTest[
     ],
     FileNameJoin @ { ".amazonq", "mcp.json" },
     SameTest -> Equal,
-    TestID   -> "ProjectInstallLocation-AmazonQ@@Tests/InstallMCPServer.wlt:3731,1-3740,2"
+    TestID   -> "ProjectInstallLocation-AmazonQ@@Tests/InstallMCPServer.wlt:3843,1-3852,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3747,14 +3859,14 @@ VerificationTest[
     installResult = InstallMCPServer[ amazonQConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "AmazonQ" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-AmazonQ-Basic@@Tests/InstallMCPServer.wlt:3745,1-3751,2"
+    TestID   -> "InstallMCPServer-AmazonQ-Basic@@Tests/InstallMCPServer.wlt:3857,1-3863,2"
 ]
 
 VerificationTest[
     FileExistsQ[ amazonQConfigFile ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AmazonQ-FileExists@@Tests/InstallMCPServer.wlt:3753,1-3758,2"
+    TestID   -> "InstallMCPServer-AmazonQ-FileExists@@Tests/InstallMCPServer.wlt:3865,1-3870,2"
 ]
 
 VerificationTest[
@@ -3764,7 +3876,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AmazonQ-VerifyContent@@Tests/InstallMCPServer.wlt:3760,1-3768,2"
+    TestID   -> "InstallMCPServer-AmazonQ-VerifyContent@@Tests/InstallMCPServer.wlt:3872,1-3880,2"
 ]
 
 VerificationTest[
@@ -3777,14 +3889,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AmazonQ-VerifyFields@@Tests/InstallMCPServer.wlt:3770,1-3781,2"
+    TestID   -> "InstallMCPServer-AmazonQ-VerifyFields@@Tests/InstallMCPServer.wlt:3882,1-3893,2"
 ]
 
 VerificationTest[
     uninstallResult = UninstallMCPServer[ amazonQConfigFile, "WolframLanguage", "ApplicationName" -> "AmazonQ" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "UninstallMCPServer-AmazonQ-Basic@@Tests/InstallMCPServer.wlt:3783,1-3788,2"
+    TestID   -> "UninstallMCPServer-AmazonQ-Basic@@Tests/InstallMCPServer.wlt:3895,1-3900,2"
 ]
 
 VerificationTest[
@@ -3794,14 +3906,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "UninstallMCPServer-AmazonQ-VerifyRemoval@@Tests/InstallMCPServer.wlt:3790,1-3798,2"
+    TestID   -> "UninstallMCPServer-AmazonQ-VerifyRemoval@@Tests/InstallMCPServer.wlt:3902,1-3910,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ amazonQConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-AmazonQ-Cleanup@@Tests/InstallMCPServer.wlt:3800,1-3805,2"
+    TestID   -> "InstallMCPServer-AmazonQ-Cleanup@@Tests/InstallMCPServer.wlt:3912,1-3917,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3813,7 +3925,7 @@ VerificationTest[
     installResult = InstallMCPServer[ amazonQConfigFile, "WolframLanguage", "VerifyLLMKit" -> False, "ApplicationName" -> "AmazonQ" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-AmazonQ-PreserveExisting@@Tests/InstallMCPServer.wlt:3810,1-3817,2"
+    TestID   -> "InstallMCPServer-AmazonQ-PreserveExisting@@Tests/InstallMCPServer.wlt:3922,1-3929,2"
 ]
 
 VerificationTest[
@@ -3824,14 +3936,14 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-AmazonQ-VerifyPreserved@@Tests/InstallMCPServer.wlt:3819,1-3828,2"
+    TestID   -> "InstallMCPServer-AmazonQ-VerifyPreserved@@Tests/InstallMCPServer.wlt:3931,1-3940,2"
 ]
 
 VerificationTest[
     cleanupTestFiles[ amazonQConfigFile ],
     { Null },
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-AmazonQ-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:3830,1-3835,2"
+    TestID   -> "InstallMCPServer-AmazonQ-PreserveExisting-Cleanup@@Tests/InstallMCPServer.wlt:3942,1-3947,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3847,7 +3959,7 @@ VerificationTest[
     ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-AmazonQ-AutoDetect-Project@@Tests/InstallMCPServer.wlt:3840,1-3851,2"
+    TestID   -> "InstallMCPServer-AmazonQ-AutoDetect-Project@@Tests/InstallMCPServer.wlt:3952,1-3963,2"
 ]
 
 VerificationTest[
@@ -3860,7 +3972,7 @@ VerificationTest[
     ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallMCPServer-AmazonQ-AutoDetect-Global@@Tests/InstallMCPServer.wlt:3853,1-3864,2"
+    TestID   -> "InstallMCPServer-AmazonQ-AutoDetect-Global@@Tests/InstallMCPServer.wlt:3965,1-3976,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -3870,21 +3982,21 @@ VerificationTest[
     $SupportedMCPClients,
     _Association? AssociationQ,
     SameTest -> MatchQ,
-    TestID   -> "SupportedMCPClients-ReturnsAssociation@@Tests/InstallMCPServer.wlt:3869,1-3874,2"
+    TestID   -> "SupportedMCPClients-ReturnsAssociation@@Tests/InstallMCPServer.wlt:3981,1-3986,2"
 ]
 
 VerificationTest[
     Length @ $SupportedMCPClients,
     22,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-Has22Clients@@Tests/InstallMCPServer.wlt:3876,1-3881,2"
+    TestID   -> "SupportedMCPClients-Has22Clients@@Tests/InstallMCPServer.wlt:3988,1-3993,2"
 ]
 
 VerificationTest[
     Keys @ $SupportedMCPClients,
     { "AmazonQ", "Antigravity", "AugmentCode", "AugmentCodeIDE", "ClaudeCode", "ClaudeDesktop", "Cline", "Codex", "Continue", "CopilotCLI", "Cursor", "GeminiCLI", "Goose", "Junie", "KimiCode", "Kiro", "LMStudio", "OpenCode", "QwenCode", "VisualStudioCode", "Windsurf", "Zed" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-KeysSorted@@Tests/InstallMCPServer.wlt:3883,1-3888,2"
+    TestID   -> "SupportedMCPClients-KeysSorted@@Tests/InstallMCPServer.wlt:3995,1-4000,2"
 ]
 
 VerificationTest[
@@ -3903,70 +4015,70 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AllHaveRequiredKeys@@Tests/InstallMCPServer.wlt:3890,1-3907,2"
+    TestID   -> "SupportedMCPClients-AllHaveRequiredKeys@@Tests/InstallMCPServer.wlt:4002,1-4019,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "ClaudeDesktop", "DisplayName" ],
     "Claude Desktop",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ClaudeDesktopDisplayName@@Tests/InstallMCPServer.wlt:3909,1-3914,2"
+    TestID   -> "SupportedMCPClients-ClaudeDesktopDisplayName@@Tests/InstallMCPServer.wlt:4021,1-4026,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "ClaudeDesktop", "Aliases" ],
     { "Claude" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ClaudeDesktopAliases@@Tests/InstallMCPServer.wlt:3916,1-3921,2"
+    TestID   -> "SupportedMCPClients-ClaudeDesktopAliases@@Tests/InstallMCPServer.wlt:4028,1-4033,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Codex", "ConfigFormat" ],
     "TOML",
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-CodexConfigFormat@@Tests/InstallMCPServer.wlt:3923,1-3928,2"
+    TestID   -> "SupportedMCPClients-CodexConfigFormat@@Tests/InstallMCPServer.wlt:4035,1-4040,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Codex", "ProjectSupport" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-CodexProjectSupport@@Tests/InstallMCPServer.wlt:3930,1-3935,2"
+    TestID   -> "SupportedMCPClients-CodexProjectSupport@@Tests/InstallMCPServer.wlt:4042,1-4047,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "ClaudeCode", "ProjectSupport" ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ClaudeCodeProjectSupport@@Tests/InstallMCPServer.wlt:3937,1-3942,2"
+    TestID   -> "SupportedMCPClients-ClaudeCodeProjectSupport@@Tests/InstallMCPServer.wlt:4049,1-4054,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "Zed", "ConfigKey" ],
     { "context_servers" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-ZedConfigKey@@Tests/InstallMCPServer.wlt:3944,1-3949,2"
+    TestID   -> "SupportedMCPClients-ZedConfigKey@@Tests/InstallMCPServer.wlt:4056,1-4061,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "VisualStudioCode", "ConfigKey" ],
     { "servers" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-VSCodeConfigKey@@Tests/InstallMCPServer.wlt:3951,1-3956,2"
+    TestID   -> "SupportedMCPClients-VSCodeConfigKey@@Tests/InstallMCPServer.wlt:4063,1-4068,2"
 ]
 
 VerificationTest[
     $SupportedMCPClients[ "OpenCode", "ConfigKey" ],
     { "mcp" },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-OpenCodeConfigKey@@Tests/InstallMCPServer.wlt:3958,1-3963,2"
+    TestID   -> "SupportedMCPClients-OpenCodeConfigKey@@Tests/InstallMCPServer.wlt:4070,1-4075,2"
 ]
 
 VerificationTest[
     AllTrue[ Values @ $SupportedMCPClients, StringQ[ #[ "URL" ] ] && StringStartsQ[ #[ "URL" ], "https://" ] & ],
     True,
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-AllHaveValidURLs@@Tests/InstallMCPServer.wlt:3965,1-3970,2"
+    TestID   -> "SupportedMCPClients-AllHaveValidURLs@@Tests/InstallMCPServer.wlt:4077,1-4082,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4003,7 +4115,7 @@ VerificationTest[
     ],
     "Zed",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-Zed@@Tests/InstallMCPServer.wlt:3997,1-4007,2"
+    TestID   -> "GuessClientNameFromJSON-Zed@@Tests/InstallMCPServer.wlt:4109,1-4119,2"
 ]
 
 (* VSCode legacy: has "mcp" with nested "servers" (settings.json format) *)
@@ -4016,7 +4128,7 @@ VerificationTest[
     ],
     "VisualStudioCode",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-VisualStudioCode-Legacy@@Tests/InstallMCPServer.wlt:4010,1-4020,2"
+    TestID   -> "GuessClientNameFromJSON-VisualStudioCode-Legacy@@Tests/InstallMCPServer.wlt:4122,1-4132,2"
 ]
 
 (* VSCode: has "servers" at root level (mcp.json format) *)
@@ -4030,7 +4142,7 @@ VerificationTest[
     ],
     "VisualStudioCode",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-VisualStudioCode@@Tests/InstallMCPServer.wlt:4023,1-4034,2"
+    TestID   -> "GuessClientNameFromJSON-VisualStudioCode@@Tests/InstallMCPServer.wlt:4135,1-4146,2"
 ]
 
 (* Generic "servers" key in non-mcp.json file -> None (avoid false positives) *)
@@ -4043,7 +4155,7 @@ VerificationTest[
     ],
     None,
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-GenericServersKey@@Tests/InstallMCPServer.wlt:4037,1-4047,2"
+    TestID   -> "GuessClientNameFromJSON-GenericServersKey@@Tests/InstallMCPServer.wlt:4149,1-4159,2"
 ]
 
 (* OpenCode: has "mcp" with entries that have "type" and List-valued "command" *)
@@ -4056,7 +4168,7 @@ VerificationTest[
     ],
     "OpenCode",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-OpenCode@@Tests/InstallMCPServer.wlt:4050,1-4060,2"
+    TestID   -> "GuessClientNameFromJSON-OpenCode@@Tests/InstallMCPServer.wlt:4162,1-4172,2"
 ]
 
 (* CopilotCLI: has "mcpServers" with entries that have "tools" *)
@@ -4069,7 +4181,7 @@ VerificationTest[
     ],
     "CopilotCLI",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-CopilotCLI@@Tests/InstallMCPServer.wlt:4063,1-4073,2"
+    TestID   -> "GuessClientNameFromJSON-CopilotCLI@@Tests/InstallMCPServer.wlt:4175,1-4185,2"
 ]
 
 (* Cline: has "mcpServers" with entries that have "disabled" and "autoApprove" *)
@@ -4082,7 +4194,7 @@ VerificationTest[
     ],
     "Cline",
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-Cline@@Tests/InstallMCPServer.wlt:4076,1-4086,2"
+    TestID   -> "GuessClientNameFromJSON-Cline@@Tests/InstallMCPServer.wlt:4188,1-4198,2"
 ]
 
 (* Ambiguous: standard mcpServers with only command/args/env -> None *)
@@ -4095,7 +4207,7 @@ VerificationTest[
     ],
     None,
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-Ambiguous@@Tests/InstallMCPServer.wlt:4089,1-4099,2"
+    TestID   -> "GuessClientNameFromJSON-Ambiguous@@Tests/InstallMCPServer.wlt:4201,1-4211,2"
 ]
 
 (* Empty JSON -> None *)
@@ -4108,7 +4220,7 @@ VerificationTest[
     ],
     None,
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-EmptyJSON@@Tests/InstallMCPServer.wlt:4102,1-4112,2"
+    TestID   -> "GuessClientNameFromJSON-EmptyJSON@@Tests/InstallMCPServer.wlt:4214,1-4224,2"
 ]
 
 (* Non-existent file -> None *)
@@ -4117,7 +4229,7 @@ VerificationTest[
         FileNameJoin @ { $TemporaryDirectory, "nonexistent_" <> CreateUUID[] <> ".json" },
     None,
     SameTest -> Equal,
-    TestID   -> "GuessClientNameFromJSON-NonExistentFile@@Tests/InstallMCPServer.wlt:4115,1-4121,2"
+    TestID   -> "GuessClientNameFromJSON-NonExistentFile@@Tests/InstallMCPServer.wlt:4227,1-4233,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4129,7 +4241,7 @@ VerificationTest[
     ],
     { "mcpServers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-ClaudeDesktop@@Tests/InstallMCPServer.wlt:4126,1-4133,2"
+    TestID   -> "ConfigKeyPath-ClaudeDesktop@@Tests/InstallMCPServer.wlt:4238,1-4245,2"
 ]
 
 VerificationTest[
@@ -4138,7 +4250,7 @@ VerificationTest[
     ],
     { "servers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-VSCode@@Tests/InstallMCPServer.wlt:4135,1-4142,2"
+    TestID   -> "ConfigKeyPath-VSCode@@Tests/InstallMCPServer.wlt:4247,1-4254,2"
 ]
 
 (* VS Code with mcp.json file: uses new key path *)
@@ -4149,7 +4261,7 @@ VerificationTest[
     ],
     { "servers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-VSCode-MCPJson@@Tests/InstallMCPServer.wlt:4145,1-4153,2"
+    TestID   -> "ConfigKeyPath-VSCode-MCPJson@@Tests/InstallMCPServer.wlt:4257,1-4265,2"
 ]
 
 (* VS Code with legacy settings.json: uses old nested key path *)
@@ -4160,7 +4272,7 @@ VerificationTest[
     ],
     { "mcp", "servers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-VSCode-LegacySettings@@Tests/InstallMCPServer.wlt:4156,1-4164,2"
+    TestID   -> "ConfigKeyPath-VSCode-LegacySettings@@Tests/InstallMCPServer.wlt:4268,1-4276,2"
 ]
 
 VerificationTest[
@@ -4169,7 +4281,7 @@ VerificationTest[
     ],
     { "context_servers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-Zed@@Tests/InstallMCPServer.wlt:4166,1-4173,2"
+    TestID   -> "ConfigKeyPath-Zed@@Tests/InstallMCPServer.wlt:4278,1-4285,2"
 ]
 
 VerificationTest[
@@ -4178,14 +4290,14 @@ VerificationTest[
     ],
     { "mcp" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-OpenCode@@Tests/InstallMCPServer.wlt:4175,1-4182,2"
+    TestID   -> "ConfigKeyPath-OpenCode@@Tests/InstallMCPServer.wlt:4287,1-4294,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`configKeyPath[ "UnknownClient" ],
     { "mcpServers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-UnknownFallback@@Tests/InstallMCPServer.wlt:4184,1-4189,2"
+    TestID   -> "ConfigKeyPath-UnknownFallback@@Tests/InstallMCPServer.wlt:4296,1-4301,2"
 ]
 
 VerificationTest[
@@ -4194,7 +4306,7 @@ VerificationTest[
     ],
     { "mcpServers" },
     SameTest -> Equal,
-    TestID   -> "ConfigKeyPath-NoneFallback@@Tests/InstallMCPServer.wlt:4191,1-4198,2"
+    TestID   -> "ConfigKeyPath-NoneFallback@@Tests/InstallMCPServer.wlt:4303,1-4310,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4204,21 +4316,21 @@ VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`emptyConfigForPath @ { "mcpServers" },
     <| "mcpServers" -> <| |> |>,
     SameTest -> Equal,
-    TestID   -> "EmptyConfigForPath-SingleKey@@Tests/InstallMCPServer.wlt:4203,1-4208,2"
+    TestID   -> "EmptyConfigForPath-SingleKey@@Tests/InstallMCPServer.wlt:4315,1-4320,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`emptyConfigForPath @ { "mcp", "servers" },
     <| "mcp" -> <| "servers" -> <| |> |> |>,
     SameTest -> Equal,
-    TestID   -> "EmptyConfigForPath-NestedKeys@@Tests/InstallMCPServer.wlt:4210,1-4215,2"
+    TestID   -> "EmptyConfigForPath-NestedKeys@@Tests/InstallMCPServer.wlt:4322,1-4327,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`emptyConfigForPath @ { },
     <| |>,
     SameTest -> Equal,
-    TestID   -> "EmptyConfigForPath-EmptyPath@@Tests/InstallMCPServer.wlt:4217,1-4222,2"
+    TestID   -> "EmptyConfigForPath-EmptyPath@@Tests/InstallMCPServer.wlt:4329,1-4334,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4228,7 +4340,7 @@ VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`ensureNestedKey[ <| "other" -> 1 |>, { "mcpServers" } ],
     <| "other" -> 1, "mcpServers" -> <| |> |>,
     SameTest -> Equal,
-    TestID   -> "EnsureNestedKey-AddMissing@@Tests/InstallMCPServer.wlt:4227,1-4232,2"
+    TestID   -> "EnsureNestedKey-AddMissing@@Tests/InstallMCPServer.wlt:4339,1-4344,2"
 ]
 
 VerificationTest[
@@ -4238,7 +4350,7 @@ VerificationTest[
     ],
     <| "mcpServers" -> <| "existing" -> "data" |> |>,
     SameTest -> Equal,
-    TestID   -> "EnsureNestedKey-PreserveExisting@@Tests/InstallMCPServer.wlt:4234,1-4242,2"
+    TestID   -> "EnsureNestedKey-PreserveExisting@@Tests/InstallMCPServer.wlt:4346,1-4354,2"
 ]
 
 VerificationTest[
@@ -4248,7 +4360,7 @@ VerificationTest[
     ],
     <| "theme" -> "dark", "mcp" -> <| "servers" -> <| |> |> |>,
     SameTest -> Equal,
-    TestID   -> "EnsureNestedKey-DeepNesting@@Tests/InstallMCPServer.wlt:4244,1-4252,2"
+    TestID   -> "EnsureNestedKey-DeepNesting@@Tests/InstallMCPServer.wlt:4356,1-4364,2"
 ]
 
 VerificationTest[
@@ -4258,14 +4370,14 @@ VerificationTest[
     ],
     <| "mcp" -> <| "existing" -> 1, "servers" -> <| |> |> |>,
     SameTest -> Equal,
-    TestID   -> "EnsureNestedKey-PartiallyExisting@@Tests/InstallMCPServer.wlt:4254,1-4262,2"
+    TestID   -> "EnsureNestedKey-PartiallyExisting@@Tests/InstallMCPServer.wlt:4366,1-4374,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`ensureNestedKey[ "notAssoc", { "mcpServers" } ],
     <| "mcpServers" -> <| |> |>,
     SameTest -> Equal,
-    TestID   -> "EnsureNestedKey-NonAssocInput@@Tests/InstallMCPServer.wlt:4264,1-4269,2"
+    TestID   -> "EnsureNestedKey-NonAssocInput@@Tests/InstallMCPServer.wlt:4376,1-4381,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4275,28 +4387,28 @@ VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`serverConverter[ "OpenCode" ],
     Wolfram`AgentTools`SupportedClients`Private`convertToOpenCodeFormat,
     SameTest -> SameQ,
-    TestID   -> "ServerConverter-OpenCode@@Tests/InstallMCPServer.wlt:4274,1-4279,2"
+    TestID   -> "ServerConverter-OpenCode@@Tests/InstallMCPServer.wlt:4386,1-4391,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`serverConverter[ "CopilotCLI" ],
     Wolfram`AgentTools`SupportedClients`Private`convertToCopilotCLIFormat,
     SameTest -> SameQ,
-    TestID   -> "ServerConverter-CopilotCLI@@Tests/InstallMCPServer.wlt:4281,1-4286,2"
+    TestID   -> "ServerConverter-CopilotCLI@@Tests/InstallMCPServer.wlt:4393,1-4398,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`serverConverter[ "Cline" ],
     Wolfram`AgentTools`SupportedClients`Private`convertToClineFormat,
     SameTest -> SameQ,
-    TestID   -> "ServerConverter-Cline@@Tests/InstallMCPServer.wlt:4288,1-4293,2"
+    TestID   -> "ServerConverter-Cline@@Tests/InstallMCPServer.wlt:4400,1-4405,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`serverConverter[ "ClaudeDesktop" ],
     Identity,
     SameTest -> SameQ,
-    TestID   -> "ServerConverter-Default@@Tests/InstallMCPServer.wlt:4295,1-4300,2"
+    TestID   -> "ServerConverter-Default@@Tests/InstallMCPServer.wlt:4407,1-4412,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4308,7 +4420,7 @@ VerificationTest[
     ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "ResolveMCPServerName-BuiltInServer@@Tests/InstallMCPServer.wlt:4305,1-4312,2"
+    TestID   -> "ResolveMCPServerName-BuiltInServer@@Tests/InstallMCPServer.wlt:4417,1-4424,2"
 ]
 
 VerificationTest[
@@ -4317,7 +4429,7 @@ VerificationTest[
     ],
     "CustomKey",
     SameTest -> Equal,
-    TestID   -> "ResolveMCPServerName-OptionOverride@@Tests/InstallMCPServer.wlt:4314,1-4321,2"
+    TestID   -> "ResolveMCPServerName-OptionOverride@@Tests/InstallMCPServer.wlt:4426,1-4433,2"
 ]
 
 VerificationTest[
@@ -4326,7 +4438,7 @@ VerificationTest[
     ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "ResolveMCPServerName-WolframServer@@Tests/InstallMCPServer.wlt:4323,1-4330,2"
+    TestID   -> "ResolveMCPServerName-WolframServer@@Tests/InstallMCPServer.wlt:4435,1-4442,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4344,7 +4456,7 @@ VerificationTest[
     $mockPaclet[ "Name" ],
     "MockMCPPacletTest",
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-MockPacletSetup@@Tests/InstallMCPServer.wlt:4341,1-4348,2"
+    TestID   -> "InstallPacletServer-MockPacletSetup@@Tests/InstallMCPServer.wlt:4453,1-4460,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4354,7 +4466,7 @@ VerificationTest[
     MCPServerObject[ "MockMCPPacletTest/TestServer" ][ "MCPServerName" ],
     "TestServer",
     SameTest -> Equal,
-    TestID   -> "MCPServerName-PacletServerProperty@@Tests/InstallMCPServer.wlt:4353,1-4358,2"
+    TestID   -> "MCPServerName-PacletServerProperty@@Tests/InstallMCPServer.wlt:4465,1-4470,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4366,7 +4478,7 @@ VerificationTest[
     ],
     "TestServer",
     SameTest -> Equal,
-    TestID   -> "ResolveMCPServerName-PacletServerShortName@@Tests/InstallMCPServer.wlt:4363,1-4370,2"
+    TestID   -> "ResolveMCPServerName-PacletServerShortName@@Tests/InstallMCPServer.wlt:4475,1-4482,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4376,7 +4488,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`ensurePacletForInstall[ "MockMCPPacletTest/TestServer" ],
     _PacletObject,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-EnsurePacletAlreadyInstalled@@Tests/InstallMCPServer.wlt:4375,1-4380,2"
+    TestID   -> "InstallPacletServer-EnsurePacletAlreadyInstalled@@Tests/InstallMCPServer.wlt:4487,1-4492,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4388,7 +4500,7 @@ VerificationTest[
     _Failure,
     { AgentTools::PacletNotInstalled },
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-EnsurePacletThreeSegment@@Tests/InstallMCPServer.wlt:4385,1-4392,2"
+    TestID   -> "InstallPacletServer-EnsurePacletThreeSegment@@Tests/InstallMCPServer.wlt:4497,1-4504,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4399,7 +4511,7 @@ VerificationTest[
     $pacletInstallResult = InstallMCPServer[ $pacletConfigFile, "MockMCPPacletTest/TestServer", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-Install@@Tests/InstallMCPServer.wlt:4397,1-4403,2"
+    TestID   -> "InstallPacletServer-Install@@Tests/InstallMCPServer.wlt:4509,1-4515,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4409,7 +4521,7 @@ VerificationTest[
     FileExistsQ @ $pacletConfigFile,
     True,
     SameTest -> Equal,
-    TestID   -> "InstallPacletServer-ConfigFileExists@@Tests/InstallMCPServer.wlt:4408,1-4413,2"
+    TestID   -> "InstallPacletServer-ConfigFileExists@@Tests/InstallMCPServer.wlt:4520,1-4525,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4420,7 +4532,7 @@ VerificationTest[
     KeyExistsQ[ $pacletConfigJSON[ "mcpServers" ], "TestServer" ],
     True,
     SameTest -> Equal,
-    TestID   -> "InstallPacletServer-ConfigHasServerName@@Tests/InstallMCPServer.wlt:4418,1-4424,2"
+    TestID   -> "InstallPacletServer-ConfigHasServerName@@Tests/InstallMCPServer.wlt:4530,1-4536,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4430,7 +4542,7 @@ VerificationTest[
     $pacletConfigJSON[ "mcpServers", "TestServer", "env", "MCP_SERVER_NAME" ],
     "MockMCPPacletTest/TestServer",
     SameTest -> Equal,
-    TestID   -> "InstallPacletServer-ConfigEnvServerName@@Tests/InstallMCPServer.wlt:4429,1-4434,2"
+    TestID   -> "InstallPacletServer-ConfigEnvServerName@@Tests/InstallMCPServer.wlt:4541,1-4546,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4440,7 +4552,7 @@ VerificationTest[
     UninstallMCPServer[ $pacletConfigFile, MCPServerObject[ "MockMCPPacletTest/TestServer" ] ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-Uninstall@@Tests/InstallMCPServer.wlt:4439,1-4444,2"
+    TestID   -> "InstallPacletServer-Uninstall@@Tests/InstallMCPServer.wlt:4551,1-4556,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4451,7 +4563,7 @@ VerificationTest[
     KeyExistsQ[ updatedJSON[ "mcpServers" ], "TestServer" ],
     False,
     SameTest -> Equal,
-    TestID   -> "InstallPacletServer-VerifyUninstall@@Tests/InstallMCPServer.wlt:4449,1-4455,2"
+    TestID   -> "InstallPacletServer-VerifyUninstall@@Tests/InstallMCPServer.wlt:4561,1-4567,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4462,7 +4574,7 @@ VerificationTest[
     $pacletInstallResult2[ "MCPServerObject" ],
     _MCPServerObject? MCPServerObjectQ,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-ResultHasMCPServerObject@@Tests/InstallMCPServer.wlt:4460,1-4466,2"
+    TestID   -> "InstallPacletServer-ResultHasMCPServerObject@@Tests/InstallMCPServer.wlt:4572,1-4578,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4473,7 +4585,7 @@ VerificationTest[
     Wolfram`AgentTools`InstallMCPServer`Private`validatePacletServerDefinitions @ obj,
     Null,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-ValidateDefinitionsValid@@Tests/InstallMCPServer.wlt:4471,1-4477,2"
+    TestID   -> "InstallPacletServer-ValidateDefinitionsValid@@Tests/InstallMCPServer.wlt:4583,1-4589,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4489,7 +4601,7 @@ VerificationTest[
     result,
     Null,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-ValidateDefinitionsNoOp@@Tests/InstallMCPServer.wlt:4482,1-4493,2"
+    TestID   -> "InstallPacletServer-ValidateDefinitionsNoOp@@Tests/InstallMCPServer.wlt:4594,1-4605,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4509,7 +4621,7 @@ VerificationTest[
     _Failure,
     { AgentTools::PacletNotInstalled },
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-ValidateToolError@@Tests/InstallMCPServer.wlt:4498,1-4513,2"
+    TestID   -> "InstallPacletServer-ValidateToolError@@Tests/InstallMCPServer.wlt:4610,1-4625,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4529,7 +4641,7 @@ VerificationTest[
     _Failure,
     { AgentTools::PacletNotInstalled },
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-ValidatePromptError@@Tests/InstallMCPServer.wlt:4518,1-4533,2"
+    TestID   -> "InstallPacletServer-ValidatePromptError@@Tests/InstallMCPServer.wlt:4630,1-4645,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4540,7 +4652,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`clearPacletDefinitionCache[ ],
     <| |>,
     SameTest -> MatchQ,
-    TestID   -> "InstallPacletServer-Cleanup@@Tests/InstallMCPServer.wlt:4538,1-4544,2"
+    TestID   -> "InstallPacletServer-Cleanup@@Tests/InstallMCPServer.wlt:4650,1-4656,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4555,7 +4667,7 @@ VerificationTest[
     InstallMCPServer[ mcpNameConfigFile, "WolframLanguage", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-BuiltInUsesWolframKey-Install@@Tests/InstallMCPServer.wlt:4553,1-4559,2"
+    TestID   -> "MCPServerName-BuiltInUsesWolframKey-Install@@Tests/InstallMCPServer.wlt:4665,1-4671,2"
 ]
 
 VerificationTest[
@@ -4564,7 +4676,7 @@ VerificationTest[
     ! KeyExistsQ[ jsonContent[ "mcpServers" ], "WolframLanguage" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-BuiltInUsesWolframKey-Verify@@Tests/InstallMCPServer.wlt:4561,1-4568,2"
+    TestID   -> "MCPServerName-BuiltInUsesWolframKey-Verify@@Tests/InstallMCPServer.wlt:4673,1-4680,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4574,7 +4686,7 @@ VerificationTest[
     InstallMCPServer[ mcpNameConfigFile, "WolframAlpha", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-SecondBuiltInOverwrites-Install@@Tests/InstallMCPServer.wlt:4573,1-4578,2"
+    TestID   -> "MCPServerName-SecondBuiltInOverwrites-Install@@Tests/InstallMCPServer.wlt:4685,1-4690,2"
 ]
 
 VerificationTest[
@@ -4583,7 +4695,7 @@ VerificationTest[
     KeyExistsQ[ jsonContent[ "mcpServers" ], "Wolfram" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-SecondBuiltInOverwrites-Verify@@Tests/InstallMCPServer.wlt:4580,1-4587,2"
+    TestID   -> "MCPServerName-SecondBuiltInOverwrites-Verify@@Tests/InstallMCPServer.wlt:4692,1-4699,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4593,7 +4705,7 @@ VerificationTest[
     UninstallMCPServer[ mcpNameConfigFile, "WolframAlpha" ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-UninstallBuiltIn@@Tests/InstallMCPServer.wlt:4592,1-4597,2"
+    TestID   -> "MCPServerName-UninstallBuiltIn@@Tests/InstallMCPServer.wlt:4704,1-4709,2"
 ]
 
 VerificationTest[
@@ -4601,7 +4713,7 @@ VerificationTest[
     ! KeyExistsQ[ jsonContent[ "mcpServers" ], "Wolfram" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-UninstallBuiltIn-Verify@@Tests/InstallMCPServer.wlt:4599,1-4605,2"
+    TestID   -> "MCPServerName-UninstallBuiltIn-Verify@@Tests/InstallMCPServer.wlt:4711,1-4717,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4616,7 +4728,7 @@ VerificationTest[
     InstallMCPServer[ mcpNameConfigFile, mcpNameCustomServer, "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-CustomServerUsesName-Install@@Tests/InstallMCPServer.wlt:4610,1-4620,2"
+    TestID   -> "MCPServerName-CustomServerUsesName-Install@@Tests/InstallMCPServer.wlt:4722,1-4732,2"
 ]
 
 VerificationTest[
@@ -4624,7 +4736,7 @@ VerificationTest[
     KeyExistsQ[ jsonContent[ "mcpServers" ], mcpNameCustomName ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-CustomServerUsesName-Verify@@Tests/InstallMCPServer.wlt:4622,1-4628,2"
+    TestID   -> "MCPServerName-CustomServerUsesName-Verify@@Tests/InstallMCPServer.wlt:4734,1-4740,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4634,7 +4746,7 @@ VerificationTest[
     InstallMCPServer[ mcpNameConfigFile, "WolframLanguage", "MCPServerName" -> "WolframDev", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-OptionOverride-Install@@Tests/InstallMCPServer.wlt:4633,1-4638,2"
+    TestID   -> "MCPServerName-OptionOverride-Install@@Tests/InstallMCPServer.wlt:4745,1-4750,2"
 ]
 
 VerificationTest[
@@ -4642,7 +4754,7 @@ VerificationTest[
     KeyExistsQ[ jsonContent[ "mcpServers" ], "WolframDev" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-OptionOverride-Verify@@Tests/InstallMCPServer.wlt:4640,1-4646,2"
+    TestID   -> "MCPServerName-OptionOverride-Verify@@Tests/InstallMCPServer.wlt:4752,1-4758,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4654,7 +4766,7 @@ VerificationTest[
     InstallMCPServer[ mcpNameConfigFile2, "WolframLanguage", "MCPServerName" -> "WolframDev2", "VerifyLLMKit" -> False ],
     _Success,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-TwoBuiltInWithOverrides-Install@@Tests/InstallMCPServer.wlt:4651,1-4658,2"
+    TestID   -> "MCPServerName-TwoBuiltInWithOverrides-Install@@Tests/InstallMCPServer.wlt:4763,1-4770,2"
 ]
 
 VerificationTest[
@@ -4663,7 +4775,7 @@ VerificationTest[
     KeyExistsQ[ jsonContent[ "mcpServers" ], "WolframDev2" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-TwoBuiltInWithOverrides-Verify@@Tests/InstallMCPServer.wlt:4660,1-4667,2"
+    TestID   -> "MCPServerName-TwoBuiltInWithOverrides-Verify@@Tests/InstallMCPServer.wlt:4772,1-4779,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4676,7 +4788,7 @@ VerificationTest[
     MemberQ[ wolframInstalls, KeyValuePattern[ "ConfigurationFile" -> mcpNameConfigFile3 ] ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-StaleRecordClearing-Setup@@Tests/InstallMCPServer.wlt:4672,1-4680,2"
+    TestID   -> "MCPServerName-StaleRecordClearing-Setup@@Tests/InstallMCPServer.wlt:4784,1-4792,2"
 ]
 
 VerificationTest[
@@ -4688,7 +4800,7 @@ VerificationTest[
     MemberQ[ wlInstalls, KeyValuePattern[ "ConfigurationFile" -> mcpNameConfigFile3 ] ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerName-StaleRecordClearing-Verify@@Tests/InstallMCPServer.wlt:4682,1-4692,2"
+    TestID   -> "MCPServerName-StaleRecordClearing-Verify@@Tests/InstallMCPServer.wlt:4794,1-4804,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4702,7 +4814,7 @@ VerificationTest[
     cleanupTestFiles[ { mcpNameConfigFile, mcpNameConfigFile2, mcpNameConfigFile3 } ],
     { Null.. },
     SameTest -> MatchQ,
-    TestID   -> "MCPServerName-Cleanup@@Tests/InstallMCPServer.wlt:4697,1-4706,2"
+    TestID   -> "MCPServerName-Cleanup@@Tests/InstallMCPServer.wlt:4809,1-4818,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4717,28 +4829,28 @@ VerificationTest[
     defaultToolsetForTarget[ "ClaudeCode" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-ClaudeCode@@Tests/InstallMCPServer.wlt:4715,1-4721,2"
+    TestID   -> "DefaultToolsetForTarget-ClaudeCode@@Tests/InstallMCPServer.wlt:4827,1-4833,2"
 ]
 
 VerificationTest[
     defaultToolsetForTarget[ "ClaudeDesktop" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-ClaudeDesktop@@Tests/InstallMCPServer.wlt:4723,1-4728,2"
+    TestID   -> "DefaultToolsetForTarget-ClaudeDesktop@@Tests/InstallMCPServer.wlt:4835,1-4840,2"
 ]
 
 VerificationTest[
     defaultToolsetForTarget[ "Goose" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-Goose@@Tests/InstallMCPServer.wlt:4730,1-4735,2"
+    TestID   -> "DefaultToolsetForTarget-Goose@@Tests/InstallMCPServer.wlt:4842,1-4847,2"
 ]
 
 VerificationTest[
     defaultToolsetForTarget[ "Cursor" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-Cursor@@Tests/InstallMCPServer.wlt:4737,1-4742,2"
+    TestID   -> "DefaultToolsetForTarget-Cursor@@Tests/InstallMCPServer.wlt:4849,1-4854,2"
 ]
 
 (* Junie is a coding agent (covers JetBrains IDE plugin and Junie CLI), so it defaults to WolframLanguage *)
@@ -4746,7 +4858,7 @@ VerificationTest[
     defaultToolsetForTarget[ "Junie" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-Junie@@Tests/InstallMCPServer.wlt:4745,1-4750,2"
+    TestID   -> "DefaultToolsetForTarget-Junie@@Tests/InstallMCPServer.wlt:4857,1-4862,2"
 ]
 
 (* Junie alias resolves to the canonical client's default *)
@@ -4754,7 +4866,7 @@ VerificationTest[
     defaultToolsetForTarget[ "JetBrainsJunie" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-Alias-JetBrainsJunie@@Tests/InstallMCPServer.wlt:4753,1-4758,2"
+    TestID   -> "DefaultToolsetForTarget-Alias-JetBrainsJunie@@Tests/InstallMCPServer.wlt:4865,1-4870,2"
 ]
 
 (* {Junie, dir} project-install form *)
@@ -4762,7 +4874,7 @@ VerificationTest[
     defaultToolsetForTarget[ { "Junie", "/some/dir" } ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-NameDir-Junie@@Tests/InstallMCPServer.wlt:4761,1-4766,2"
+    TestID   -> "DefaultToolsetForTarget-NameDir-Junie@@Tests/InstallMCPServer.wlt:4873,1-4878,2"
 ]
 
 (* Aliases resolve to their canonical client's default *)
@@ -4770,14 +4882,14 @@ VerificationTest[
     defaultToolsetForTarget[ "Claude" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-Alias-Claude@@Tests/InstallMCPServer.wlt:4769,1-4774,2"
+    TestID   -> "DefaultToolsetForTarget-Alias-Claude@@Tests/InstallMCPServer.wlt:4881,1-4886,2"
 ]
 
 VerificationTest[
     defaultToolsetForTarget[ "VSCode" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-Alias-VSCode@@Tests/InstallMCPServer.wlt:4776,1-4781,2"
+    TestID   -> "DefaultToolsetForTarget-Alias-VSCode@@Tests/InstallMCPServer.wlt:4888,1-4893,2"
 ]
 
 (* Unknown client falls back to $defaultMCPServer *)
@@ -4785,7 +4897,7 @@ VerificationTest[
     defaultToolsetForTarget[ "TotallyMadeUpClient" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-Unknown@@Tests/InstallMCPServer.wlt:4784,1-4789,2"
+    TestID   -> "DefaultToolsetForTarget-Unknown@@Tests/InstallMCPServer.wlt:4896,1-4901,2"
 ]
 
 (* {name, dir} project-install form dispatches on the name *)
@@ -4793,14 +4905,14 @@ VerificationTest[
     defaultToolsetForTarget[ { "ClaudeCode", "/some/dir" } ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-NameDir-ClaudeCode@@Tests/InstallMCPServer.wlt:4792,1-4797,2"
+    TestID   -> "DefaultToolsetForTarget-NameDir-ClaudeCode@@Tests/InstallMCPServer.wlt:4904,1-4909,2"
 ]
 
 VerificationTest[
     defaultToolsetForTarget[ { "ClaudeDesktop", "/some/dir" } ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-NameDir-ClaudeDesktop@@Tests/InstallMCPServer.wlt:4799,1-4804,2"
+    TestID   -> "DefaultToolsetForTarget-NameDir-ClaudeDesktop@@Tests/InstallMCPServer.wlt:4911,1-4916,2"
 ]
 
 (* File target with no client match falls back *)
@@ -4808,7 +4920,7 @@ VerificationTest[
     defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ] ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-Unknown@@Tests/InstallMCPServer.wlt:4807,1-4812,2"
+    TestID   -> "DefaultToolsetForTarget-File-Unknown@@Tests/InstallMCPServer.wlt:4919,1-4924,2"
 ]
 
 (* Recognizable File[...] targets resolve via path-based client detection
@@ -4821,7 +4933,7 @@ VerificationTest[
     defaultToolsetForTarget[ File[ "/some/project/.mcp.json" ] ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-ClaudeCodeProject@@Tests/InstallMCPServer.wlt:4820,1-4825,2"
+    TestID   -> "DefaultToolsetForTarget-File-ClaudeCodeProject@@Tests/InstallMCPServer.wlt:4932,1-4937,2"
 ]
 
 (* .vscode/mcp.json -> VisualStudioCode (coding client, "WolframLanguage") *)
@@ -4829,7 +4941,7 @@ VerificationTest[
     defaultToolsetForTarget[ File[ "/some/project/.vscode/mcp.json" ] ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-VSCodeProject@@Tests/InstallMCPServer.wlt:4828,1-4833,2"
+    TestID   -> "DefaultToolsetForTarget-File-VSCodeProject@@Tests/InstallMCPServer.wlt:4940,1-4945,2"
 ]
 
 (* opencode.json -> OpenCode (coding client, "WolframLanguage") *)
@@ -4837,7 +4949,7 @@ VerificationTest[
     defaultToolsetForTarget[ File[ "/some/project/opencode.json" ] ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-OpenCodeProject@@Tests/InstallMCPServer.wlt:4836,1-4841,2"
+    TestID   -> "DefaultToolsetForTarget-File-OpenCodeProject@@Tests/InstallMCPServer.wlt:4948,1-4953,2"
 ]
 
 (* Non-target argument falls back *)
@@ -4845,7 +4957,7 @@ VerificationTest[
     defaultToolsetForTarget[ 42 ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-NonTarget@@Tests/InstallMCPServer.wlt:4844,1-4849,2"
+    TestID   -> "DefaultToolsetForTarget-NonTarget@@Tests/InstallMCPServer.wlt:4956,1-4961,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4857,14 +4969,14 @@ VerificationTest[
     defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], "Cline" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-AppName-Cline@@Tests/InstallMCPServer.wlt:4856,1-4861,2"
+    TestID   -> "DefaultToolsetForTarget-File-AppName-Cline@@Tests/InstallMCPServer.wlt:4968,1-4973,2"
 ]
 
 VerificationTest[
     defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], "ClaudeDesktop" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-AppName-ClaudeDesktop@@Tests/InstallMCPServer.wlt:4863,1-4868,2"
+    TestID   -> "DefaultToolsetForTarget-File-AppName-ClaudeDesktop@@Tests/InstallMCPServer.wlt:4975,1-4980,2"
 ]
 
 (* Aliases route through toInstallName, so an alias picks up the canonical client's default *)
@@ -4872,7 +4984,7 @@ VerificationTest[
     defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], "VSCode" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-AppName-Alias@@Tests/InstallMCPServer.wlt:4871,1-4876,2"
+    TestID   -> "DefaultToolsetForTarget-File-AppName-Alias@@Tests/InstallMCPServer.wlt:4983,1-4988,2"
 ]
 
 (* Automatic in the 2-arg form falls back to the existing target-based resolution *)
@@ -4880,7 +4992,7 @@ VerificationTest[
     defaultToolsetForTarget[ File[ "C:/this/path/is/not/a/known/client.json" ], Automatic ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-File-AppName-Automatic@@Tests/InstallMCPServer.wlt:4879,1-4884,2"
+    TestID   -> "DefaultToolsetForTarget-File-AppName-Automatic@@Tests/InstallMCPServer.wlt:4991,1-4996,2"
 ]
 
 (* String target is also overridden by an explicit ApplicationName *)
@@ -4888,7 +5000,7 @@ VerificationTest[
     defaultToolsetForTarget[ "ClaudeCode", "ClaudeDesktop" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "DefaultToolsetForTarget-StringTarget-AppName@@Tests/InstallMCPServer.wlt:4887,1-4892,2"
+    TestID   -> "DefaultToolsetForTarget-StringTarget-AppName@@Tests/InstallMCPServer.wlt:4999,1-5004,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4904,7 +5016,7 @@ VerificationTest[
     autoInstallResultAuto[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Automatic-ClaudeCode@@Tests/InstallMCPServer.wlt:4897,1-4908,2"
+    TestID   -> "InstallMCPServer-Automatic-ClaudeCode@@Tests/InstallMCPServer.wlt:5009,1-5020,2"
 ]
 
 (* 1-arg form should give the same result as Automatic *)
@@ -4918,7 +5030,7 @@ VerificationTest[
     autoInstallResult1Arg[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-1Arg-ClaudeCode@@Tests/InstallMCPServer.wlt:4911,1-4922,2"
+    TestID   -> "InstallMCPServer-1Arg-ClaudeCode@@Tests/InstallMCPServer.wlt:5023,1-5034,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4937,7 +5049,7 @@ VerificationTest[
     autoInstallResultFileApp[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Automatic-File-AppName-Cline@@Tests/InstallMCPServer.wlt:4929,1-4941,2"
+    TestID   -> "InstallMCPServer-Automatic-File-AppName-Cline@@Tests/InstallMCPServer.wlt:5041,1-5053,2"
 ]
 
 VerificationTest[
@@ -4952,7 +5064,7 @@ VerificationTest[
     autoInstallResultFileChat[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "Wolfram",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Automatic-File-AppName-ClaudeDesktop@@Tests/InstallMCPServer.wlt:4943,1-4956,2"
+    TestID   -> "InstallMCPServer-Automatic-File-AppName-ClaudeDesktop@@Tests/InstallMCPServer.wlt:5055,1-5068,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -4975,7 +5087,7 @@ VerificationTest[
     autoInstallResultFileClaudeCode[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Automatic-File-ClaudeCodeProject@@Tests/InstallMCPServer.wlt:4967,1-4979,2"
+    TestID   -> "InstallMCPServer-Automatic-File-ClaudeCodeProject@@Tests/InstallMCPServer.wlt:5079,1-5091,2"
 ]
 
 (* .vscode/mcp.json -> VisualStudioCode -> "WolframLanguage" *)
@@ -4992,7 +5104,7 @@ VerificationTest[
     autoInstallResultFileVSCode[[ 2 ]][ "MCPServerObject" ][ "Name" ],
     "WolframLanguage",
     SameTest -> Equal,
-    TestID   -> "InstallMCPServer-Automatic-File-VSCodeProject@@Tests/InstallMCPServer.wlt:4982,1-4996,2"
+    TestID   -> "InstallMCPServer-Automatic-File-VSCodeProject@@Tests/InstallMCPServer.wlt:5094,1-5108,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -5013,7 +5125,7 @@ VerificationTest[
     ],
     { },
     SameTest -> Equal,
-    TestID   -> "SupportedMCPClients-DefaultToolset-Coverage@@Tests/InstallMCPServer.wlt:5004,1-5017,2"
+    TestID   -> "SupportedMCPClients-DefaultToolset-Coverage@@Tests/InstallMCPServer.wlt:5116,1-5129,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -5025,7 +5137,7 @@ VerificationTest[
     cleanupTestFiles @ autoCustomFile;
     True,
     True,
-    TestID -> "Automatic-Cleanup@@Tests/InstallMCPServer.wlt:5022,1-5029,2"
+    TestID -> "Automatic-Cleanup@@Tests/InstallMCPServer.wlt:5134,1-5141,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/MCPServerObject.wlt
+++ b/Tests/MCPServerObject.wlt
@@ -154,6 +154,44 @@ VerificationTest[
     TestID   -> "MCPServerObject-BuiltInServerLocation@@Tests/MCPServerObject.wlt:150,1-155,2"
 ]
 
+(* Built-in servers opt in to anonymous usage tracking via the "EnableUsageData" property (see docs/usage-data.md);
+   servers created with CreateMCPServer do not have the property. *)
+VerificationTest[
+    builtInServer["EnableUsageData"],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "MCPServerObject-BuiltInServerEnableUsageData@@Tests/MCPServerObject.wlt:159,1-164,2"
+]
+
+VerificationTest[
+    AllTrue[ Values @ $DefaultMCPServers, #[ "EnableUsageData" ] === True & ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "MCPServerObject-AllBuiltInServersEnableUsageData@@Tests/MCPServerObject.wlt:166,1-171,2"
+]
+
+VerificationTest[
+    MemberQ[ builtInServer[ "Properties" ], "EnableUsageData" ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "MCPServerObject-BuiltInServerPropertiesIncludeEnableUsageData@@Tests/MCPServerObject.wlt:173,1-178,2"
+]
+
+VerificationTest[
+    Module[ { customServer, result },
+        customServer = CreateMCPServer[
+            StringJoin[ "TestServer_UsageData_", CreateUUID[] ],
+            LLMConfiguration @ <| "Tools" -> { LLMTool[ "PrimeFinder", { "n" -> "Integer" }, Prime[ #n ] & ] } |>
+        ];
+        result = customServer[ "EnableUsageData" ];
+        DeleteObject[ customServer ];
+        result
+    ],
+    Missing[ "UnknownProperty", "EnableUsageData" ],
+    SameTest -> SameQ,
+    TestID   -> "MCPServerObject-CustomServerNoEnableUsageData@@Tests/MCPServerObject.wlt:180,1-193,2"
+]
+
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*Server Objects Listing*)
@@ -161,7 +199,7 @@ VerificationTest[
     servers = MCPServerObjects[],
     { ___MCPServerObject? MCPServerObjectQ },
     SameTest -> MatchQ,
-    TestID   -> "MCPServerObject-ListAllServers@@Tests/MCPServerObject.wlt:160,1-165,2"
+    TestID   -> "MCPServerObject-ListAllServers@@Tests/MCPServerObject.wlt:198,1-203,2"
 ]
 
 (* Note: We can't rely on built-in servers being found in MCPServerObjects since
@@ -171,7 +209,7 @@ VerificationTest[
     Length[MCPServerObjects[]] >= 0,
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerObject-ConfirmServersExist@@Tests/MCPServerObject.wlt:170,1-175,2"
+    TestID   -> "MCPServerObject-ConfirmServersExist@@Tests/MCPServerObject.wlt:208,1-213,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -181,7 +219,7 @@ VerificationTest[
     DeleteObject @ server,
     Null,
     SameTest -> MatchQ,
-    TestID   -> "MCPServerObject-DeleteObject@@Tests/MCPServerObject.wlt:180,1-185,2"
+    TestID   -> "MCPServerObject-DeleteObject@@Tests/MCPServerObject.wlt:218,1-223,2"
 ]
 
 VerificationTest[
@@ -189,7 +227,7 @@ VerificationTest[
     _Failure,
     { MCPServerObject::MCPServerNotFound },
     SameTest -> MatchQ,
-    TestID   -> "MCPServerObject-VerifyDeletion@@Tests/MCPServerObject.wlt:187,1-193,2"
+    TestID   -> "MCPServerObject-VerifyDeletion@@Tests/MCPServerObject.wlt:225,1-231,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -200,7 +238,7 @@ VerificationTest[
     _Failure,
     { MCPServerObject::MCPServerNotFound },
     SameTest -> MatchQ,
-    TestID   -> "MCPServerObject-NonExistentServer@@Tests/MCPServerObject.wlt:198,1-204,2"
+    TestID   -> "MCPServerObject-NonExistentServer@@Tests/MCPServerObject.wlt:236,1-242,2"
 ]
 
 VerificationTest[
@@ -208,7 +246,7 @@ VerificationTest[
     _Failure,
     { MCPServerObject::InvalidArguments },
     SameTest -> MatchQ,
-    TestID   -> "MCPServerObject-InvalidInput@@Tests/MCPServerObject.wlt:206,1-212,2"
+    TestID   -> "MCPServerObject-InvalidInput@@Tests/MCPServerObject.wlt:244,1-250,2"
 ]
 
 VerificationTest[
@@ -216,7 +254,7 @@ VerificationTest[
     _Failure,
     { MCPServerObject::InvalidArguments },
     SameTest -> MatchQ,
-    TestID   -> "MCPServerObject-InvalidAssociation@@Tests/MCPServerObject.wlt:214,1-220,2"
+    TestID   -> "MCPServerObject-InvalidAssociation@@Tests/MCPServerObject.wlt:252,1-258,2"
 ]
 
 (* :!CodeAnalysis::BeginBlock:: *)
@@ -238,7 +276,7 @@ VerificationTest[
     $mockPaclet[ "Name" ],
     "MockMCPPacletTest",
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-MockSetup@@Tests/MCPServerObject.wlt:235,1-242,2"
+    TestID   -> "PacletServer-MockSetup@@Tests/MCPServerObject.wlt:273,1-280,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -248,42 +286,42 @@ VerificationTest[
     $pacletServer = MCPServerObject[ "MockMCPPacletTest/TestServer" ],
     _MCPServerObject? MCPServerObjectQ,
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-ObjectCreation@@Tests/MCPServerObject.wlt:247,1-252,2"
+    TestID   -> "PacletServer-ObjectCreation@@Tests/MCPServerObject.wlt:285,1-290,2"
 ]
 
 VerificationTest[
     $pacletServer[ "Name" ],
     "MockMCPPacletTest/TestServer",
     SameTest -> Equal,
-    TestID   -> "PacletServer-Name@@Tests/MCPServerObject.wlt:254,1-259,2"
+    TestID   -> "PacletServer-Name@@Tests/MCPServerObject.wlt:292,1-297,2"
 ]
 
 VerificationTest[
     $pacletServer[ "Location" ],
     _PacletObject,
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-Location@@Tests/MCPServerObject.wlt:261,1-266,2"
+    TestID   -> "PacletServer-Location@@Tests/MCPServerObject.wlt:299,1-304,2"
 ]
 
 VerificationTest[
     $pacletServer[ "Location" ][ "Name" ],
     "MockMCPPacletTest",
     SameTest -> Equal,
-    TestID   -> "PacletServer-LocationPacletName@@Tests/MCPServerObject.wlt:268,1-273,2"
+    TestID   -> "PacletServer-LocationPacletName@@Tests/MCPServerObject.wlt:306,1-311,2"
 ]
 
 VerificationTest[
     $pacletServer[ "ServerVersion" ],
     _String? StringQ,
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-ServerVersion@@Tests/MCPServerObject.wlt:275,1-280,2"
+    TestID   -> "PacletServer-ServerVersion@@Tests/MCPServerObject.wlt:313,1-318,2"
 ]
 
 VerificationTest[
     $pacletServer[ "Transport" ],
     "StandardInputOutput",
     SameTest -> Equal,
-    TestID   -> "PacletServer-Transport@@Tests/MCPServerObject.wlt:282,1-287,2"
+    TestID   -> "PacletServer-Transport@@Tests/MCPServerObject.wlt:320,1-325,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -293,14 +331,14 @@ VerificationTest[
     $pacletServer[ "ToolNames" ],
     { "MockMCPPacletTest/TestTool", "MockMCPPacletTest/DescribedTool", "MockMCPPacletTest/LLMToolTest" },
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-ToolNames@@Tests/MCPServerObject.wlt:292,1-297,2"
+    TestID   -> "PacletServer-ToolNames@@Tests/MCPServerObject.wlt:330,1-335,2"
 ]
 
 VerificationTest[
     $pacletServer[ "PromptNames" ],
     { "MockMCPPacletTest/TestPrompt" },
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-PromptNames@@Tests/MCPServerObject.wlt:299,1-304,2"
+    TestID   -> "PacletServer-PromptNames@@Tests/MCPServerObject.wlt:337,1-342,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -310,14 +348,14 @@ VerificationTest[
     MemberQ[ $pacletServer[ "Properties" ], "ToolNames" ],
     True,
     SameTest -> Equal,
-    TestID   -> "PacletServer-PropertiesIncludesToolNames@@Tests/MCPServerObject.wlt:309,1-314,2"
+    TestID   -> "PacletServer-PropertiesIncludesToolNames@@Tests/MCPServerObject.wlt:347,1-352,2"
 ]
 
 VerificationTest[
     MemberQ[ $pacletServer[ "Properties" ], "PromptNames" ],
     True,
     SameTest -> Equal,
-    TestID   -> "PacletServer-PropertiesIncludesPromptNames@@Tests/MCPServerObject.wlt:316,1-321,2"
+    TestID   -> "PacletServer-PropertiesIncludesPromptNames@@Tests/MCPServerObject.wlt:354,1-359,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -327,14 +365,14 @@ VerificationTest[
     $pacletServer[ "LLMEvaluator" ][ "Tools" ],
     { "MockMCPPacletTest/TestTool", "MockMCPPacletTest/DescribedTool", "MockMCPPacletTest/LLMToolTest" },
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-LLMEvaluatorQualifiedTools@@Tests/MCPServerObject.wlt:326,1-331,2"
+    TestID   -> "PacletServer-LLMEvaluatorQualifiedTools@@Tests/MCPServerObject.wlt:364,1-369,2"
 ]
 
 VerificationTest[
     $pacletServer[ "LLMEvaluator" ][ "MCPPrompts" ],
     { "MockMCPPacletTest/TestPrompt" },
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-LLMEvaluatorQualifiedPrompts@@Tests/MCPServerObject.wlt:333,1-338,2"
+    TestID   -> "PacletServer-LLMEvaluatorQualifiedPrompts@@Tests/MCPServerObject.wlt:371,1-376,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -344,7 +382,7 @@ VerificationTest[
     MCPServerObjectQ @ $pacletServer,
     True,
     SameTest -> Equal,
-    TestID   -> "PacletServer-MCPServerObjectQ@@Tests/MCPServerObject.wlt:343,1-348,2"
+    TestID   -> "PacletServer-MCPServerObjectQ@@Tests/MCPServerObject.wlt:381,1-386,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -355,7 +393,7 @@ VerificationTest[
     _Failure,
     { MCPServerObject::DeletePacletMCPServer },
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-DeleteObjectRefused@@Tests/MCPServerObject.wlt:353,1-359,2"
+    TestID   -> "PacletServer-DeleteObjectRefused@@Tests/MCPServerObject.wlt:391,1-397,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -366,7 +404,7 @@ VerificationTest[
     _Failure,
     { MCPServerObject::MCPServerNotFound },
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-NonExistentPaclet@@Tests/MCPServerObject.wlt:364,1-370,2"
+    TestID   -> "PacletServer-NonExistentPaclet@@Tests/MCPServerObject.wlt:402,1-408,2"
 ]
 
 VerificationTest[
@@ -374,7 +412,7 @@ VerificationTest[
     _Failure,
     { MCPServerObject::PacletServerNotFound },
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-NonExistentServer@@Tests/MCPServerObject.wlt:372,1-378,2"
+    TestID   -> "PacletServer-NonExistentServer@@Tests/MCPServerObject.wlt:410,1-416,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -385,7 +423,7 @@ VerificationTest[
     builtIn[ "ToolNames" ],
     _List,
     SameTest -> MatchQ,
-    TestID   -> "ToolNames-BuiltInServer@@Tests/MCPServerObject.wlt:383,1-389,2"
+    TestID   -> "ToolNames-BuiltInServer@@Tests/MCPServerObject.wlt:421,1-427,2"
 ]
 
 VerificationTest[
@@ -393,7 +431,7 @@ VerificationTest[
     builtIn[ "PromptNames" ],
     _List,
     SameTest -> MatchQ,
-    TestID   -> "PromptNames-BuiltInServer@@Tests/MCPServerObject.wlt:391,1-397,2"
+    TestID   -> "PromptNames-BuiltInServer@@Tests/MCPServerObject.wlt:429,1-435,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -404,7 +442,7 @@ VerificationTest[
     AssociationQ @ props && props[ "Name" ] === "MockMCPPacletTest/TestServer",
     True,
     SameTest -> Equal,
-    TestID   -> "PacletServer-MultipleProperties@@Tests/MCPServerObject.wlt:402,1-408,2"
+    TestID   -> "PacletServer-MultipleProperties@@Tests/MCPServerObject.wlt:440,1-446,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -414,14 +452,14 @@ VerificationTest[
     Wolfram`AgentTools`MCPServerObject`Private`convertStringTools0[ "MockMCPPacletTest/TestTool" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "ConvertStringTools0-PacletTool@@Tests/MCPServerObject.wlt:413,1-418,2"
+    TestID   -> "ConvertStringTools0-PacletTool@@Tests/MCPServerObject.wlt:451,1-456,2"
 ]
 
 VerificationTest[
     Wolfram`AgentTools`MCPServerObject`Private`convertStringTools0[ "MockMCPPacletTest/DescribedTool" ],
     _LLMTool,
     SameTest -> MatchQ,
-    TestID   -> "ConvertStringTools0-PacletDescribedTool@@Tests/MCPServerObject.wlt:420,1-425,2"
+    TestID   -> "ConvertStringTools0-PacletDescribedTool@@Tests/MCPServerObject.wlt:458,1-463,2"
 ]
 
 (* Built-in tools still take precedence over paclet resolution *)
@@ -432,7 +470,7 @@ VerificationTest[
     ],
     True,
     SameTest -> Equal,
-    TestID   -> "ConvertStringTools0-BuiltInPrecedence@@Tests/MCPServerObject.wlt:428,1-436,2"
+    TestID   -> "ConvertStringTools0-BuiltInPrecedence@@Tests/MCPServerObject.wlt:466,1-474,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -442,7 +480,7 @@ VerificationTest[
     Wolfram`AgentTools`MCPServerObject`Private`normalizePromptData[ "MockMCPPacletTest/TestPrompt" ],
     KeyValuePattern[ { "Name" -> "TestPrompt", "Type" -> "Text" } ],
     SameTest -> MatchQ,
-    TestID   -> "NormalizePromptData-PacletPrompt@@Tests/MCPServerObject.wlt:441,1-446,2"
+    TestID   -> "NormalizePromptData-PacletPrompt@@Tests/MCPServerObject.wlt:479,1-484,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -452,7 +490,7 @@ VerificationTest[
     $pacletServer[ "Tools" ],
     { _LLMTool, _LLMTool, _LLMTool },
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-GetTools@@Tests/MCPServerObject.wlt:451,1-456,2"
+    TestID   -> "PacletServer-GetTools@@Tests/MCPServerObject.wlt:489,1-494,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -462,7 +500,7 @@ VerificationTest[
     $pacletServer[ "PromptData" ],
     { KeyValuePattern[ { "Name" -> "TestPrompt", "Type" -> "Text" } ] },
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-GetPromptData@@Tests/MCPServerObject.wlt:461,1-466,2"
+    TestID   -> "PacletServer-GetPromptData@@Tests/MCPServerObject.wlt:499,1-504,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -472,7 +510,7 @@ VerificationTest[
     $pacletServer[ "LLMConfiguration" ],
     _LLMConfiguration,
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-LLMConfiguration@@Tests/MCPServerObject.wlt:471,1-476,2"
+    TestID   -> "PacletServer-LLMConfiguration@@Tests/MCPServerObject.wlt:509,1-514,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -485,7 +523,7 @@ VerificationTest[
     _Failure,
     { AgentTools::PacletToolNotFound },
     SameTest -> MatchQ,
-    TestID   -> "ConvertStringTools0-PacletToolNotFound@@Tests/MCPServerObject.wlt:482,1-489,2"
+    TestID   -> "ConvertStringTools0-PacletToolNotFound@@Tests/MCPServerObject.wlt:520,1-527,2"
 ]
 
 VerificationTest[
@@ -494,7 +532,7 @@ VerificationTest[
     _Failure,
     { AgentTools::PacletPromptNotFound },
     SameTest -> MatchQ,
-    TestID   -> "NormalizePromptData-PacletPromptNotFound@@Tests/MCPServerObject.wlt:491,1-498,2"
+    TestID   -> "NormalizePromptData-PacletPromptNotFound@@Tests/MCPServerObject.wlt:529,1-536,2"
 ]
 
 VerificationTest[
@@ -503,7 +541,7 @@ VerificationTest[
     _Failure,
     { AgentTools::PacletNotInstalled },
     SameTest -> MatchQ,
-    TestID   -> "ConvertStringTools0-PacletNotInstalled@@Tests/MCPServerObject.wlt:500,1-507,2"
+    TestID   -> "ConvertStringTools0-PacletNotInstalled@@Tests/MCPServerObject.wlt:538,1-545,2"
 ]
 
 VerificationTest[
@@ -512,7 +550,7 @@ VerificationTest[
     _Failure,
     { AgentTools::PacletNotInstalled },
     SameTest -> MatchQ,
-    TestID   -> "NormalizePromptData-PacletNotInstalled@@Tests/MCPServerObject.wlt:509,1-516,2"
+    TestID   -> "NormalizePromptData-PacletNotInstalled@@Tests/MCPServerObject.wlt:547,1-554,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -531,7 +569,7 @@ VerificationTest[
     _Failure,
     { AgentTools::PacletNotInstalled },
     SameTest -> MatchQ,
-    TestID   -> "getToolList-PacletNotInstalled@@Tests/MCPServerObject.wlt:521,1-535,2"
+    TestID   -> "getToolList-PacletNotInstalled@@Tests/MCPServerObject.wlt:559,1-573,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -541,7 +579,7 @@ VerificationTest[
     Wolfram`AgentTools`MCPServerObject`Private`validateTool[ "MockMCPPacletTest/TestTool" ],
     "MockMCPPacletTest/TestTool",
     SameTest -> Equal,
-    TestID   -> "ValidateTool-PacletPassthrough@@Tests/MCPServerObject.wlt:540,1-545,2"
+    TestID   -> "ValidateTool-PacletPassthrough@@Tests/MCPServerObject.wlt:578,1-583,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -551,7 +589,7 @@ VerificationTest[
     Wolfram`AgentTools`MCPServerObject`Private`validateMCPPrompt[ "MockMCPPacletTest/TestPrompt" ],
     "MockMCPPacletTest/TestPrompt",
     SameTest -> Equal,
-    TestID   -> "ValidateMCPPrompt-PacletPassthrough@@Tests/MCPServerObject.wlt:550,1-555,2"
+    TestID   -> "ValidateMCPPrompt-PacletPassthrough@@Tests/MCPServerObject.wlt:588,1-593,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -562,14 +600,14 @@ VerificationTest[
     MemberQ[ #[ "Name" ] & /@ $allServers, "MockMCPPacletTest/TestServer" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerObjects-IncludesPacletServers@@Tests/MCPServerObject.wlt:560,1-566,2"
+    TestID   -> "MCPServerObjects-IncludesPacletServers@@Tests/MCPServerObject.wlt:598,1-604,2"
 ]
 
 VerificationTest[
     MatchQ[ $allServers, { ___MCPServerObject? MCPServerObjectQ } ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerObjects-AllAreValidObjects@@Tests/MCPServerObject.wlt:568,1-573,2"
+    TestID   -> "MCPServerObjects-AllAreValidObjects@@Tests/MCPServerObject.wlt:606,1-611,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -580,7 +618,7 @@ VerificationTest[
     MemberQ[ #[ "Name" ] & /@ $withBuiltIn, "WolframLanguage" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerObjects-IncludeBuiltIn@@Tests/MCPServerObject.wlt:578,1-584,2"
+    TestID   -> "MCPServerObjects-IncludeBuiltIn@@Tests/MCPServerObject.wlt:616,1-622,2"
 ]
 
 VerificationTest[
@@ -589,7 +627,7 @@ VerificationTest[
     !MemberQ[ defaultNames, "WolframLanguage" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerObjects-ExcludesBuiltInByDefault@@Tests/MCPServerObject.wlt:586,1-593,2"
+    TestID   -> "MCPServerObjects-ExcludesBuiltInByDefault@@Tests/MCPServerObject.wlt:624,1-631,2"
 ]
 
 VerificationTest[
@@ -599,7 +637,7 @@ VerificationTest[
     AllTrue[ { "Wolfram", "WolframLanguage", "WolframAlpha" }, MemberQ[ builtInNames, # ] & ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerObjects-IncludeBuiltInWithAll@@Tests/MCPServerObject.wlt:595,1-603,2"
+    TestID   -> "MCPServerObjects-IncludeBuiltInWithAll@@Tests/MCPServerObject.wlt:633,1-641,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -610,7 +648,7 @@ VerificationTest[
     #[ "Name" ] & /@ $mockFiltered,
     { "MockMCPPacletTest/TestServer" },
     SameTest -> MatchQ,
-    TestID   -> "MCPServerObjects-PatternMatchesPacletServers@@Tests/MCPServerObject.wlt:608,1-614,2"
+    TestID   -> "MCPServerObjects-PatternMatchesPacletServers@@Tests/MCPServerObject.wlt:646,1-652,2"
 ]
 
 VerificationTest[
@@ -620,7 +658,7 @@ VerificationTest[
     MemberQ[ wolfNames, "Wolfram" ] && MemberQ[ wolfNames, "WolframLanguage" ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerObjects-PatternWithIncludeBuiltIn@@Tests/MCPServerObject.wlt:616,1-624,2"
+    TestID   -> "MCPServerObjects-PatternWithIncludeBuiltIn@@Tests/MCPServerObject.wlt:654,1-662,2"
 ]
 
 VerificationTest[
@@ -628,7 +666,7 @@ VerificationTest[
     MCPServerObjects[ "ZZZNonExistentPattern12345*" ],
     { },
     SameTest -> MatchQ,
-    TestID   -> "MCPServerObjects-PatternNoMatch@@Tests/MCPServerObject.wlt:626,1-632,2"
+    TestID   -> "MCPServerObjects-PatternNoMatch@@Tests/MCPServerObject.wlt:664,1-670,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -640,7 +678,7 @@ VerificationTest[
     MatchQ[ $withRemote, { ___MCPServerObject } ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerObjects-IncludeRemotePacletsNoError@@Tests/MCPServerObject.wlt:637,1-644,2"
+    TestID   -> "MCPServerObjects-IncludeRemotePacletsNoError@@Tests/MCPServerObject.wlt:675,1-682,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -654,7 +692,7 @@ VerificationTest[
         UpdatePacletSites      -> Automatic
     },
     SameTest -> MatchQ,
-    TestID   -> "MCPServerObjects-OptionsDeclaration@@Tests/MCPServerObject.wlt:649,1-658,2"
+    TestID   -> "MCPServerObjects-OptionsDeclaration@@Tests/MCPServerObject.wlt:687,1-696,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -667,7 +705,7 @@ VerificationTest[
     names === DeleteDuplicates[ names ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerObjects-NoDuplicates@@Tests/MCPServerObject.wlt:663,1-671,2"
+    TestID   -> "MCPServerObjects-NoDuplicates@@Tests/MCPServerObject.wlt:701,1-709,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -677,7 +715,7 @@ VerificationTest[
     MCPServerObjects[ All ] === MCPServerObjects[ ],
     True,
     SameTest -> Equal,
-    TestID   -> "MCPServerObjects-AllEquivalence@@Tests/MCPServerObject.wlt:676,1-681,2"
+    TestID   -> "MCPServerObjects-AllEquivalence@@Tests/MCPServerObject.wlt:714,1-719,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -688,7 +726,7 @@ VerificationTest[
     Wolfram`AgentTools`Common`clearPacletDefinitionCache[ ],
     <| |>,
     SameTest -> MatchQ,
-    TestID   -> "PacletServer-MockCleanup@@Tests/MCPServerObject.wlt:686,1-692,2"
+    TestID   -> "PacletServer-MockCleanup@@Tests/MCPServerObject.wlt:724,1-730,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/MCPServerTestUtilities.wl
+++ b/Tests/MCPServerTestUtilities.wl
@@ -76,7 +76,8 @@ GetMCPEnvironment[ serverName_String ] := Module[ { env, keys, usable },
 
     usable = KeyTake[ env, keys ];
 
-    <| usable, "MCP_SERVER_NAME" -> serverName |>
+    (* Test servers must never record or submit usage data (see docs/usage-data.md) *)
+    <| usable, "MCP_SERVER_NAME" -> serverName, "SUBMIT_USAGE_DATA" -> "false" |>
 ];
 
 (* ::**************************************************************************************************************:: *)
@@ -85,7 +86,8 @@ GetMCPEnvironment[ serverName_String ] := Module[ { env, keys, usable },
 StartMCPTestServer // ClearAll;
 StartMCPTestServer // Options = {
     "ServerName" -> "WolframLanguage",
-    "DevelopmentMode" -> True
+    "DevelopmentMode" -> True,
+    "Environment" -> <| |> (* extra or overriding environment variables for the server process *)
 };
 
 StartMCPTestServer[ opts: OptionsPattern[ ] ] := Catch @ Module[
@@ -96,7 +98,7 @@ StartMCPTestServer[ opts: OptionsPattern[ ] ] := Catch @ Module[
 
     serverName = OptionValue[ "ServerName" ];
     devMode = OptionValue[ "DevelopmentMode" ];
-    env = GetMCPEnvironment @ serverName;
+    env = <| GetMCPEnvironment @ serverName, Replace[ OptionValue[ "Environment" ], Except[ _Association ] -> <| |> ] |>;
 
     cmd = If[ TrueQ @ devMode,
         getDevelopmentModeCommand[ ],

--- a/Tests/PreferencesContent.wlt
+++ b/Tests/PreferencesContent.wlt
@@ -39,3 +39,72 @@ VerificationTest[
     SameTest -> MatchQ,
     TestID   -> "CreatePreferencesContent-InvalidArguments@@Tests/PreferencesContent.wlt:35,1-41,2"
 ]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Usage Data Opt-Out*)
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* Without a front end there is no stored setting, which means the default: usage data is shared and deployments
+   made from the panel get no extra options. *)
+VerificationTest[
+    Wolfram`AgentTools`PreferencesContent`Private`usageDataOptOutQ[ ],
+    False,
+    SameTest -> SameQ,
+    TestID   -> "PreferencesContent-UsageDataOptOutQ-Default@@Tests/PreferencesContent.wlt:51,1-56,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`PreferencesContent`Private`usageDataDeployOptions[ ],
+    { },
+    SameTest -> SameQ,
+    TestID   -> "PreferencesContent-UsageDataDeployOptions-Default@@Tests/PreferencesContent.wlt:58,1-63,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`AgentTools`PreferencesContent`Private`usageDataOptOutQ = True & },
+        Wolfram`AgentTools`PreferencesContent`Private`usageDataDeployOptions[ ]
+    ],
+    { "SubmitUsageData" -> False },
+    SameTest -> SameQ,
+    TestID   -> "PreferencesContent-UsageDataDeployOptions-OptedOut@@Tests/PreferencesContent.wlt:65,1-72,2"
+]
+
+(* Re-deploying an existing deployment applies the current setting and keeps the deployment's other options *)
+VerificationTest[
+    Module[ { configFile, dep, optedOut, env1, options, optedIn, env2 },
+        configFile = File @ FileNameJoin @ { $TemporaryDirectory, StringJoin[ "usage_prefs_", CreateUUID[], ".json" ] };
+        dep = DeployAgentTools[ configFile, "Wolfram", "ApplicationName" -> "ClaudeCode", "EnableMCPApps" -> False, "VerifyLLMKit" -> False ];
+
+        optedOut = Block[ { Wolfram`AgentTools`PreferencesContent`Private`usageDataOptOutQ = True & },
+            Wolfram`AgentTools`PreferencesContent`Private`redeployForUsageData @ dep
+        ];
+        env1 = Developer`ReadRawJSONString[ ReadString @ First @ configFile ][ "mcpServers", "Wolfram", "env" ];
+        options = Normal @ optedOut[ "MCP", "Options" ];
+
+        optedIn = Block[ { Wolfram`AgentTools`PreferencesContent`Private`usageDataOptOutQ = False & },
+            Wolfram`AgentTools`PreferencesContent`Private`redeployForUsageData @ optedOut
+        ];
+        env2 = Developer`ReadRawJSONString[ ReadString @ First @ configFile ][ "mcpServers", "Wolfram", "env" ];
+
+        DeleteObject[ optedIn ];
+        Quiet @ DeleteFile @ First @ configFile;
+
+        {
+            Head @ optedOut,
+            Lookup[ env1, "SUBMIT_USAGE_DATA", Missing[ "Absent" ] ],
+            Lookup[ env1, "MCP_APPS_ENABLED", Missing[ "Absent" ] ],
+            MemberQ[ options, "EnableMCPApps" -> False ],
+            MemberQ[ options, "SubmitUsageData" -> False ],
+            Head @ optedIn,
+            Lookup[ env2, "SUBMIT_USAGE_DATA", Missing[ "Absent" ] ],
+            Lookup[ env2, "MCP_APPS_ENABLED", Missing[ "Absent" ] ]
+        }
+    ],
+    { AgentToolsDeployment, "false", "false", True, True, AgentToolsDeployment, Missing[ "Absent" ], "false" },
+    SameTest -> SameQ,
+    TestID   -> "PreferencesContent-RedeployForUsageData@@Tests/PreferencesContent.wlt:75,1-108,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/UsageData.wlt
+++ b/Tests/UsageData.wlt
@@ -1,0 +1,849 @@
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+VerificationTest[
+    Needs[ "Wolfram`AgentToolsTests`", FileNameJoin @ { DirectoryName @ $TestFileName, "Common.wl" } ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "GetDefinitions@@Tests/UsageData.wlt:7,1-12,2"
+]
+
+VerificationTest[
+    Needs[ "Wolfram`AgentTools`" ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "LoadContext@@Tests/UsageData.wlt:14,1-19,2"
+]
+
+VerificationTest[
+    Get[ FileNameJoin @ { DirectoryName @ $TestFileName, "MCPServerTestUtilities.wl" } ];
+    (* Set the source directory so the test utilities can find Scripts/StartMCPServer.wls *)
+    Wolfram`AgentToolsTests`MCPServerTestUtilities`$MCPTestSourceDirectory = DirectoryName[ $TestFileName, 2 ],
+    _String? DirectoryQ,
+    SameTest -> MatchQ,
+    TestID   -> "LoadTestUtilities@@Tests/UsageData.wlt:21,1-28,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Fixtures*)
+usageDataEnabledQ   = Wolfram`AgentTools`Server`UsageData`Private`usageDataEnabledQ;
+booleanString       = Wolfram`AgentTools`Server`UsageData`Private`booleanString;
+initializeUsageData = Wolfram`AgentTools`Server`initializeUsageData;
+recordUsageData     = Wolfram`AgentTools`Server`recordUsageData;
+stopUsageDataTasks  = Wolfram`AgentTools`Server`UsageData`Private`stopUsageDataTasks;
+usageDataPayload    = Wolfram`AgentTools`Server`UsageData`Private`usageDataPayload;
+usageDataJSON       = Wolfram`AgentTools`Server`UsageData`Private`usageDataJSON;
+touchUsageStatsFile = Wolfram`AgentTools`Server`UsageData`Private`touchUsageStatsFile;
+staleUsageFileQ     = Wolfram`AgentTools`Server`UsageData`Private`staleUsageFileQ;
+fileAge             = Wolfram`AgentTools`Server`UsageData`Private`fileAge;
+submitUsageData     = Wolfram`AgentTools`Server`UsageData`Private`submitUsageData;
+submitUsagePayload  = Wolfram`AgentTools`Server`UsageData`Private`submitUsagePayload;
+
+usageStatsFile[ ] := Wolfram`AgentTools`Server`UsageData`Private`$usageStatsFile;
+usageDataPath[ ]  := Wolfram`AgentTools`Server`UsageData`Private`$usageDataPath;
+sessionData[ ]    := Developer`ReadWXFFile @ usageStatsFile[ ];
+usageEvents[ ]    := Internal`BagPart[ Wolfram`AgentTools`Server`$usageEvents, All ];
+
+$testTool = LLMTool[ "PrimeFinder", { "n" -> "Integer" }, Prime[ #n ] & ];
+
+makeTempRoot[ ] := FileNameJoin @ { $TemporaryDirectory, "AgentToolsUsageData_" <> CreateUUID[ ] };
+
+(* Evaluates body as if inside a tracked server session (fresh session ID, data under a temporary root directory),
+   then removes the directory again. *)
+withUsageSession // Attributes = { HoldFirst };
+withUsageSession[ body_ ] :=
+    Module[ { root, result },
+        root = makeTempRoot[ ];
+        result = Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath                              = root,
+                Wolfram`AgentTools`Server`$usageDataEnabled                      = True,
+                Wolfram`AgentTools`Server`$mcpSessionID                          = CreateUUID[ ],
+                Wolfram`AgentTools`Server`$mcpClientInformation                  = Null,
+                Wolfram`AgentTools`Server`$usageEvents                           = Internal`Bag[ ],
+                Wolfram`AgentTools`Server`UsageData`Private`$usageDataServerName = "TestServer",
+                Wolfram`AgentTools`Server`$llmTools                              = <| "PrimeFinder" -> $testTool |>,
+                Wolfram`AgentTools`Server`$promptLookup                          = <| "Greet" -> <| "Name" -> "Greet", "Type" -> "Text", "Content" -> "Hello" |> |>
+            },
+            body
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        result
+    ];
+
+(* A session file for a session named `name` whose last modification was `age` ago *)
+makeUsageFile[ dir_, name_, age_ ] :=
+    With[ { file = FileNameJoin @ { dir, name <> ".wxf" } },
+        Developer`WriteWXFFile[ file, <| "MCPSessionID" -> name, "Events" -> { } |> ];
+        SetFileDate[ file, Now - age, "Modification" ];
+        file
+    ];
+
+$initMessage = <|
+    "jsonrpc" -> "2.0",
+    "id"      -> 0,
+    "method"  -> "initialize",
+    "params"  -> <|
+        "clientInfo"      -> <| "name" -> "test-client", "version" -> "1.2.3" |>,
+        "protocolVersion" -> "2025-11-25",
+        "capabilities"    -> <| "roots" -> <| |> |>
+    |>
+|>;
+
+$initResponse = <| "jsonrpc" -> "2.0", "id" -> 0, "result" -> <| "protocolVersion" -> "2025-11-25" |> |>;
+
+$toolCallMessage = <|
+    "jsonrpc" -> "2.0",
+    "id"      -> 1,
+    "method"  -> "tools/call",
+    "params"  -> <| "name" -> "PrimeFinder", "arguments" -> <| "n" -> 12345 |> |>
+|>;
+
+$toolCallResponse = <|
+    "jsonrpc" -> "2.0",
+    "id"      -> 1,
+    "result"  -> <| "content" -> { <| "type" -> "text", "text" -> "SECRET-RESULT" |> }, "isError" -> False |>
+|>;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Configuration*)
+VerificationTest[
+    Wolfram`AgentTools`Server`UsageData`Private`$usageDataEndpoint,
+    "https://www.wolframcloud.com/obj/wolframai-content/api/1.0/usage",
+    SameTest -> SameQ,
+    TestID   -> "UsageData-Endpoint@@Tests/UsageData.wlt:115,1-120,2"
+]
+
+(* Outside a server session nothing is tracked *)
+VerificationTest[
+    {
+        Wolfram`AgentTools`Server`$usageDataEnabled,
+        Wolfram`AgentTools`Server`$mcpSessionID,
+        recordUsageData[ "tools/call", $toolCallMessage, $toolCallResponse ]
+    },
+    { False, None, Null },
+    SameTest -> SameQ,
+    TestID   -> "UsageData-DisabledOutsideServer@@Tests/UsageData.wlt:123,1-132,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*usageDataEnabledQ*)
+VerificationTest[
+    booleanString /@ { "true", "TRUE", " yes ", "on", "1", "false", "No", "off", "0", "", "maybe", 1, None },
+    { True, True, True, True, True, False, False, False, False, None, None, None, None },
+    SameTest -> SameQ,
+    TestID   -> "UsageData-BooleanString@@Tests/UsageData.wlt:137,1-142,2"
+]
+
+$customServer = CreateMCPServer[
+    "TestServer_UsageData_" <> CreateUUID[ ],
+    LLMConfiguration @ <| "Tools" -> { $testTool } |>
+];
+
+(* Without SUBMIT_USAGE_DATA the server's "EnableUsageData" property decides *)
+VerificationTest[
+    environmentBlock[ "SUBMIT_USAGE_DATA" -> None,
+        {
+            usageDataEnabledQ @ MCPServerObject[ "Wolfram" ],
+            AllTrue[ Values @ $DefaultMCPServers, usageDataEnabledQ ],
+            usageDataEnabledQ @ $customServer,
+            usageDataEnabledQ @ None
+        }
+    ],
+    { True, True, False, False },
+    SameTest -> SameQ,
+    TestID   -> "UsageDataEnabledQ-Property@@Tests/UsageData.wlt:150,1-162,2"
+]
+
+(* An explicit boolean in SUBMIT_USAGE_DATA takes precedence over the property in both directions *)
+VerificationTest[
+    environmentBlock[ "SUBMIT_USAGE_DATA" -> "false",
+        { usageDataEnabledQ @ MCPServerObject[ "Wolfram" ], usageDataEnabledQ @ $customServer }
+    ],
+    { False, False },
+    SameTest -> SameQ,
+    TestID   -> "UsageDataEnabledQ-EnvironmentFalse@@Tests/UsageData.wlt:165,1-172,2"
+]
+
+VerificationTest[
+    environmentBlock[ "SUBMIT_USAGE_DATA" -> "true",
+        { usageDataEnabledQ @ MCPServerObject[ "Wolfram" ], usageDataEnabledQ @ $customServer }
+    ],
+    { True, True },
+    SameTest -> SameQ,
+    TestID   -> "UsageDataEnabledQ-EnvironmentTrue@@Tests/UsageData.wlt:174,1-181,2"
+]
+
+(* A value that is not a boolean is ignored *)
+VerificationTest[
+    environmentBlock[ "SUBMIT_USAGE_DATA" -> "maybe",
+        { usageDataEnabledQ @ MCPServerObject[ "Wolfram" ], usageDataEnabledQ @ $customServer }
+    ],
+    { True, False },
+    SameTest -> SameQ,
+    TestID   -> "UsageDataEnabledQ-EnvironmentNonBoolean@@Tests/UsageData.wlt:184,1-191,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*initializeUsageData*)
+
+(* A tracked server: fresh session ID, tracking enabled, keep-alive and submission tasks started, but no file yet *)
+VerificationTest[
+    Module[ { root, result },
+        root = makeTempRoot[ ];
+        result = Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath                             = root,
+                Wolfram`AgentTools`Server`$usageDataEnabled                     = False,
+                Wolfram`AgentTools`Server`$mcpSessionID                         = None,
+                Wolfram`AgentTools`Server`$mcpClientInformation                 = Null,
+                Wolfram`AgentTools`Server`$usageEvents                          = Internal`Bag[ ],
+                Wolfram`AgentTools`Server`UsageData`Private`$usageKeepAliveTask = None,
+                Wolfram`AgentTools`Server`UsageData`Private`$usageSubmitTask    = None
+            },
+            environmentBlock[ "SUBMIT_USAGE_DATA" -> None,
+                WithCleanup[
+                    {
+                        initializeUsageData @ MCPServerObject[ "Wolfram" ],
+                        Wolfram`AgentTools`Server`$usageDataEnabled,
+                        StringMatchQ[ Wolfram`AgentTools`Server`$mcpSessionID, Repeated[ HexadecimalCharacter | "-" ] ],
+                        Head @ Wolfram`AgentTools`Server`UsageData`Private`$usageKeepAliveTask,
+                        Head @ Wolfram`AgentTools`Server`UsageData`Private`$usageSubmitTask,
+                        Wolfram`AgentTools`Server`UsageData`Private`$usageDataServerName,
+                        DirectoryQ @ usageDataPath[ ]
+                    },
+                    stopUsageDataTasks[ ]
+                ]
+            ]
+        ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        result
+    ],
+    { True, True, True, TaskObject, TaskObject, "Wolfram", False },
+    SameTest -> SameQ,
+    TestID   -> "InitializeUsageData-Enabled@@Tests/UsageData.wlt:198,1-232,2"
+]
+
+(* An untracked server still gets a session ID, but nothing else happens *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Server`$usageDataEnabled                     = False,
+            Wolfram`AgentTools`Server`$mcpSessionID                         = None,
+            Wolfram`AgentTools`Server`UsageData`Private`$usageKeepAliveTask = None,
+            Wolfram`AgentTools`Server`UsageData`Private`$usageSubmitTask    = None
+        },
+        environmentBlock[ "SUBMIT_USAGE_DATA" -> None,
+            {
+                initializeUsageData @ $customServer,
+                Wolfram`AgentTools`Server`$usageDataEnabled,
+                StringQ @ Wolfram`AgentTools`Server`$mcpSessionID,
+                Wolfram`AgentTools`Server`UsageData`Private`$usageKeepAliveTask,
+                Wolfram`AgentTools`Server`UsageData`Private`$usageSubmitTask
+            }
+        ]
+    ],
+    { False, False, True, None, None },
+    SameTest -> SameQ,
+    TestID   -> "InitializeUsageData-Disabled@@Tests/UsageData.wlt:235,1-256,2"
+]
+
+(* Opting out via the environment wins over the built-in server's property *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Server`$usageDataEnabled                     = False,
+            Wolfram`AgentTools`Server`$mcpSessionID                         = None,
+            Wolfram`AgentTools`Server`UsageData`Private`$usageKeepAliveTask = None,
+            Wolfram`AgentTools`Server`UsageData`Private`$usageSubmitTask    = None
+        },
+        environmentBlock[ "SUBMIT_USAGE_DATA" -> "false",
+            { initializeUsageData @ MCPServerObject[ "Wolfram" ], Wolfram`AgentTools`Server`$usageDataEnabled }
+        ]
+    ],
+    { False, False },
+    SameTest -> SameQ,
+    TestID   -> "InitializeUsageData-OptedOut@@Tests/UsageData.wlt:259,1-274,2"
+]
+
+(* Initialization never breaks server startup, even with a bogus server *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Server`$usageDataEnabled                     = False,
+            Wolfram`AgentTools`Server`$mcpSessionID                         = None,
+            Wolfram`AgentTools`Server`UsageData`Private`$usageKeepAliveTask = None,
+            Wolfram`AgentTools`Server`UsageData`Private`$usageSubmitTask    = None
+        },
+        environmentBlock[ "SUBMIT_USAGE_DATA" -> None, initializeUsageData @ None ]
+    ],
+    False,
+    SameTest -> SameQ,
+    TestID   -> "InitializeUsageData-InvalidServer@@Tests/UsageData.wlt:277,1-290,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Recording*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Client Information*)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "initialize", $initMessage, $initResponse ];
+        With[ { data = sessionData[ ] },
+            {
+                data[ "MCPSessionID" ] === Wolfram`AgentTools`Server`$mcpSessionID,
+                data[ "ClientInformation" ] === $initMessage[ "params" ],
+                data[ "Events" ],
+                data[ "ServerName" ],
+                data[ "PacletVersion" ] === Wolfram`AgentTools`Common`$pacletVersion,
+                data[ "WolframVersion" ] === $Version,
+                data[ "SystemID" ] === $SystemID,
+                Abs[ data[ "LastUpdated" ] - AbsoluteTime[ TimeZone -> 0 ] ] < 60,
+                Sort @ Keys @ data
+            }
+        ]
+    ],
+    {
+        True, True, { }, "TestServer", True, True, True, True,
+        { "ClientInformation", "Events", "LastUpdated", "MCPSessionID", "PacletVersion", "ServerName", "SystemID", "WolframVersion" }
+    },
+    SameTest -> SameQ,
+    TestID   -> "RecordUsageData-Initialize@@Tests/UsageData.wlt:299,1-322,2"
+]
+
+(* The session file is named after the session ID and lives in $rootPath/UsageData *)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "initialize", $initMessage, $initResponse ];
+        {
+            FileExistsQ @ usageStatsFile[ ],
+            FileBaseName @ usageStatsFile[ ] === Wolfram`AgentTools`Server`$mcpSessionID,
+            DirectoryName @ usageStatsFile[ ] === FileNameJoin @ { Wolfram`AgentTools`Common`$rootPath, "UsageData" } <> $PathnameSeparator
+        }
+    ],
+    { True, True, True },
+    SameTest -> SameQ,
+    TestID   -> "RecordUsageData-SessionFileLocation@@Tests/UsageData.wlt:325,1-337,2"
+]
+
+(* Malformed initialize parameters are stored as Null rather than failing *)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "initialize", <| "method" -> "initialize", "params" -> "bogus" |>, $initResponse ];
+        sessionData[ ][ "ClientInformation" ]
+    ],
+    Null,
+    SameTest -> SameQ,
+    TestID   -> "RecordUsageData-InitializeInvalidParams@@Tests/UsageData.wlt:340,1-348,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Tool Calls*)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "tools/call", $toolCallMessage, $toolCallResponse ];
+        sessionData[ ][ "Events" ]
+    ],
+    { KeyValuePattern @ { "Type" -> "ToolCall", "Name" -> "PrimeFinder", "Success" -> True, "Timestamp" -> _Real } },
+    SameTest -> MatchQ,
+    TestID   -> "RecordUsageData-ToolCallSuccess@@Tests/UsageData.wlt:353,1-361,2"
+]
+
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "tools/call", $toolCallMessage, $toolCallResponse ];
+        With[ { event = First @ sessionData[ ][ "Events" ] },
+            { Sort @ Keys @ event, Abs[ event[ "Timestamp" ] - AbsoluteTime[ TimeZone -> 0 ] ] < 60 }
+        ]
+    ],
+    { { "Name", "Success", "Timestamp", "Type" }, True },
+    SameTest -> SameQ,
+    TestID   -> "RecordUsageData-ToolCallEventShape@@Tests/UsageData.wlt:363,1-373,2"
+]
+
+(* Neither arguments nor results are recorded *)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "tools/call", $toolCallMessage, $toolCallResponse ];
+        With[ { data = sessionData[ ] },
+            { FreeQ[ data, 12345 ], FreeQ[ data, "arguments" ], FreeQ[ data, "SECRET-RESULT" ], FreeQ[ data, "content" ] }
+        ]
+    ],
+    { True, True, True, True },
+    SameTest -> SameQ,
+    TestID   -> "RecordUsageData-ToolCallNoParameters@@Tests/UsageData.wlt:376,1-386,2"
+]
+
+(* Failures: tool errors, unknown tools (name not recorded), internal failures, and JSON-RPC errors *)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "tools/call", $toolCallMessage, <| "result" -> <| "content" -> { }, "isError" -> True |> |> ];
+        recordUsageData[ "tools/call", <| "params" -> <| "name" -> "NoSuchTool", "arguments" -> <| "n" -> 1 |> |> |>, <| "result" -> <| "content" -> { }, "isError" -> True |> |> ];
+        recordUsageData[ "tools/call", $toolCallMessage, Failure[ "AgentTools::Internal", <| |> ] ];
+        recordUsageData[ "tools/call", $toolCallMessage, <| "error" -> <| "code" -> -32603, "message" -> "Internal error" |> |> ];
+        recordUsageData[ "tools/call", <| "params" -> <| |> |>, <| "result" -> <| "isError" -> True |> |> ];
+        Lookup[ sessionData[ ][ "Events" ], { "Name", "Success" } ]
+    ],
+    { { "PrimeFinder", False }, { Null, False }, { "PrimeFinder", False }, { "PrimeFinder", False }, { Null, False } },
+    SameTest -> SameQ,
+    TestID   -> "RecordUsageData-ToolCallFailures@@Tests/UsageData.wlt:389,1-401,2"
+]
+
+(* Events accumulate in order, and the file always holds all of them *)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "initialize", $initMessage, $initResponse ];
+        recordUsageData[ "tools/call", $toolCallMessage, $toolCallResponse ];
+        recordUsageData[ "tools/call", $toolCallMessage, <| "result" -> <| "content" -> { }, "isError" -> True |> |> ];
+        recordUsageData[ "tools/call", $toolCallMessage, $toolCallResponse ];
+        { Lookup[ sessionData[ ][ "Events" ], "Success" ], Length @ usageEvents[ ], sessionData[ ][ "ClientInformation" ] === $initMessage[ "params" ] }
+    ],
+    { { True, False, True }, 3, True },
+    SameTest -> SameQ,
+    TestID   -> "RecordUsageData-EventsAccumulate@@Tests/UsageData.wlt:404,1-415,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Prompts*)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "prompts/get", <| "params" -> <| "name" -> "Greet", "arguments" -> <| "who" -> "SECRET" |> |> |>, <| "result" -> <| "messages" -> { } |> |> ];
+        recordUsageData[ "prompts/get", <| "params" -> <| "name" -> "NoSuchPrompt" |> |>, Failure[ "AgentTools::Internal", <| |> ] ];
+        With[ { data = sessionData[ ] },
+            { Lookup[ data[ "Events" ], { "Type", "Name", "Success" } ], FreeQ[ data, "SECRET" ], FreeQ[ data, "who" ] }
+        ]
+    ],
+    { { { "PromptGet", "Greet", True }, { "PromptGet", Null, False } }, True, True },
+    SameTest -> SameQ,
+    TestID   -> "RecordUsageData-Prompts@@Tests/UsageData.wlt:420,1-431,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Other Requests and Disabled Tracking*)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "tools/list", <| "params" -> <| |> |>, <| "result" -> <| "tools" -> { } |> |> ];
+        recordUsageData[ "ping", <| |>, <| "result" -> <| |> |> ];
+        recordUsageData[ "resources/list", <| |>, <| "result" -> <| "resources" -> { } |> |> ];
+        recordUsageData[ "notifications/initialized", <| |>, Null ];
+        recordUsageData[ None, <| |>, Null ];
+        { FileExistsQ @ usageStatsFile[ ], Length @ usageEvents[ ] }
+    ],
+    { False, 0 },
+    SameTest -> SameQ,
+    TestID   -> "RecordUsageData-OtherMethodsIgnored@@Tests/UsageData.wlt:436,1-448,2"
+]
+
+VerificationTest[
+    withUsageSession[
+        Block[ { Wolfram`AgentTools`Server`$usageDataEnabled = False },
+            {
+                recordUsageData[ "initialize", $initMessage, $initResponse ],
+                recordUsageData[ "tools/call", $toolCallMessage, $toolCallResponse ],
+                FileExistsQ @ usageStatsFile[ ],
+                DirectoryQ @ usageDataPath[ ],
+                Wolfram`AgentTools`Server`$mcpClientInformation,
+                Length @ usageEvents[ ]
+            }
+        ]
+    ],
+    { Null, Null, False, False, Null, 0 },
+    SameTest -> SameQ,
+    TestID   -> "RecordUsageData-DisabledRecordsNothing@@Tests/UsageData.wlt:450,1-466,2"
+]
+
+(* The number of events per session is capped *)
+VerificationTest[
+    withUsageSession[
+        Block[ { Wolfram`AgentTools`Server`UsageData`Private`$usageDataMaxEvents = 3 },
+            Do[ recordUsageData[ "tools/call", $toolCallMessage, $toolCallResponse ], 5 ];
+            { Length @ usageEvents[ ], Length @ sessionData[ ][ "Events" ] }
+        ]
+    ],
+    { 3, 3 },
+    SameTest -> SameQ,
+    TestID   -> "RecordUsageData-EventLimit@@Tests/UsageData.wlt:469,1-479,2"
+]
+
+(* A failure while recording (here: the session file cannot be written) is swallowed and never propagates to the
+   read loop; the event itself is still kept in memory *)
+VerificationTest[
+    withUsageSession[
+        Block[ { Wolfram`AgentTools`Common`writeWXFFile = $Failed & },
+            { recordUsageData[ "tools/call", $toolCallMessage, $toolCallResponse ], Length @ usageEvents[ ] }
+        ]
+    ],
+    { _Failure, 1 },
+    SameTest -> MatchQ,
+    TestID   -> "RecordUsageData-FailuresAreIsolated@@Tests/UsageData.wlt:483,1-492,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*JSON Payload*)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "initialize", $initMessage, $initResponse ];
+        recordUsageData[ "tools/call", $toolCallMessage, $toolCallResponse ];
+        recordUsageData[ "tools/call", <| "params" -> <| "name" -> "NoSuchTool" |> |>, <| "result" -> <| "isError" -> True |> |> ];
+        Developer`ReadRawJSONString @ usageDataJSON @ usageDataPayload[ ]
+    ],
+    KeyValuePattern @ {
+        "MCPSessionID"      -> _String,
+        "ServerName"        -> "TestServer",
+        "ClientInformation" -> KeyValuePattern[ "clientInfo" -> KeyValuePattern[ "name" -> "test-client" ] ],
+        "Events"            -> {
+            KeyValuePattern @ { "Type" -> "ToolCall", "Name" -> "PrimeFinder", "Success" -> True, "Timestamp" -> _Real },
+            KeyValuePattern @ { "Type" -> "ToolCall", "Name" -> Null, "Success" -> False }
+        },
+        "PacletVersion"     -> _String,
+        "WolframVersion"    -> _String,
+        "SystemID"          -> _String,
+        "LastUpdated"       -> _Real
+    },
+    SameTest -> MatchQ,
+    TestID   -> "UsageData-JSONPayload@@Tests/UsageData.wlt:497,1-519,2"
+]
+
+(* The JSON is exactly what is stored in the session file *)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "initialize", $initMessage, $initResponse ];
+        recordUsageData[ "tools/call", $toolCallMessage, $toolCallResponse ];
+        With[ { stored = sessionData[ ] },
+            KeyDrop[ Developer`ReadRawJSONString @ usageDataJSON @ stored, "LastUpdated" ] === KeyDrop[ stored, "LastUpdated" ]
+        ]
+    ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "UsageData-JSONRoundTrip@@Tests/UsageData.wlt:522,1-533,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Keep-Alive*)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "initialize", $initMessage, $initResponse ];
+        SetFileDate[ usageStatsFile[ ], Now - Quantity[ 2, "Hours" ], "Modification" ];
+        {
+            fileAge @ usageStatsFile[ ] > 3600,
+            touchUsageStatsFile[ ] === usageStatsFile[ ],
+            fileAge @ usageStatsFile[ ] < 60,
+            sessionData[ ][ "ClientInformation" ] === $initMessage[ "params" ] (* touching does not rewrite the data *)
+        }
+    ],
+    { True, True, True, True },
+    SameTest -> SameQ,
+    TestID   -> "UsageData-KeepAliveTouchesFile@@Tests/UsageData.wlt:538,1-552,2"
+]
+
+VerificationTest[
+    withUsageSession[ { touchUsageStatsFile[ ], FileExistsQ @ usageStatsFile[ ] } ],
+    { Null, False },
+    SameTest -> SameQ,
+    TestID   -> "UsageData-KeepAliveWithoutFile@@Tests/UsageData.wlt:554,1-559,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Finished Sessions*)
+VerificationTest[
+    withUsageSession[
+        recordUsageData[ "initialize", $initMessage, $initResponse ];
+        With[ { other = FileNameJoin @ { usageDataPath[ ], "other-session.wxf" } },
+            CopyFile[ usageStatsFile[ ], other ];
+            SetFileDate[ other, Now - Quantity[ 25, "Hours" ], "Modification" ];
+            SetFileDate[ usageStatsFile[ ], Now - Quantity[ 25, "Hours" ], "Modification" ];
+            {
+                staleUsageFileQ @ other,
+                staleUsageFileQ @ usageStatsFile[ ], (* the current session is never considered finished *)
+                (SetFileDate @ other; staleUsageFileQ @ other)
+            }
+        ]
+    ],
+    { True, False, False },
+    SameTest -> SameQ,
+    TestID   -> "UsageData-StaleUsageFileQ@@Tests/UsageData.wlt:564,1-581,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Submission*)
+
+(* Finished sessions are submitted (oldest first) and deleted; expired and unreadable files are discarded without
+   submission; the fresh session stays; the lock is released. *)
+VerificationTest[
+    Module[ { root, dir, submitted = { }, result, remaining, lockLeft },
+        root = makeTempRoot[ ];
+        dir  = FileNameJoin @ { root, "UsageData" };
+        CreateDirectory[ dir, CreateIntermediateDirectories -> True ];
+        makeUsageFile[ dir, "finished", Quantity[ 25, "Hours" ] ];
+        makeUsageFile[ dir, "older"   , Quantity[ 3, "Days" ] ];
+        makeUsageFile[ dir, "fresh"   , Quantity[ 1, "Hours" ] ];
+        makeUsageFile[ dir, "expired" , Quantity[ 31, "Days" ] ];
+        Export[ FileNameJoin @ { dir, "corrupt.wxf" }, "this is not WXF", "Text" ];
+        SetFileDate[ FileNameJoin @ { dir, "corrupt.wxf" }, Now - Quantity[ 25, "Hours" ], "Modification" ];
+        result = Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath                            = root,
+                Wolfram`AgentTools`Server`$mcpSessionID                        = None,
+                Wolfram`AgentTools`Server`UsageData`Private`submitUsagePayload = Function[ AppendTo[ submitted, #MCPSessionID ]; True ]
+            },
+            submitUsageData[ ]
+        ];
+        remaining = FileBaseName /@ FileNames[ "*.wxf", dir ];
+        lockLeft  = FileExistsQ @ FileNameJoin @ { dir, "Submit.lock" };
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        { Sort[ FileBaseName /@ result ], submitted, remaining, lockLeft }
+    ],
+    { { "corrupt", "expired", "finished", "older" }, { "older", "finished" }, { "fresh" }, False },
+    SameTest -> SameQ,
+    TestID   -> "SubmitUsageData-SubmitsFinishedSessions@@Tests/UsageData.wlt:589,1-616,2"
+]
+
+(* A failed submission keeps the file and stops the batch *)
+VerificationTest[
+    Module[ { root, dir, calls = 0, result, remaining },
+        root = makeTempRoot[ ];
+        dir  = FileNameJoin @ { root, "UsageData" };
+        CreateDirectory[ dir, CreateIntermediateDirectories -> True ];
+        makeUsageFile[ dir, "first" , Quantity[ 26, "Hours" ] ];
+        makeUsageFile[ dir, "second", Quantity[ 25, "Hours" ] ];
+        result = Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath                            = root,
+                Wolfram`AgentTools`Server`$mcpSessionID                        = None,
+                Wolfram`AgentTools`Server`UsageData`Private`submitUsagePayload = Function[ calls++; False ]
+            },
+            submitUsageData[ ]
+        ];
+        remaining = Sort[ FileBaseName /@ FileNames[ "*.wxf", dir ] ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        { result, calls, remaining }
+    ],
+    { { }, 1, { "first", "second" } },
+    SameTest -> SameQ,
+    TestID   -> "SubmitUsageData-FailureStopsBatch@@Tests/UsageData.wlt:619,1-641,2"
+]
+
+(* While another process holds the lock, this one skips its turn without waiting long *)
+VerificationTest[
+    Module[ { root, dir, calls = 0, timing, result, remaining },
+        root = makeTempRoot[ ];
+        dir  = FileNameJoin @ { root, "UsageData" };
+        CreateDirectory[ dir, CreateIntermediateDirectories -> True ];
+        makeUsageFile[ dir, "finished", Quantity[ 25, "Hours" ] ];
+        Put[ <| "Header" -> "held by another process" |>, FileNameJoin @ { dir, "Submit.lock" } ];
+        { timing, result } = AbsoluteTiming @ Block[
+            {
+                Wolfram`AgentTools`Common`$rootPath                            = root,
+                Wolfram`AgentTools`Server`$mcpSessionID                        = None,
+                Wolfram`AgentTools`Server`UsageData`Private`submitUsagePayload = Function[ calls++; True ]
+            },
+            submitUsageData[ ]
+        ];
+        remaining = FileBaseName /@ FileNames[ "*.wxf", dir ];
+        Quiet @ DeleteDirectory[ root, DeleteContents -> True ];
+        { result, calls, remaining, timing < 30 }
+    ],
+    { { }, 0, { "finished" }, True },
+    SameTest -> SameQ,
+    TestID   -> "SubmitUsageData-LockHeld@@Tests/UsageData.wlt:644,1-666,2"
+]
+
+VerificationTest[
+    submitUsageData @ FileNameJoin @ { $TemporaryDirectory, "does-not-exist-" <> CreateUUID[ ] },
+    { },
+    SameTest -> SameQ,
+    TestID   -> "SubmitUsageData-NoDirectory@@Tests/UsageData.wlt:668,1-673,2"
+]
+
+(* The current session's file is never submitted, even when it looks old *)
+VerificationTest[
+    withUsageSession[
+        Module[ { calls = 0, result, remaining },
+            recordUsageData[ "initialize", $initMessage, $initResponse ];
+            SetFileDate[ usageStatsFile[ ], Now - Quantity[ 25, "Hours" ], "Modification" ];
+            result = Block[
+                { Wolfram`AgentTools`Server`UsageData`Private`submitUsagePayload = Function[ calls++; True ] },
+                submitUsageData[ ]
+            ];
+            { result, calls, FileExistsQ @ usageStatsFile[ ] }
+        ]
+    ],
+    { { }, 0, True },
+    SameTest -> SameQ,
+    TestID   -> "SubmitUsageData-CurrentSessionExcluded@@Tests/UsageData.wlt:676,1-691,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*HTTP Request*)
+
+(* An unreachable endpoint reports failure (and nothing is thrown) *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Server`UsageData`Private`$usageDataEndpoint      = "http://127.0.0.1:9/usage",
+            Wolfram`AgentTools`Server`UsageData`Private`$usageDataSubmitTimeout = 2
+        },
+        submitUsagePayload @ <| "MCPSessionID" -> "test", "Events" -> { } |>
+    ],
+    False,
+    SameTest -> SameQ,
+    TestID   -> "SubmitUsagePayload-Unreachable@@Tests/UsageData.wlt:698,1-709,2"
+]
+
+(* The development endpoint accepts a JSON body (skipped on CI, where network access is not guaranteed) *)
+skipIfGitHubActions @ VerificationTest[
+    submitUsagePayload @ <|
+        "MCPSessionID"      -> "AgentToolsTestSuite-" <> CreateUUID[ ],
+        "ServerName"        -> "AgentToolsTestSuite",
+        "ClientInformation" -> Null,
+        "Events"            -> { },
+        "PacletVersion"     -> Wolfram`AgentTools`Common`$pacletVersion,
+        "WolframVersion"    -> $Version,
+        "SystemID"          -> $SystemID,
+        "LastUpdated"       -> AbsoluteTime[ TimeZone -> 0 ]
+    |>,
+    True,
+    SameTest -> SameQ,
+    TestID   -> "SubmitUsagePayload-Endpoint@@Tests/UsageData.wlt:712,23-726,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Server Integration*)
+
+(* Note: These integration tests spawn a subprocess running the MCP server and communicate via JSON-RPC. As in
+   StartMCPServer.wlt, they are skipped when running as a script (see skipIfScript). Test servers get
+   SUBMIT_USAGE_DATA=false by default (see GetMCPEnvironment), so the tracked session here opts in explicitly. *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Tracked Session*)
+skipIfScript @ VerificationTest[
+    $usageProcess = StartMCPTestServer[
+        "ServerName"  -> "WolframLanguage",
+        "Environment" -> <| "SUBMIT_USAGE_DATA" -> "true" |>
+    ],
+    _ProcessObject,
+    SameTest -> MatchQ,
+    TestID   -> "UsageData-Integration-ServerStarts@@Tests/UsageData.wlt:739,16-747,2"
+]
+
+skipIfScript @ VerificationTest[
+    $usageClientName = "usage-data-test-" <> CreateUUID[ ];
+    MCPInitialize[ "ClientName" -> $usageClientName ],
+    KeyValuePattern[ "result" -> _Association ],
+    SameTest -> MatchQ,
+    TestID   -> "UsageData-Integration-Initialize@@Tests/UsageData.wlt:749,16-755,2"
+]
+
+skipIfScript @ VerificationTest[
+    SendMCPRequest[ "tools/call", <| "name" -> "WolframLanguageEvaluator", "arguments" -> <| "code" -> "Prime[1000]" |> |> ],
+    KeyValuePattern[ "result" -> KeyValuePattern[ "isError" -> False ] ],
+    SameTest -> MatchQ,
+    TestID   -> "UsageData-Integration-ToolCall@@Tests/UsageData.wlt:757,16-762,2"
+]
+
+skipIfScript @ VerificationTest[
+    SendMCPRequest[ "tools/call", <| "name" -> "NoSuchTool", "arguments" -> <| |> |> ],
+    KeyValuePattern[ "result" -> KeyValuePattern[ "isError" -> True ] ],
+    SameTest -> MatchQ,
+    TestID   -> "UsageData-Integration-UnknownToolCall@@Tests/UsageData.wlt:764,16-769,2"
+]
+
+skipIfScript @ VerificationTest[
+    SendMCPRequest[ "prompts/get", <| "name" -> "NoSuchPrompt", "arguments" -> <| |> |> ],
+    KeyValuePattern[ "error" -> _Association ],
+    SameTest -> MatchQ,
+    TestID   -> "UsageData-Integration-UnknownPrompt@@Tests/UsageData.wlt:771,16-776,2"
+]
+
+skipIfScript @ VerificationTest[
+    $usageFile = SelectFirst[
+        FileNames[ "*.wxf", FileNameJoin @ { Wolfram`AgentTools`Common`$rootPath, "UsageData" } ],
+        Quiet[ Developer`ReadWXFFile[ # ][ "ClientInformation", "clientInfo", "name" ] ] === $usageClientName &
+    ],
+    _String? FileExistsQ,
+    SameTest -> MatchQ,
+    TestID   -> "UsageData-Integration-SessionFileWritten@@Tests/UsageData.wlt:778,16-786,2"
+]
+
+skipIfScript @ VerificationTest[
+    $usageSession = Developer`ReadWXFFile @ $usageFile;
+    $usageSession[ "Events" ],
+    {
+        KeyValuePattern @ { "Type" -> "ToolCall" , "Name" -> "WolframLanguageEvaluator", "Success" -> True, "Timestamp" -> _Real },
+        KeyValuePattern @ { "Type" -> "ToolCall" , "Name" -> Null, "Success" -> False },
+        KeyValuePattern @ { "Type" -> "PromptGet", "Name" -> Null, "Success" -> False }
+    },
+    SameTest -> MatchQ,
+    TestID   -> "UsageData-Integration-Events@@Tests/UsageData.wlt:788,16-798,2"
+]
+
+skipIfScript @ VerificationTest[
+    {
+        $usageSession[ "ServerName" ],
+        $usageSession[ "ClientInformation", "protocolVersion" ],
+        StringQ @ $usageSession[ "MCPSessionID" ],
+        FreeQ[ $usageSession, "Prime[1000]" ]
+    },
+    { "WolframLanguage", "2024-11-05", True, True },
+    SameTest -> SameQ,
+    TestID   -> "UsageData-Integration-Payload@@Tests/UsageData.wlt:800,16-810,2"
+]
+
+skipIfScript @ VerificationTest[
+    StopMCPTestServer[ ];
+    Quiet @ DeleteFile @ $usageFile;
+    FileExistsQ @ $usageFile,
+    False,
+    SameTest -> SameQ,
+    TestID   -> "UsageData-Integration-Cleanup@@Tests/UsageData.wlt:812,16-819,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Opted-Out Session*)
+skipIfScript @ VerificationTest[
+    $usageProcess = StartMCPTestServer[ "ServerName" -> "WolframLanguage" ]; (* SUBMIT_USAGE_DATA=false *)
+    $usageClientName = "usage-data-test-" <> CreateUUID[ ];
+    MCPInitialize[ "ClientName" -> $usageClientName ];
+    SendMCPRequest[ "tools/call", <| "name" -> "WolframLanguageEvaluator", "arguments" -> <| "code" -> "1 + 1" |> |> ];
+    StopMCPTestServer[ ];
+    SelectFirst[
+        FileNames[ "*.wxf", FileNameJoin @ { Wolfram`AgentTools`Common`$rootPath, "UsageData" } ],
+        Quiet[ Developer`ReadWXFFile[ # ][ "ClientInformation", "clientInfo", "name" ] ] === $usageClientName &
+    ],
+    _Missing,
+    SameTest -> MatchQ,
+    TestID   -> "UsageData-Integration-OptedOutWritesNothing@@Tests/UsageData.wlt:824,16-837,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Cleanup*)
+VerificationTest[
+    DeleteObject @ $customServer,
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "UsageData-Cleanup@@Tests/UsageData.wlt:842,1-847,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ This is the developer documentation for contributing to AgentTools. For user doc
 - **[Deploy Agent Tools](deploy-agent-tools.md)** - Managed deployment of Wolfram tools to AI agent clients
 - **[Cloud Deployment](cloud-deployment.md)** - Deploying an `MCPServerObject` as a remote HTTP MCP server in the Wolfram Cloud
 - **[Preferences Content](preferences-content.md)** - System preferences UI for managing deployed Wolfram toolsets
+- **[Usage Data](usage-data.md)** - Anonymous usage data collected by the built-in local servers, and how to opt out
 - **[Paclet Extensions](paclet-extensions.md)** - Third-party paclet extension system for contributing tools, prompts, and servers
 
 ## Development Workflow

--- a/docs/deploy-agent-tools.md
+++ b/docs/deploy-agent-tools.md
@@ -43,7 +43,7 @@ DeployAgentTools[All, server]
 
 `DeployAgentTools` also accepts all `InstallMCPServer` options, which are passed through:
 
-- `"ApplicationName"`, `"DevelopmentMode"`, `"EnableMCPApps"`, `"MCPServerName"`, `"ProcessEnvironment"`, `"ToolOptions"`, `"VerifyLLMKit"`
+- `"ApplicationName"`, `"DevelopmentMode"`, `"EnableLLMKit"`, `"EnableMCPApps"`, `"MCPServerName"`, `"ProcessEnvironment"`, `"SubmitUsageData"`, `"ToolOptions"`, `"VerifyLLMKit"`
 
 ### Examples
 

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -576,6 +576,7 @@ Include these environment variables for proper operation:
 | `WOLFRAM_CLOUDBASE` | Set to a cloud base URL (e.g. `"https://www.test.wolframcloud.com"`) to override `$CloudBase` for the server session; cloud URLs in [MCP Apps](mcp-apps.md) assets are rewritten to match (optional, primarily for internal purposes) |
 | `LLMKIT_ENABLED` | Set to `"false"` to make the context tools (`WolframContext`, etc.) behave as if the user has no LLMKit subscription, without emitting subscription warnings (optional) |
 | `MCP_TOOL_OPTIONS` | JSON string of tool option overrides, set automatically by `"ToolOptions"` (optional) |
+| `SUBMIT_USAGE_DATA` | Set to `"false"` to opt out of [anonymous usage data](usage-data.md) collection (or `"true"` to opt a custom server in); set automatically by `"SubmitUsageData"` (optional) |
 
 ### Getting the Configuration
 
@@ -676,6 +677,22 @@ This option works with both `InstallMCPServer` and `UninstallMCPServer`. When un
 (* Uninstall the "WolframDev" entry that was installed with a custom name *)
 UninstallMCPServer["ClaudeDesktop", "WolframLanguage", "MCPServerName" -> "WolframDev"]
 ```
+
+### SubmitUsageData
+
+Controls whether the installed server collects and submits [anonymous usage data](usage-data.md) — which MCP client is used, which tools and prompts are called, and whether each call succeeded, never any content:
+
+| Value | Behavior |
+|-------|----------|
+| `Automatic` (default) | Nothing is added to the configuration; the server's `"EnableUsageData"` property decides, so built-in servers collect usage data and custom servers do not |
+| `False` | Opts out; sets `SUBMIT_USAGE_DATA=false` in the server environment |
+| `True` | Opts in even for a custom server; sets `SUBMIT_USAGE_DATA=true` |
+
+```wl
+InstallMCPServer["ClaudeCode", "WolframLanguage", "SubmitUsageData" -> False]
+```
+
+Users who configure toolsets from the system preferences panel can opt out with its checkbox instead (see [preferences-content.md](preferences-content.md)).
 
 ### ToolOptions
 

--- a/docs/preferences-content.md
+++ b/docs/preferences-content.md
@@ -49,6 +49,15 @@ Each client row contains:
 - An info icon that, when hovered, shows the on-disk install location for the deployed toolset
 - A per-directory settings list (when applicable) showing project-level deployments
 
+### Usage Data Checkbox
+
+Below the client list, a checkbox labeled *Share anonymous usage data with Wolfram to help improve these tools* (checked by default, with a tooltip describing what is collected) controls the `"SubmitUsageData"` option of the deployments made from the panel. The state is stored in `CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SubmitUsageData"}]`; only an explicit `False` opts out.
+
+- Checked: deployments are made without the option, so the server's default applies (the built-in toolsets collect usage data).
+- Unchecked: deployments are made with `"SubmitUsageData" -> False`, which writes `SUBMIT_USAGE_DATA=false` into the client configuration.
+
+Toggling the checkbox re-deploys every existing deployment of a built-in toolset (global and per-directory), preserving the other options each deployment was made with, so the change takes effect immediately. The re-deployment is submitted as a session task (`SessionSubmit`) rather than run inside the checkbox's preemptive evaluation. See [usage-data.md](usage-data.md) for what is collected and how.
+
 ### Per-Directory Settings
 
 When a client has project-level deployments (e.g., from `DeployAgentTools[{"ClaudeCode", "/path/to/project"}, ...]`), each path is listed under "Settings for specific directories:" along with the toolset that was deployed there. Clicking a path opens its directory in the OS file browser.
@@ -59,7 +68,7 @@ The optional file-scoped flag `$allowDirectoryOperations` (default `False` in `K
 
 Strings and graphics used by the panel are loaded from `FrontEnd/Assets/AgentTools.wl` via `FEPrivate`FrontEndResource`:
 
-- `"AgentToolsStrings"` — `LanguageSwitched` translations for every label and tooltip in the panel (English plus Chinese Simplified, Chinese Traditional, French, Japanese, Korean, and Spanish)
+- `"AgentToolsStrings"` — `LanguageSwitched` translations for every label and tooltip in the panel (English plus Chinese Simplified, Chinese Traditional, French, Japanese, Korean, and Spanish). The usage data strings (`prefsSubmitUsageData`, `prefsSubmitUsageDataDescription`) are currently English only, pending localization
 - `"AgentToolsExpressions"` — `GraphicsBox` definitions for the down-pointer, remove ("x"), and info icons
 
 These resources are made available to the front end through the paclet's `"FrontEnd"` extension declared in `PacletInfo.wl`:
@@ -74,7 +83,7 @@ To add new strings or icons, edit `FrontEnd/Assets/AgentTools.wl` and reference 
 
 ## Related Files
 
-- `Kernel/PreferencesContent.wl` — Implementation of `CreatePreferencesContent` and its helpers (`clientInterfaces`, `clientRow`, `clientControls`, `dirSettingsRow`, `infoLink`, `docsLink`)
+- `Kernel/PreferencesContent.wl` — Implementation of `CreatePreferencesContent` and its helpers (`clientInterfaces`, `clientRow`, `clientControls`, `dirSettingsRow`, `infoLink`, `docsLink`, `usageDataCheckbox`)
 - `FrontEnd/Assets/AgentTools.wl` — Localized strings and graphics resources
 - `Kernel/DeployAgentTools.wl` — Deployment system used by the panel (see [deploy-agent-tools.md](deploy-agent-tools.md))
 - `Kernel/SupportedClients.wl` — Source of `$SupportedMCPClients` data shown for each client row
@@ -84,3 +93,4 @@ To add new strings or icons, edit `FrontEnd/Assets/AgentTools.wl` and reference 
 - [deploy-agent-tools.md](deploy-agent-tools.md) — Underlying deployment management used by the panel
 - [mcp-clients.md](mcp-clients.md) — Supported MCP clients listed in the panel
 - [servers.md](servers.md) — `Wolfram` and `WolframLanguage` predefined servers exposed by the panel
+- [usage-data.md](usage-data.md) — The anonymous usage data controlled by the panel's checkbox

--- a/docs/servers.md
+++ b/docs/servers.md
@@ -195,7 +195,12 @@ server["Name"]           (* "WolframLanguage" *)
 server["Tools"]          (* List of LLMTool objects *)
 server["MCPPrompts"]     (* List of prompt definitions *)
 server["JSONConfiguration"]  (* JSON config for manual setup *)
+server["EnableUsageData"]    (* True: the built-in servers collect anonymous usage data *)
 ```
+
+### Usage Data
+
+The predefined servers have `"EnableUsageData" -> True`, so their local sessions record which MCP client is used and which tools and prompts are called (never any content) and submit that data to Wolfram. Installations can opt out with `InstallMCPServer`'s `"SubmitUsageData" -> False` option or the preferences panel's checkbox. Custom servers do not have the property and are not tracked unless installed with `"SubmitUsageData" -> True`. See [usage-data.md](usage-data.md).
 
 ## Creating Custom Servers
 

--- a/docs/usage-data.md
+++ b/docs/usage-data.md
@@ -1,0 +1,113 @@
+# Usage Data
+
+This document describes the anonymous usage data collected by the local MCP servers, how users control it, and how it is stored and submitted.
+
+## Overview
+
+To learn which AI environments (MCP clients) people use with the Wolfram tools and which tools and prompts get used, the built-in local MCP servers (`Wolfram`, `WolframAlpha`, `WolframLanguage`, and `WolframPacletDevelopment`) record basic usage data for each server session and submit it to Wolfram. The data is anonymous and never contains content: no tool arguments, prompt arguments, results, code, or queries.
+
+Cloud-deployed servers (see [cloud-deployment.md](cloud-deployment.md)) do not collect usage data.
+
+## What Is Recorded
+
+For each local server session (one server process, from start to exit):
+
+| Field | Description |
+|-------|-------------|
+| `MCPSessionID` | A random UUID assigned when the server starts (`$mcpSessionID`) |
+| `ServerName` | The name of the MCP server, e.g. `"WolframLanguage"` |
+| `ClientInformation` | The `params` of the client's `initialize` request: `clientInfo` (name and version of the MCP client), `protocolVersion`, and `capabilities`. `null` until `initialize` has been received |
+| `Events` | One event per `tools/call` and `prompts/get` request (see below) |
+| `PacletVersion` | The version of Wolfram/AgentTools |
+| `WolframVersion` | `$Version` |
+| `SystemID` | `$SystemID` |
+| `LastUpdated` | `AbsoluteTime[TimeZone -> 0]` of the last change |
+
+Each event has:
+
+| Field | Description |
+|-------|-------------|
+| `Type` | `"ToolCall"` or `"PromptGet"` |
+| `Name` | The name of the tool or prompt, or `null` if the request named a tool or prompt the server does not have (so arbitrary text can never end up in the data) |
+| `Success` | Whether the request succeeded: `false` for tool errors (`isError`), JSON-RPC errors, and internal failures |
+| `Timestamp` | `AbsoluteTime[TimeZone -> 0]` of the request |
+
+Everything else in a request — in particular the `arguments` — is never looked at.
+
+## When It Is Recorded
+
+Whether a session is tracked is decided once, when the server starts (`initializeUsageData` in `Kernel/Server/UsageData.wl`):
+
+1. If the `SUBMIT_USAGE_DATA` environment variable holds a boolean (`true`/`false`, case-insensitive; `yes`/`no`, `on`/`off`, and `1`/`0` are accepted too), that value wins.
+2. Otherwise the session is tracked only if the server's `"EnableUsageData"` property is exactly `True`. The built-in servers set it (see `Kernel/DefaultServers.wl`); servers created with `CreateMCPServer` or defined by paclets do not have the property, so they are not tracked unless the environment variable says otherwise.
+
+```wl
+MCPServerObject["WolframLanguage"]["EnableUsageData"]  (* True *)
+```
+
+### Opting Out (or In)
+
+`InstallMCPServer` — and therefore `DeployAgentTools`, which forwards all `InstallMCPServer` options — has a `"SubmitUsageData"` option:
+
+| Value | Behavior |
+|-------|----------|
+| `Automatic` (default) | Nothing is added to the client configuration; the server's `"EnableUsageData"` property decides |
+| `False` | Sets `SUBMIT_USAGE_DATA=false` in the server's environment: no usage data is recorded or submitted by that installation |
+| `True` | Sets `SUBMIT_USAGE_DATA=true`: usage data is recorded even for a custom server |
+
+```wl
+InstallMCPServer["ClaudeCode", "WolframLanguage", "SubmitUsageData" -> False]
+```
+
+Any other value is rejected with `InstallMCPServer::InvalidSubmitUsageData`.
+
+The system preferences panel built by `CreatePreferencesContent` (see [preferences-content.md](preferences-content.md)) has a checkbox, *Share anonymous usage data with Wolfram to help improve these tools*, which is checked by default. Unchecking it re-deploys the currently configured toolsets with `"SubmitUsageData" -> False` (keeping their other options) and applies to toolsets configured from the panel afterward; checking it again re-deploys them without the option.
+
+Servers started by the test suite never track anything: `GetMCPEnvironment` in `Tests/MCPServerTestUtilities.wl` sets `SUBMIT_USAGE_DATA=false` for every test server.
+
+## How It Is Stored
+
+The session's data is written to `$rootPath/UsageData/<MCPSessionID>.wxf`, i.e. under `$UserBaseDirectory/ApplicationData/Wolfram/AgentTools/UsageData/`. The file is rewritten in full whenever the client information arrives or an event is added, so it always holds the complete session. At most 10,000 events are recorded per session.
+
+A server session cannot know that it is over, and an MCP client may leave a server idle for a long time, so the file's modification time is kept current on purpose: a scheduled task in the server kernel (`SessionSubmit@ScheduledTask[...]`) touches the file once an hour. A session counts as finished once its file has not been modified for 24 hours.
+
+## How It Is Submitted
+
+Submission happens in later sessions. Ten seconds after any tracked server starts, a scheduled task submits every session file that has not been modified for 24 hours by POSTing the file's contents as JSON (`Content-Type: application/json`) to
+
+```
+https://www.wolframcloud.com/obj/wolframai-content/api/1.0/usage
+```
+
+and deletes the file once the endpoint has accepted it with a 2xx status. The JSON has exactly the fields listed above.
+
+Only one process submits at a time: the scan runs under `WithLock` on `UsageData/Submit.lock`. A server that finds the lock taken skips its turn (it waits at most one second), and a lock left behind by a crashed process expires after ten minutes.
+
+Failures are handled conservatively:
+
+- A failed submission (for example, no network) keeps the file and stops the batch for this session; the remaining files are tried again by a later session.
+- Files that could not be submitted for 30 days, and files that cannot be read, are deleted.
+- Sessions that are not tracked (opted out, or a server without the property) never submit, delete, or create files.
+
+Usage tracking must never interfere with the server: every hook is wrapped in `usageDataQuietly`, which logs a failure to the server log (`Log.wl`) and otherwise ignores it.
+
+## Implementation
+
+| File | Role |
+|------|------|
+| `Kernel/Server/UsageData.wl` | Session state, enabling logic, recording, the session file, the keep-alive task, and locked submission |
+| `Kernel/Server/Local.wl` | Calls `initializeUsageData` when the server starts and `recordUsageData` after each handled request |
+| `Kernel/Server/Server.wl` | Declares the session symbols and hooks shared with the local transport |
+| `Kernel/DefaultServers.wl` | `"EnableUsageData" -> True` for the built-in servers |
+| `Kernel/InstallMCPServer.wl` | The `"SubmitUsageData"` option and the `SUBMIT_USAGE_DATA` environment variable |
+| `Kernel/PreferencesContent.wl` | The opt-out checkbox and re-deployment of configured toolsets |
+| `Tests/UsageData.wlt` | Unit tests and server integration tests |
+
+Session state lives in the `` Wolfram`AgentTools`Server` `` context: `$mcpSessionID`, `$mcpClientInformation`, `$usageEvents` (an `` Internal`Bag ``), and `$usageDataEnabled`. Tunable settings (endpoint, timeouts, intervals, limits) are file-scoped variables at the top of `Kernel/Server/UsageData.wl`.
+
+## See Also
+
+- [mcp-clients.md](mcp-clients.md) — The `"SubmitUsageData"` option and the `SUBMIT_USAGE_DATA` environment variable
+- [servers.md](servers.md) — The built-in servers and their `"EnableUsageData"` property
+- [preferences-content.md](preferences-content.md) — The opt-out checkbox in the preferences panel
+- [Specs/UsageData.md](../Specs/UsageData.md) — Design specification


### PR DESCRIPTION
## Summary

Adds basic, anonymous usage tracking for the built-in local MCP servers so we can see which MCP clients are in use and which tools/prompts get called. No content is ever recorded — no tool or prompt arguments, results, code, or queries.

- **What is recorded** (per local server session, in `$rootPath/UsageData/<session id>.wxf`): the client's `initialize` params (`clientInfo`, `protocolVersion`, `capabilities`) and one event per `tools/call` / `prompts/get` request with the tool/prompt name, whether it succeeded, and a timestamp. A name is recorded only if it matches one of the server's tools/prompts (otherwise `null`), so hallucinated names can't smuggle text into the data. Also included: `ServerName`, `PacletVersion`, `WolframVersion`, `SystemID`, `LastUpdated`.
- **When**: decided once at server start (`Kernel/Server/UsageData.wl`). A boolean `SUBMIT_USAGE_DATA` environment variable wins; otherwise the server's `"EnableUsageData"` property must be exactly `True`. The four built-in servers now set it; custom/paclet servers don't, so they aren't tracked unless opted in. Nothing is tracked for cloud-deployed servers, and test servers always run with `SUBMIT_USAGE_DATA=false`.
- **Opt-out**: `InstallMCPServer[..., "SubmitUsageData" -> False]` (new option, default `Automatic`; `True`/`False` write `SUBMIT_USAGE_DATA` into the client config, forwarded by `DeployAgentTools`), or the new checkbox in `CreatePreferencesContent` (checked by default; toggling re-deploys the configured toolsets so it takes effect immediately). Checkbox strings are English-only for now, pending the localization pass.
- **Submission**: a session can't know it's over, so an hourly `SessionSubmit@ScheduledTask` keeps the file's mtime current while the server lives (verified to fire while blocked in `InputString[""]`), and a later tracked session POSTs files untouched for 24 h as JSON to `https://www.wolframcloud.com/obj/wolframai-content/api/1.0/usage` and deletes them once accepted (2xx). Runs 10 s after startup under `WithLock` (`UsageData/Submit.lock`, 1 s wait, 10 min stale-lock expiry); a failed submission keeps the file and stops the batch; files unsubmittable for 30 days or unreadable are discarded. Every hook is wrapped so a failure can only reach `Log.wl`, never the client.
- Docs: `docs/usage-data.md`, `Specs/UsageData.md`, updates to `mcp-clients.md`, `servers.md`, `preferences-content.md`, `deploy-agent-tools.md`, `AGENTS.md`, and the `InstallMCPServer` reference page.

Submitted payload shape:

```json
{"MCPSessionID": "…", "ServerName": "WolframLanguage",
 "ClientInformation": {"clientInfo": {"name": "…", "version": "…"}, "protocolVersion": "…", "capabilities": {}},
 "Events": [{"Type": "ToolCall", "Name": "WolframLanguageEvaluator", "Success": true, "Timestamp": 3.99e9}],
 "PacletVersion": "2.2.10", "WolframVersion": "…", "SystemID": "…", "LastUpdated": 3.99e9}
```

## Test plan

- [x] `Tests/UsageData.wlt` (new, 50 tests): enabling precedence (property vs. env var), recording matrix (success/tool error/JSON-RPC error/internal failure, unknown names → `null`, no arguments or results in the file, other methods ignored, disabled sessions write nothing, event cap, failure isolation), JSON round trip, keep-alive touch, stale-file detection, locked submission with a stubbed HTTP call (oldest-first, discard expired/unreadable, failure stops batch, held lock skips), unreachable endpoint, live endpoint (skipped on GitHub Actions), and subprocess-server integration (tracked session writes the expected file; opted-out session writes nothing)
- [x] New tests in `Tests/InstallMCPServer.wlt` (option/env var/validation/`DeployAgentTools` forwarding), `Tests/MCPServerObject.wlt` (property), `Tests/PreferencesContent.wlt` (opt-out helpers and re-deployment)
- [x] Regression: `StartMCPServer`, `DeployAgentTools`, `ToolOverrides`, `MCPRoots`, `CreateMCPServer`, `UninstallMCPServer`, `Prompts`, `MCPServerObject` — all green; CodeInspector clean on every changed file
- [x] Manual end-to-end with a dev-mode server on a redirected `$rootPath` and shortened timers: file written on `initialize`, three events recorded with correct names/flags, keep-alive touched the file while idle on stdin, a seeded 25 h-old session was submitted (`200 {"Success":true}`) and deleted while a fresh one stayed
- [ ] Preferences panel checkbox in the desktop front end (not verifiable headless here)

Note: `CreatePreferencesContent-SmokeTest` emits `FrontEndObject::notavail` in headless test kernels; this is pre-existing on `main` (the header's `FrontEndResource[...]` call) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrYV5hPegFwHLhHueb1eK4
