### PR TITLE
Store the usage data opt-out as a single global setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ See [building.md](docs/building.md) for detailed instructions.
   - `CreateMCPServer.wl`: Implementation for creating MCP servers
   - `DefaultServers.wl`: Defines several predefined named MCP servers
   - `DeployAgentTools.wl`: Implementation for deploying and managing agent tool deployments
-  - `Files.wl`: Helper functions for file operations (local WXF/JSON I/O plus `readCloudWXF`/`writeCloudWXF` for cloud-object WXF, used by the cloud admin API's key-label store)
+  - `Files.wl`: Helper functions for file operations (local WXF/JSON I/O plus `readCloudWXF`/`writeCloudWXF` for cloud-object WXF, used by the cloud admin API's key-label store) and the machine-wide settings store `$rootPath/GlobalSettings.wxf` (`readGlobalSettings`/`getGlobalSetting`/`setGlobalSetting`), which currently holds the usage-data opt-out
   - `Formatting.wl`: Definitions for formatting in notebooks
   - `InstallMCPServer.wl`: Implementation for installing MCP servers for use in some common MCP client applications
   - `MCPClientRequests.wl`: Server-to-client request infrastructure (request registry, response correlation, notification dispatch) used by [MCP roots](docs/mcp-roots.md) and other server-initiated requests
@@ -58,7 +58,7 @@ See [building.md](docs/building.md) for detailed instructions.
     - `Server.wl`: Aggregator that declares the server-session state shared across the subcontexts, defines the exported `$MCPEvaluationEnvironment`/`$MCPTransport` host descriptors (bound per session/request by each transport), and loads the children below
     - `Shared.wl`: Transport-agnostic core — method dispatch (`handleMethod`), tool/prompt resolution, tool evaluation and result formatting, capability negotiation (`initResponse`), server-state build (`initializeServerState`), environment-specific tool overrides (`applyToolOverrides`, driven by the `"Overrides"` tool property), and logging helpers
     - `Local.wl`: Local stdio transport — `StartMCPServer`, the read loop (`processRequest`), tool warmup, and stdout-protecting output suppression (`superQuiet`); calls the usage-data hooks (`initializeUsageData`, `recordUsageData`)
-    - `UsageData.wl`: [Anonymous usage data](docs/usage-data.md) for local servers — per-session state (`$mcpSessionID`, `$mcpClientInformation`, `$usageEvents`), the enabling logic (`SUBMIT_USAGE_DATA` environment variable vs. the servers' `"EnableUsageData"` property), the session file under `$rootPath/UsageData`, the hourly keep-alive task, and the locked submission of finished sessions to the usage endpoint
+    - `UsageData.wl`: [Anonymous usage data](docs/usage-data.md) for local servers — per-session state (`$mcpSessionID`, `$mcpClientInformation`, `$usageEvents`), the enabling logic (`SUBMIT_USAGE_DATA` environment variable, otherwise the servers' `"EnableUsageData"` property combined with the global opt-out from `GlobalSettings.wxf` via `getGlobalUsageDataSetting`/`setGlobalUsageDataSetting`, which the preferences checkbox reads and writes), the session file under `$rootPath/UsageData`, the hourly keep-alive task, and the locked submission of finished sessions to the usage endpoint
     - `Cloud.wl`: Cloud HTTP transport — `RunCloudMCPServer` (stateless Streamable HTTP handler), `CloudDeployMCPServer`, the full-directory-bundle deploy implementation (`cloudDeployDirectory`) behind both the `CloudDeploy` UpValue on `MCPServerObject` (the UpValue itself is defined in `MCPServerObject.wl`) and the exported `CloudDeployMCPServerBundle` that deploys `/mcp`, the landing page, `/api/info`, and the forced-`Private` admin page/API, the self-describing session-ID capability codec, server-embedding deploy helpers (including the cloud-paclet detection — `$cloudSupportPacletVersion`/`cloudAgentToolsAvailableQ` — that swaps the heavy definition-bundling payloads for light paclet-loading ones when the connected cloud account has a new-enough Wolfram/AgentTools installed), the landing-page `/api/info` metadata generator, and the owner-only `/api/admin` key-management handler (`runCloudAdminAPI`: list/create/revoke `PermissionsKey`s) (see [Cloud Deployment spec](Specs/CloudDeployment.md))
   - `SupportedClients.wl`: Registry of supported MCP clients (`$SupportedMCPClients`) and relevant utility functions
   - `ValidateAgentToolsPacletExtension.wl`: Validation of `"AgentTools"` [paclet extensions](docs/paclet-extensions.md)
@@ -105,7 +105,7 @@ See [building.md](docs/building.md) for detailed instructions.
   - `mcp-roots.md`: MCP roots handshake, working-directory propagation, and guidance for tools that resolve relative paths
   - `paclet-extensions.md`: Third-party paclet extension system for contributing tools, prompts, and servers
   - `preferences-content.md`: System preferences UI for managing deployed Wolfram toolsets
-  - `usage-data.md`: Anonymous usage data collected by the built-in local servers (`"SubmitUsageData"` option, `SUBMIT_USAGE_DATA`, storage and submission)
+  - `usage-data.md`: Anonymous usage data collected by the built-in local servers (`"SubmitUsageData"` option, `SUBMIT_USAGE_DATA`, the global opt-out in `GlobalSettings.wxf`, storage and submission)
 
 ### MCP Documentation
 

--- a/Kernel/CommonSymbols.wl
+++ b/Kernel/CommonSymbols.wl
@@ -115,6 +115,14 @@ BeginPackage[ "Wolfram`AgentTools`Common`" ];
 `outputLogFile;
 `cleanupOldOutputLogs;
 
+(* Global settings (Files.wl) and the usage-data setting kept there (Server/UsageData.wl): *)
+`$globalSettingsFile;
+`getGlobalSetting;
+`getGlobalUsageDataSetting;
+`readGlobalSettings;
+`setGlobalSetting;
+`setGlobalUsageDataSetting;
+
 (* Logging utilities: *)
 `debugPrint;
 `writeError;

--- a/Kernel/Files.wl
+++ b/Kernel/Files.wl
@@ -263,6 +263,57 @@ writeRawJSONFile // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
+(*Global Settings*)
+(* Settings that apply to everything on this machine -- every server session and every deployment -- are kept as an
+   association in $rootPath/GlobalSettings.wxf. It currently holds a single entry, "SubmitUsageData" (the usage-data
+   opt-out made in the preferences panel; see docs/usage-data.md), but is meant to take other global settings in the
+   future. A missing or unreadable file simply means that nothing has been set yet. *)
+$globalSettingsFile := FileNameJoin @ { $rootPath, "GlobalSettings.wxf" };
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*readGlobalSettings*)
+readGlobalSettings // beginDefinition;
+
+readGlobalSettings[ ] :=
+    readGlobalSettings @ $globalSettingsFile;
+
+readGlobalSettings[ file_String ] /; FileExistsQ @ file :=
+    Replace[ Quiet @ readWXFFile @ file, Except[ _? AssociationQ ] :> <| |> ];
+
+readGlobalSettings[ _String ] :=
+    <| |>;
+
+readGlobalSettings // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*getGlobalSetting*)
+(* Missing[ "KeyAbsent", key ] (or the given default) when the setting has never been set *)
+getGlobalSetting // beginDefinition;
+getGlobalSetting[ key_String ] := Lookup[ readGlobalSettings[ ], key ];
+getGlobalSetting[ key_String, default_ ] := Lookup[ readGlobalSettings[ ], key, default ];
+getGlobalSetting // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*setGlobalSetting*)
+(* Rewrites the file with the setting merged into the existing ones. Returns the value. *)
+setGlobalSetting // beginDefinition;
+
+setGlobalSetting[ key_String, value_ ] := Enclose[
+    Module[ { settings },
+        settings = ConfirmBy[ <| readGlobalSettings[ ], key -> value |>, AssociationQ, "Settings" ];
+        ConfirmBy[ writeWXFFile[ $globalSettingsFile, settings ], FileExistsQ, "Write" ];
+        value
+    ],
+    throwInternalFailure
+];
+
+setGlobalSetting // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
 (*Cloud Object Files*)
 (* WXF read/write for a CloudObject, used by the cloud-deployment admin API's optional key-label store.
    These are the cloud analogs of readWXFFile / writeWXFFile above. *)

--- a/Kernel/PreferencesContent.wl
+++ b/Kernel/PreferencesContent.wl
@@ -254,7 +254,7 @@ configureAllButton[detectedClients_, Dynamic[refresh_]] :=
 					DeployAgentTools[
 						client,
 						CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SelectedToolset", client}],
-						OverwriteTarget -> True, Sequence @@ usageDataDeployOptions[]
+						OverwriteTarget -> True
 					],
 					{client, detectedClients}
 				],
@@ -384,7 +384,7 @@ clientMenu[category_, client_, Dynamic[refresh_]] :=
 			CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SelectedToolset", client}],
 			(
 				CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SelectedToolset", client}] = #;
-				If[category === "Configured", refresh @ DeployAgentTools[client, #, OverwriteTarget -> True, Sequence @@ usageDataDeployOptions[]]]
+				If[category === "Configured", refresh @ DeployAgentTools[client, #, OverwriteTarget -> True]]
 			)&
 		]
 		,
@@ -488,7 +488,7 @@ clientButton[category_, client_, Dynamic[refresh_]] :=
 		refresh @ DeployAgentTools[
 			client,
 			CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SelectedToolset", client}],
-			OverwriteTarget -> True, Sequence @@ usageDataDeployOptions[]
+			OverwriteTarget -> True
 		]
 	]
 
@@ -662,64 +662,19 @@ dirSettingsRow[Dynamic[dirSettings_], i_, {obj_, server_, scope_, active_}] :=
 
 
 (*
-	Anonymous usage data (see docs/usage-data.md) is shared by default. The opt-out made here is stored in the front
-	end's private settings next to the per-client "SelectedToolset" choices; only an explicit False opts out.
+	Anonymous usage data (see docs/usage-data.md) is shared by default. The opt-out made here is a single global
+	setting stored on disk (getGlobalUsageDataSetting and setGlobalUsageDataSetting in Kernel/Server/UsageData.wl),
+	which every server session consults when it starts, so changing it never requires re-deploying anything. The
+	stored value is read when the checkbox is displayed rather than when the panel is built, so it is always current;
+	writing it is quick enough to happen right in the checkbox's preemptive evaluation (catchAlways keeps a failed
+	write from surfacing as an uncaught Throw there).
 *)
-$usageDataSettingPath = {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SubmitUsageData"};
-
-
-usageDataOptOutQ[] := Quiet[CurrentValue[$FrontEnd, $usageDataSettingPath]] === False
-
-
-(*
-	Extra InstallMCPServer options for deployments made from this panel: an opt-out is written into the client's
-	configuration as "SubmitUsageData" -> False (the SUBMIT_USAGE_DATA environment variable); otherwise nothing is
-	added and the server's own default applies.
-*)
-usageDataDeployOptions[] := If[usageDataOptOutQ[], {"SubmitUsageData" -> False}, {}]
-
-
-(*
-	Re-deploys every existing deployment of a built-in toolset so that the new setting is reflected in the clients'
-	configurations right away, preserving the other options each deployment was made with.
-*)
-applyUsageDataSetting[] :=
-	Scan[
-		redeployForUsageData,
-		Select[
-			Replace[Quiet @ DeployedAgentTools[], Except[_List] -> {}],
-			KeyExistsQ[Wolfram`AgentTools`$DefaultMCPServers, #["Toolset"]]&
-		]
-	]
-
-
-redeployForUsageData[dep_AgentToolsDeployment] :=
-	Module[{options},
-		options = DeleteCases[
-			Replace[Normal @ dep["MCP", "Options"], Except[{___Rule}] -> {}],
-			"SubmitUsageData" -> _
-		];
-		Quiet @ catchAlways @ DeployAgentTools[
-			dep["Target"],
-			dep["Toolset"],
-			OverwriteTarget -> True,
-			Sequence @@ Join[options, usageDataDeployOptions[]]
-		]
-	]
-
-
 usageDataCheckbox[] :=
 	Grid[
 		{{
-			Checkbox[
-				Dynamic[
-					CurrentValue[$FrontEnd, $usageDataSettingPath] =!= False,
-					(
-						CurrentValue[$FrontEnd, $usageDataSettingPath] = TrueQ[#];
-						(* Re-deploying can take a while, so it is queued rather than run in this preemptive evaluation *)
-						SessionSubmit @ applyUsageDataSetting[]
-					)&
-				]
+			DynamicModule[{submit = True},
+				Checkbox @ Dynamic[submit, catchAlways @ setGlobalUsageDataSetting[submit = TrueQ[#]]&],
+				Initialization :> (submit = getGlobalUsageDataSetting[])
 			],
 			Tooltip[
 				tr["prefsSubmitUsageData"],
@@ -738,8 +693,10 @@ usageDataCheckbox[] :=
 CreatePreferencesContent // beginDefinition;
 
 
+(* The subtitle is a StringTemplate built from an actual front end resource string (not a Dynamic), so a front end is
+   needed to evaluate this; UsingFrontEnd launches one when the kernel has none (e.g. in tests) and is otherwise a no-op. *)
 CreatePreferencesContent[] :=
-Deploy[
+UsingFrontEnd @ Deploy[
 	Pane[
 		Column[
 			{

--- a/Kernel/Server/UsageData.wl
+++ b/Kernel/Server/UsageData.wl
@@ -21,7 +21,9 @@ Needs[ "Wolfram`AgentTools`Server`" ];
     Tracking is enabled for a session when the SUBMIT_USAGE_DATA environment variable holds a boolean (written into
     the client's configuration by the "SubmitUsageData" option of InstallMCPServer), or -- when that variable is
     absent -- when the server's "EnableUsageData" property is explicitly True (the built-in servers set it; see
-    DefaultServers.wl). Nothing is tracked for cloud-deployed servers.
+    DefaultServers.wl) and the user has not opted out globally: the preferences panel's checkbox keeps its state in
+    $rootPath/GlobalSettings.wxf (see getGlobalUsageDataSetting), which every later session reads when it starts.
+    Nothing is tracked for cloud-deployed servers.
 
     The session's data lives in $rootPath/UsageData/<session id>.wxf. The file is rewritten whenever the data changes
     and touched hourly by a scheduled task, so its modification time tells whether the session is still alive even
@@ -80,11 +82,11 @@ usageDataQuietly // endDefinition;
 (*usageDataEnabledQ*)
 (* SUBMIT_USAGE_DATA takes precedence when it holds a boolean: an explicit true also tracks custom servers and an
    explicit false opts a built-in server out. Otherwise only servers whose "EnableUsageData" property is exactly
-   True are tracked. *)
+   True are tracked, and only if the user has not opted out globally (getGlobalUsageDataSetting). *)
 usageDataEnabledQ // beginDefinition;
 usageDataEnabledQ[ obj_ ] := usageDataEnabledQ[ obj, booleanEnvironment[ "SUBMIT_USAGE_DATA" ] ];
 usageDataEnabledQ[ _, enabled: True|False ] := enabled;
-usageDataEnabledQ[ obj_MCPServerObject, None ] := obj[ "EnableUsageData" ] === True;
+usageDataEnabledQ[ obj_MCPServerObject, None ] := obj[ "EnableUsageData" ] === True && getGlobalUsageDataSetting[ ];
 usageDataEnabledQ[ _, None ] := False;
 usageDataEnabledQ // endDefinition;
 
@@ -110,6 +112,28 @@ booleanString[ value_String ] :=
 booleanString[ _ ] := None;
 
 booleanString // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Global Setting*)
+(* The opt-out made with the preferences panel's checkbox (usageDataCheckbox in PreferencesContent.wl) is stored as
+   the "SubmitUsageData" entry of the global settings file (see Files.wl), where every later server session finds it,
+   so nothing has to be re-deployed when it changes. Only an explicit False opts out: a missing setting (or file), or
+   anything else, means the default, which is to share usage data. *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*getGlobalUsageDataSetting*)
+getGlobalUsageDataSetting // beginDefinition;
+getGlobalUsageDataSetting[ ] := getGlobalSetting[ "SubmitUsageData" ] =!= False;
+getGlobalUsageDataSetting // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*setGlobalUsageDataSetting*)
+setGlobalUsageDataSetting // beginDefinition;
+setGlobalUsageDataSetting[ setting: True|False ] := setGlobalSetting[ "SubmitUsageData", setting ];
+setGlobalUsageDataSetting // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Specs/UsageData.md
+++ b/Specs/UsageData.md
@@ -32,8 +32,8 @@ Events, for `tools/call` and `prompts/get` only:
 
 - `InstallMCPServer` gets a `"SubmitUsageData"` option (default `Automatic`). `True`/`False` write `SUBMIT_USAGE_DATA=true|false` into the server's environment in the MCP configuration; `Automatic` writes nothing. Other values fail with `InvalidSubmitUsageData`. `DeployAgentTools` forwards the option like every other `InstallMCPServer` option and records it with the deployment.
 - The built-in servers get `"EnableUsageData" -> True` in their metadata.
-- At server start: if `SUBMIT_USAGE_DATA` holds a boolean, it wins (an explicit `True` also tracks custom servers, an explicit `False` opts a built-in server out); otherwise the server's `"EnableUsageData"` property must be exactly `True`.
-- `CreatePreferencesContent` shows a checkbox (checked by default) whose state is stored in `CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SubmitUsageData"}]`. Checked adds nothing to deployments (`Automatic`); unchecked adds `"SubmitUsageData" -> False`. Toggling re-deploys every existing deployment of a built-in toolset, preserving its other options, so the change takes effect without re-configuring each client; the re-deployment runs as a session task rather than in the checkbox's preemptive evaluation.
+- At server start: if `SUBMIT_USAGE_DATA` holds a boolean, it wins (an explicit `True` also tracks custom servers, an explicit `False` opts a built-in server out); otherwise the server's `"EnableUsageData"` property must be exactly `True` and the global setting (next bullet) must not be `False`.
+- `CreatePreferencesContent` shows a checkbox (checked by default) whose state is a single global setting on disk: the `"SubmitUsageData"` entry of `$rootPath/GlobalSettings.wxf`, a WXF association meant to hold other machine-wide settings later (`readGlobalSettings`/`getGlobalSetting`/`setGlobalSetting` in `Kernel/Files.wl`, wrapped by `getGlobalUsageDataSetting`/`setGlobalUsageDataSetting` in `Kernel/Server/UsageData.wl`). Only an explicit `False` opts out. The checkbox is a `DynamicModule` whose `Initialization` reads the setting when the panel is displayed and whose `Dynamic` setter writes it. Since every server session reads the setting when it starts, nothing is re-deployed when it changes, and deployments made from the panel pass no `"SubmitUsageData"` option. (An earlier design kept the state in the front end and re-deployed every built-in toolset on each toggle, which was far too slow.)
 - Development-mode servers are tracked like any other built-in server. Test servers are not: `GetMCPEnvironment` sets `SUBMIT_USAGE_DATA=false`.
 
 ## How It Is Tracked
@@ -82,23 +82,25 @@ We cannot know when a session's last message has arrived, so sessions are submit
 
 | File | Change |
 |------|--------|
-| `Kernel/Server/UsageData.wl` | New: configuration, session state, `usageDataEnabledQ`, `initializeUsageData`, `recordUsageData`, session file, keep-alive task, locked submission |
+| `Kernel/Server/UsageData.wl` | New: configuration, session state, `usageDataEnabledQ`, `getGlobalUsageDataSetting`/`setGlobalUsageDataSetting`, `initializeUsageData`, `recordUsageData`, session file, keep-alive task, locked submission |
 | `Kernel/Server/Server.wl` | Declare the shared session symbols and hooks; load the new subcontext |
 | `Kernel/Server/Local.wl` | Call the hooks |
 | `Kernel/DefaultServers.wl` | `"EnableUsageData" -> True` on the four built-in servers |
 | `Kernel/InstallMCPServer.wl` | `"SubmitUsageData"` option, validation, `SUBMIT_USAGE_DATA` in `addEnvironmentVariables` |
 | `Kernel/Messages.wl` | `InvalidSubmitUsageData` |
-| `Kernel/PreferencesContent.wl` | Checkbox, setting helpers, re-deployment; deployments from the panel pass the opt-out |
+| `Kernel/Files.wl` | The global settings file: `$globalSettingsFile`, `readGlobalSettings`, `getGlobalSetting`, `setGlobalSetting` |
+| `Kernel/PreferencesContent.wl` | Checkbox reading and writing the global setting; deployments from the panel pass nothing |
 | `FrontEnd/Assets/AgentTools.wl` | `prefsSubmitUsageData` and `prefsSubmitUsageDataDescription` strings (English only until localized) |
 | `Tests/UsageData.wlt` | Unit tests (enabling logic, recording, payload/JSON, keep-alive, staleness, locked submission with a stubbed HTTP call) and server integration tests |
-| `Tests/InstallMCPServer.wlt`, `Tests/MCPServerObject.wlt`, `Tests/PreferencesContent.wlt` | Option, property, and panel tests |
+| `Tests/InstallMCPServer.wlt`, `Tests/MCPServerObject.wlt`, `Tests/PreferencesContent.wlt`, `Tests/Files.wlt` | Option, property, panel (checkbox structure and setter), and global-settings-file tests |
 | `Tests/MCPServerTestUtilities.wl` | `SUBMIT_USAGE_DATA=false` for test servers; `"Environment"` option of `StartMCPTestServer` |
 | `docs/usage-data.md` and related docs | Documentation |
 
 ## Testing
 
-- `usageDataEnabledQ`: property vs. environment precedence, non-boolean values ignored.
-- `initializeUsageData`: session ID always assigned; tasks only when enabled; never fails startup.
+- `usageDataEnabledQ`: property vs. environment precedence, non-boolean values ignored, global opt-out honored (and still overridden by the environment), opt-in restores the default.
+- Global settings file: missing/unreadable file counts as no settings, set/get round trip, merge preserves other keys; `getGlobalUsageDataSetting` treats only an explicit `False` as an opt-out; `setGlobalUsageDataSetting` rejects non-booleans; the checkbox's setter writes the file.
+- `initializeUsageData`: session ID always assigned; tasks only when enabled; the global opt-out is read at startup; never fails startup.
 - `recordUsageData`: client information, tool/prompt events, success/failure cases, unknown names recorded as `Null`, no arguments or results in the file, other methods ignored, disabled sessions record nothing, event cap, failure isolation.
 - Payload JSON round trip.
 - Keep-alive touch, stale-file detection (current session excluded).

--- a/Tests/Common.wl
+++ b/Tests/Common.wl
@@ -9,6 +9,7 @@ BeginPackage[ "Wolfram`AgentToolsTests`" ];
 `environmentBlock;
 `skipIfGitHubActions;
 `skipIfScript;
+`withTemporaryRoot;
 
 Begin[ "`Private`" ];
 
@@ -71,6 +72,23 @@ environmentBlock[ name_ -> value_, eval_ ] :=
     With[ { previous = Replace[ Environment @ name, $Failed -> None ] },
         SetEnvironment[ name -> value ];
         WithCleanup[ eval, SetEnvironment[ name -> previous ] ]
+    ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*withTemporaryRoot*)
+(* Evaluates eval with the paclet's data directory ($rootPath, which holds e.g. the global settings file and the
+   session files of usage data) pointed at a fresh temporary directory, which is removed afterward -- including
+   on abort/failure via WithCleanup. Usage: withTemporaryRoot @ someExpr. *)
+withTemporaryRoot // Attributes = { HoldFirst };
+
+withTemporaryRoot[ eval_ ] :=
+    Module[ { root },
+        root = FileNameJoin @ { $TemporaryDirectory, "AgentToolsTestRoot_" <> CreateUUID[ ] };
+        WithCleanup[
+            Block[ { Wolfram`AgentTools`Common`$rootPath = root }, eval ],
+            Quiet @ DeleteDirectory[ root, DeleteContents -> True ]
+        ]
     ];
 
 (* ::**************************************************************************************************************:: *)

--- a/Tests/Files.wlt
+++ b/Tests/Files.wlt
@@ -67,3 +67,83 @@ VerificationTest[
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Global Settings*)
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* Machine-wide settings live in a single WXF association directly under $rootPath (see docs/usage-data.md) *)
+VerificationTest[
+    withTemporaryRoot[
+        Wolfram`AgentTools`Common`$globalSettingsFile ===
+            FileNameJoin @ { Wolfram`AgentTools`Common`$rootPath, "GlobalSettings.wxf" }
+    ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "GlobalSettings-FileLocation@@Tests/Files.wlt:78,1-86,2"
+]
+
+(* Nothing has been set yet: reading gives no settings and creates nothing *)
+VerificationTest[
+    withTemporaryRoot @ {
+        Wolfram`AgentTools`Common`readGlobalSettings[ ],
+        Wolfram`AgentTools`Common`getGlobalSetting[ "Anything" ],
+        Wolfram`AgentTools`Common`getGlobalSetting[ "Anything", "default" ],
+        FileExistsQ @ Wolfram`AgentTools`Common`$globalSettingsFile,
+        DirectoryQ @ Wolfram`AgentTools`Common`$rootPath
+    },
+    { <| |>, Missing[ "KeyAbsent", "Anything" ], "default", False, False },
+    SameTest -> SameQ,
+    TestID   -> "GlobalSettings-Unset@@Tests/Files.wlt:89,1-100,2"
+]
+
+(* Setting a value creates the file (and its directory) and returns the value *)
+VerificationTest[
+    withTemporaryRoot @ {
+        Wolfram`AgentTools`Common`setGlobalSetting[ "A", 1 ],
+        FileExistsQ @ Wolfram`AgentTools`Common`$globalSettingsFile,
+        Developer`ReadWXFFile @ Wolfram`AgentTools`Common`$globalSettingsFile,
+        Wolfram`AgentTools`Common`getGlobalSetting[ "A" ],
+        Wolfram`AgentTools`Common`getGlobalSetting[ "A", "default" ],
+        Wolfram`AgentTools`Common`readGlobalSettings[ ]
+    },
+    { 1, True, <| "A" -> 1 |>, 1, 1, <| "A" -> 1 |> },
+    SameTest -> SameQ,
+    TestID   -> "GlobalSettings-SetAndGet@@Tests/Files.wlt:103,1-115,2"
+]
+
+(* New values are merged into the existing settings, so setting one never loses another *)
+VerificationTest[
+    withTemporaryRoot @ (
+        Wolfram`AgentTools`Common`setGlobalSetting[ "A", 1 ];
+        Wolfram`AgentTools`Common`setGlobalSetting[ "B", { "x", "y" } ];
+        Wolfram`AgentTools`Common`setGlobalSetting[ "A", False ];
+        Wolfram`AgentTools`Common`readGlobalSettings[ ]
+    ),
+    <| "A" -> False, "B" -> { "x", "y" } |>,
+    SameTest -> SameQ,
+    TestID   -> "GlobalSettings-Merge@@Tests/Files.wlt:118,1-128,2"
+]
+
+(* A file that cannot be read, or that does not hold an association, counts as no settings and is replaced by the
+   next write *)
+VerificationTest[
+    withTemporaryRoot @ Module[ { file, text, list, written },
+        file = Wolfram`AgentTools`Common`$globalSettingsFile;
+        CreateDirectory @ Wolfram`AgentTools`Common`$rootPath;
+        Export[ file, "not a WXF file", "Text" ];
+        text = Wolfram`AgentTools`Common`readGlobalSettings[ ];
+        Developer`WriteWXFFile[ file, { 1, 2, 3 } ];
+        list = Wolfram`AgentTools`Common`readGlobalSettings[ ];
+        Wolfram`AgentTools`Common`setGlobalSetting[ "A", 1 ];
+        written = Wolfram`AgentTools`Common`readGlobalSettings[ ];
+        { text, list, written }
+    ],
+    { <| |>, <| |>, <| "A" -> 1 |> },
+    SameTest -> SameQ,
+    TestID   -> "GlobalSettings-Unreadable@@Tests/Files.wlt:132,1-147,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/PreferencesContent.wlt
+++ b/Tests/PreferencesContent.wlt
@@ -42,69 +42,66 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
-(*Usage Data Opt-Out*)
+(*Usage Data Checkbox*)
 (* :!CodeAnalysis::BeginBlock:: *)
 (* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
 
-(* Without a front end there is no stored setting, which means the default: usage data is shared and deployments
-   made from the panel get no extra options. *)
+(* The checkbox is a DynamicModule that reads the global setting when it is displayed and writes it when toggled;
+   nothing is re-deployed and no InstallMCPServer option is involved. *)
 VerificationTest[
-    Wolfram`AgentTools`PreferencesContent`Private`usageDataOptOutQ[ ],
-    False,
-    SameTest -> SameQ,
-    TestID   -> "PreferencesContent-UsageDataOptOutQ-Default@@Tests/PreferencesContent.wlt:51,1-56,2"
-]
-
-VerificationTest[
-    Wolfram`AgentTools`PreferencesContent`Private`usageDataDeployOptions[ ],
-    { },
-    SameTest -> SameQ,
-    TestID   -> "PreferencesContent-UsageDataDeployOptions-Default@@Tests/PreferencesContent.wlt:58,1-63,2"
-]
-
-VerificationTest[
-    Block[ { Wolfram`AgentTools`PreferencesContent`Private`usageDataOptOutQ = True & },
-        Wolfram`AgentTools`PreferencesContent`Private`usageDataDeployOptions[ ]
+    Wolfram`AgentTools`PreferencesContent`Private`usageDataCheckbox[ ],
+    Grid[
+        { {
+            (* Verbatim heads keep the pattern from being evaluated (or linted) as an actual DynamicModule *)
+            Verbatim[ DynamicModule ][
+                { Verbatim[ Set ][ _Symbol, True ] },
+                Checkbox @ Dynamic[ _Symbol, _Function ],
+                Initialization :> Verbatim[ Set ][ _Symbol, Wolfram`AgentTools`Common`getGlobalUsageDataSetting[ ] ],
+                ___ (* the kernel appends DynamicModuleValues :> { } when it evaluates a DynamicModule *)
+            ],
+            _Tooltip
+        } },
+        ___
     ],
-    { "SubmitUsageData" -> False },
-    SameTest -> SameQ,
-    TestID   -> "PreferencesContent-UsageDataDeployOptions-OptedOut@@Tests/PreferencesContent.wlt:65,1-72,2"
+    SameTest -> MatchQ,
+    TestID   -> "PreferencesContent-UsageDataCheckbox-Structure@@Tests/PreferencesContent.wlt:51,1-68,2"
 ]
 
-(* Re-deploying an existing deployment applies the current setting and keeps the deployment's other options *)
+(* Toggling the checkbox writes the global setting (the Dynamic's setter is applied by hand, since there is no
+   front end to display the DynamicModule) *)
 VerificationTest[
-    Module[ { configFile, dep, optedOut, env1, options, optedIn, env2 },
-        configFile = File @ FileNameJoin @ { $TemporaryDirectory, StringJoin[ "usage_prefs_", CreateUUID[], ".json" ] };
-        dep = DeployAgentTools[ configFile, "Wolfram", "ApplicationName" -> "ClaudeCode", "EnableMCPApps" -> False, "VerifyLLMKit" -> False ];
-
-        optedOut = Block[ { Wolfram`AgentTools`PreferencesContent`Private`usageDataOptOutQ = True & },
-            Wolfram`AgentTools`PreferencesContent`Private`redeployForUsageData @ dep
+    withTemporaryRoot @ Module[ { setter },
+        setter = First @ Cases[
+            Wolfram`AgentTools`PreferencesContent`Private`usageDataCheckbox[ ],
+            Checkbox[ Dynamic[ _, f_ ] ] :> f,
+            Infinity
         ];
-        env1 = Developer`ReadRawJSONString[ ReadString @ First @ configFile ][ "mcpServers", "Wolfram", "env" ];
-        options = Normal @ optedOut[ "MCP", "Options" ];
-
-        optedIn = Block[ { Wolfram`AgentTools`PreferencesContent`Private`usageDataOptOutQ = False & },
-            Wolfram`AgentTools`PreferencesContent`Private`redeployForUsageData @ optedOut
-        ];
-        env2 = Developer`ReadRawJSONString[ ReadString @ First @ configFile ][ "mcpServers", "Wolfram", "env" ];
-
-        DeleteObject[ optedIn ];
-        Quiet @ DeleteFile @ First @ configFile;
-
-        {
-            Head @ optedOut,
-            Lookup[ env1, "SUBMIT_USAGE_DATA", Missing[ "Absent" ] ],
-            Lookup[ env1, "MCP_APPS_ENABLED", Missing[ "Absent" ] ],
-            MemberQ[ options, "EnableMCPApps" -> False ],
-            MemberQ[ options, "SubmitUsageData" -> False ],
-            Head @ optedIn,
-            Lookup[ env2, "SUBMIT_USAGE_DATA", Missing[ "Absent" ] ],
-            Lookup[ env2, "MCP_APPS_ENABLED", Missing[ "Absent" ] ]
-        }
+        Block[ { Wolfram`AgentTools`PreferencesContent`Private`submit },
+            {
+                Wolfram`AgentTools`Common`getGlobalUsageDataSetting[ ],
+                setter[ False ],
+                Wolfram`AgentTools`PreferencesContent`Private`submit,
+                Wolfram`AgentTools`Common`getGlobalUsageDataSetting[ ],
+                Developer`ReadWXFFile @ Wolfram`AgentTools`Common`$globalSettingsFile,
+                setter[ True ],
+                Wolfram`AgentTools`Common`getGlobalUsageDataSetting[ ]
+            }
+        ]
     ],
-    { AgentToolsDeployment, "false", "false", True, True, AgentToolsDeployment, Missing[ "Absent" ], "false" },
+    { True, False, False, False, <| "SubmitUsageData" -> False |>, True, True },
     SameTest -> SameQ,
-    TestID   -> "PreferencesContent-RedeployForUsageData@@Tests/PreferencesContent.wlt:75,1-108,2"
+    TestID   -> "PreferencesContent-UsageDataCheckbox-Setter@@Tests/PreferencesContent.wlt:72,1-94,2"
+]
+
+(* Toggling the checkbox only writes the setting: no deployment is touched, and nothing is queued *)
+VerificationTest[
+    FreeQ[
+        Wolfram`AgentTools`PreferencesContent`Private`usageDataCheckbox[ ],
+        DeployAgentTools | InstallMCPServer | DeployedAgentTools | SessionSubmit | "SubmitUsageData"
+    ],
+    True,
+    SameTest -> SameQ,
+    TestID   -> "PreferencesContent-UsageDataCheckbox-NoRedeploy@@Tests/PreferencesContent.wlt:97,1-105,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/UsageData.wlt
+++ b/Tests/UsageData.wlt
@@ -42,11 +42,14 @@ staleUsageFileQ     = Wolfram`AgentTools`Server`UsageData`Private`staleUsageFile
 fileAge             = Wolfram`AgentTools`Server`UsageData`Private`fileAge;
 submitUsageData     = Wolfram`AgentTools`Server`UsageData`Private`submitUsageData;
 submitUsagePayload  = Wolfram`AgentTools`Server`UsageData`Private`submitUsagePayload;
+getGlobalUsageDataSetting = Wolfram`AgentTools`Common`getGlobalUsageDataSetting;
+setGlobalUsageDataSetting = Wolfram`AgentTools`Common`setGlobalUsageDataSetting;
 
 usageStatsFile[ ] := Wolfram`AgentTools`Server`UsageData`Private`$usageStatsFile;
 usageDataPath[ ]  := Wolfram`AgentTools`Server`UsageData`Private`$usageDataPath;
 sessionData[ ]    := Developer`ReadWXFFile @ usageStatsFile[ ];
 usageEvents[ ]    := Internal`BagPart[ Wolfram`AgentTools`Server`$usageEvents, All ];
+globalSettingsFile[ ] := Wolfram`AgentTools`Common`$globalSettingsFile;
 
 $testTool = LLMTool[ "PrimeFinder", { "n" -> "Integer" }, Prime[ #n ] & ];
 
@@ -116,7 +119,7 @@ VerificationTest[
     Wolfram`AgentTools`Server`UsageData`Private`$usageDataEndpoint,
     "https://www.wolframcloud.com/obj/wolframai-content/api/1.0/usage",
     SameTest -> SameQ,
-    TestID   -> "UsageData-Endpoint@@Tests/UsageData.wlt:115,1-120,2"
+    TestID   -> "UsageData-Endpoint@@Tests/UsageData.wlt:118,1-123,2"
 ]
 
 (* Outside a server session nothing is tracked *)
@@ -128,7 +131,68 @@ VerificationTest[
     },
     { False, None, Null },
     SameTest -> SameQ,
-    TestID   -> "UsageData-DisabledOutsideServer@@Tests/UsageData.wlt:123,1-132,2"
+    TestID   -> "UsageData-DisabledOutsideServer@@Tests/UsageData.wlt:126,1-135,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Global Setting*)
+(* The preferences panel's checkbox stores its state as the "SubmitUsageData" entry of the global settings file
+   ($rootPath/GlobalSettings.wxf), which is read again by every server session when it starts. *)
+
+(* Nothing stored means the default: usage data is shared, and no file is created just by asking *)
+VerificationTest[
+    withTemporaryRoot @ { getGlobalUsageDataSetting[ ], FileExistsQ @ globalSettingsFile[ ] },
+    { True, False },
+    SameTest -> SameQ,
+    TestID   -> "GlobalUsageDataSetting-Default@@Tests/UsageData.wlt:144,1-149,2"
+]
+
+(* Opting out and back in *)
+VerificationTest[
+    withTemporaryRoot @ {
+        setGlobalUsageDataSetting[ False ],
+        getGlobalUsageDataSetting[ ],
+        Developer`ReadWXFFile @ globalSettingsFile[ ],
+        setGlobalUsageDataSetting[ True ],
+        getGlobalUsageDataSetting[ ],
+        Developer`ReadWXFFile @ globalSettingsFile[ ]
+    },
+    { False, False, <| "SubmitUsageData" -> False |>, True, True, <| "SubmitUsageData" -> True |> },
+    SameTest -> SameQ,
+    TestID   -> "GlobalUsageDataSetting-SetAndGet@@Tests/UsageData.wlt:152,1-164,2"
+]
+
+(* Other global settings in the file are left alone *)
+VerificationTest[
+    withTemporaryRoot @ (
+        Wolfram`AgentTools`Common`setGlobalSetting[ "Other", 1 ];
+        setGlobalUsageDataSetting[ False ];
+        Developer`ReadWXFFile @ globalSettingsFile[ ]
+    ),
+    <| "Other" -> 1, "SubmitUsageData" -> False |>,
+    SameTest -> SameQ,
+    TestID   -> "GlobalUsageDataSetting-PreservesOtherSettings@@Tests/UsageData.wlt:167,1-176,2"
+]
+
+(* Only an explicit False opts out *)
+VerificationTest[
+    withTemporaryRoot @ (
+        Wolfram`AgentTools`Common`setGlobalSetting[ "SubmitUsageData", "no" ];
+        getGlobalUsageDataSetting[ ]
+    ),
+    True,
+    SameTest -> SameQ,
+    TestID   -> "GlobalUsageDataSetting-NonBooleanIgnored@@Tests/UsageData.wlt:179,1-187,2"
+]
+
+(* The setting can only be set to a boolean *)
+VerificationTest[
+    withTemporaryRoot @ Wolfram`AgentTools`Common`catchTop @ setGlobalUsageDataSetting[ "no" ],
+    Failure[ "AgentTools::Internal", _ ],
+    { General::AgentToolsInternal },
+    SameTest -> MatchQ,
+    TestID   -> "GlobalUsageDataSetting-InvalidValue@@Tests/UsageData.wlt:190,1-196,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -138,7 +202,7 @@ VerificationTest[
     booleanString /@ { "true", "TRUE", " yes ", "on", "1", "false", "No", "off", "0", "", "maybe", 1, None },
     { True, True, True, True, True, False, False, False, False, None, None, None, None },
     SameTest -> SameQ,
-    TestID   -> "UsageData-BooleanString@@Tests/UsageData.wlt:137,1-142,2"
+    TestID   -> "UsageData-BooleanString@@Tests/UsageData.wlt:201,1-206,2"
 ]
 
 $customServer = CreateMCPServer[
@@ -146,9 +210,9 @@ $customServer = CreateMCPServer[
     LLMConfiguration @ <| "Tools" -> { $testTool } |>
 ];
 
-(* Without SUBMIT_USAGE_DATA the server's "EnableUsageData" property decides *)
+(* Without SUBMIT_USAGE_DATA (and without a global opt-out) the server's "EnableUsageData" property decides *)
 VerificationTest[
-    environmentBlock[ "SUBMIT_USAGE_DATA" -> None,
+    withTemporaryRoot @ environmentBlock[ "SUBMIT_USAGE_DATA" -> None,
         {
             usageDataEnabledQ @ MCPServerObject[ "Wolfram" ],
             AllTrue[ Values @ $DefaultMCPServers, usageDataEnabledQ ],
@@ -158,7 +222,7 @@ VerificationTest[
     ],
     { True, True, False, False },
     SameTest -> SameQ,
-    TestID   -> "UsageDataEnabledQ-Property@@Tests/UsageData.wlt:150,1-162,2"
+    TestID   -> "UsageDataEnabledQ-Property@@Tests/UsageData.wlt:214,1-226,2"
 ]
 
 (* An explicit boolean in SUBMIT_USAGE_DATA takes precedence over the property in both directions *)
@@ -168,7 +232,7 @@ VerificationTest[
     ],
     { False, False },
     SameTest -> SameQ,
-    TestID   -> "UsageDataEnabledQ-EnvironmentFalse@@Tests/UsageData.wlt:165,1-172,2"
+    TestID   -> "UsageDataEnabledQ-EnvironmentFalse@@Tests/UsageData.wlt:229,1-236,2"
 ]
 
 VerificationTest[
@@ -177,17 +241,66 @@ VerificationTest[
     ],
     { True, True },
     SameTest -> SameQ,
-    TestID   -> "UsageDataEnabledQ-EnvironmentTrue@@Tests/UsageData.wlt:174,1-181,2"
+    TestID   -> "UsageDataEnabledQ-EnvironmentTrue@@Tests/UsageData.wlt:238,1-245,2"
 ]
 
 (* A value that is not a boolean is ignored *)
 VerificationTest[
-    environmentBlock[ "SUBMIT_USAGE_DATA" -> "maybe",
+    withTemporaryRoot @ environmentBlock[ "SUBMIT_USAGE_DATA" -> "maybe",
         { usageDataEnabledQ @ MCPServerObject[ "Wolfram" ], usageDataEnabledQ @ $customServer }
     ],
     { True, False },
     SameTest -> SameQ,
-    TestID   -> "UsageDataEnabledQ-EnvironmentNonBoolean@@Tests/UsageData.wlt:184,1-191,2"
+    TestID   -> "UsageDataEnabledQ-EnvironmentNonBoolean@@Tests/UsageData.wlt:248,1-255,2"
+]
+
+(* A global opt-out (the preferences panel's checkbox) turns tracking off for the built-in servers... *)
+VerificationTest[
+    withTemporaryRoot @ (
+        setGlobalUsageDataSetting[ False ];
+        environmentBlock[ "SUBMIT_USAGE_DATA" -> None,
+            {
+                usageDataEnabledQ @ MCPServerObject[ "Wolfram" ],
+                AnyTrue[ Values @ $DefaultMCPServers, usageDataEnabledQ ],
+                usageDataEnabledQ @ $customServer
+            }
+        ]
+    ),
+    { False, False, False },
+    SameTest -> SameQ,
+    TestID   -> "UsageDataEnabledQ-GlobalOptOut@@Tests/UsageData.wlt:258,1-272,2"
+]
+
+(* ...but an explicit boolean in SUBMIT_USAGE_DATA still takes precedence over it *)
+VerificationTest[
+    withTemporaryRoot @ (
+        setGlobalUsageDataSetting[ False ];
+        {
+            environmentBlock[ "SUBMIT_USAGE_DATA" -> "true",
+                { usageDataEnabledQ @ MCPServerObject[ "Wolfram" ], usageDataEnabledQ @ $customServer }
+            ],
+            environmentBlock[ "SUBMIT_USAGE_DATA" -> "maybe",
+                { usageDataEnabledQ @ MCPServerObject[ "Wolfram" ], usageDataEnabledQ @ $customServer }
+            ]
+        }
+    ),
+    { { True, True }, { False, False } },
+    SameTest -> SameQ,
+    TestID   -> "UsageDataEnabledQ-GlobalOptOutEnvironmentPrecedence@@Tests/UsageData.wlt:275,1-290,2"
+]
+
+(* Opting back in restores the default *)
+VerificationTest[
+    withTemporaryRoot @ (
+        setGlobalUsageDataSetting[ False ];
+        setGlobalUsageDataSetting[ True ];
+        environmentBlock[ "SUBMIT_USAGE_DATA" -> None,
+            { usageDataEnabledQ @ MCPServerObject[ "Wolfram" ], usageDataEnabledQ @ $customServer }
+        ]
+    ),
+    { True, False },
+    SameTest -> SameQ,
+    TestID   -> "UsageDataEnabledQ-GlobalOptIn@@Tests/UsageData.wlt:293,1-304,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -228,7 +341,7 @@ VerificationTest[
     ],
     { True, True, True, TaskObject, TaskObject, "Wolfram", False },
     SameTest -> SameQ,
-    TestID   -> "InitializeUsageData-Enabled@@Tests/UsageData.wlt:198,1-232,2"
+    TestID   -> "InitializeUsageData-Enabled@@Tests/UsageData.wlt:311,1-345,2"
 ]
 
 (* An untracked server still gets a session ID, but nothing else happens *)
@@ -252,7 +365,7 @@ VerificationTest[
     ],
     { False, False, True, None, None },
     SameTest -> SameQ,
-    TestID   -> "InitializeUsageData-Disabled@@Tests/UsageData.wlt:235,1-256,2"
+    TestID   -> "InitializeUsageData-Disabled@@Tests/UsageData.wlt:348,1-369,2"
 ]
 
 (* Opting out via the environment wins over the built-in server's property *)
@@ -270,7 +383,32 @@ VerificationTest[
     ],
     { False, False },
     SameTest -> SameQ,
-    TestID   -> "InitializeUsageData-OptedOut@@Tests/UsageData.wlt:259,1-274,2"
+    TestID   -> "InitializeUsageData-OptedOut@@Tests/UsageData.wlt:372,1-387,2"
+]
+
+(* A global opt-out (the preferences panel's checkbox) is read when the server starts *)
+VerificationTest[
+    withTemporaryRoot @ Block[
+        {
+            Wolfram`AgentTools`Server`$usageDataEnabled                     = False,
+            Wolfram`AgentTools`Server`$mcpSessionID                         = None,
+            Wolfram`AgentTools`Server`UsageData`Private`$usageKeepAliveTask = None,
+            Wolfram`AgentTools`Server`UsageData`Private`$usageSubmitTask    = None
+        },
+        setGlobalUsageDataSetting[ False ];
+        environmentBlock[ "SUBMIT_USAGE_DATA" -> None,
+            {
+                initializeUsageData @ MCPServerObject[ "Wolfram" ],
+                Wolfram`AgentTools`Server`$usageDataEnabled,
+                StringQ @ Wolfram`AgentTools`Server`$mcpSessionID,
+                Wolfram`AgentTools`Server`UsageData`Private`$usageKeepAliveTask,
+                Wolfram`AgentTools`Server`UsageData`Private`$usageSubmitTask
+            }
+        ]
+    ],
+    { False, False, True, None, None },
+    SameTest -> SameQ,
+    TestID   -> "InitializeUsageData-GlobalOptOut@@Tests/UsageData.wlt:390,1-412,2"
 ]
 
 (* Initialization never breaks server startup, even with a bogus server *)
@@ -286,7 +424,7 @@ VerificationTest[
     ],
     False,
     SameTest -> SameQ,
-    TestID   -> "InitializeUsageData-InvalidServer@@Tests/UsageData.wlt:277,1-290,2"
+    TestID   -> "InitializeUsageData-InvalidServer@@Tests/UsageData.wlt:415,1-428,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -318,7 +456,7 @@ VerificationTest[
         { "ClientInformation", "Events", "LastUpdated", "MCPSessionID", "PacletVersion", "ServerName", "SystemID", "WolframVersion" }
     },
     SameTest -> SameQ,
-    TestID   -> "RecordUsageData-Initialize@@Tests/UsageData.wlt:299,1-322,2"
+    TestID   -> "RecordUsageData-Initialize@@Tests/UsageData.wlt:437,1-460,2"
 ]
 
 (* The session file is named after the session ID and lives in $rootPath/UsageData *)
@@ -333,7 +471,7 @@ VerificationTest[
     ],
     { True, True, True },
     SameTest -> SameQ,
-    TestID   -> "RecordUsageData-SessionFileLocation@@Tests/UsageData.wlt:325,1-337,2"
+    TestID   -> "RecordUsageData-SessionFileLocation@@Tests/UsageData.wlt:463,1-475,2"
 ]
 
 (* Malformed initialize parameters are stored as Null rather than failing *)
@@ -344,7 +482,7 @@ VerificationTest[
     ],
     Null,
     SameTest -> SameQ,
-    TestID   -> "RecordUsageData-InitializeInvalidParams@@Tests/UsageData.wlt:340,1-348,2"
+    TestID   -> "RecordUsageData-InitializeInvalidParams@@Tests/UsageData.wlt:478,1-486,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -357,7 +495,7 @@ VerificationTest[
     ],
     { KeyValuePattern @ { "Type" -> "ToolCall", "Name" -> "PrimeFinder", "Success" -> True, "Timestamp" -> _Real } },
     SameTest -> MatchQ,
-    TestID   -> "RecordUsageData-ToolCallSuccess@@Tests/UsageData.wlt:353,1-361,2"
+    TestID   -> "RecordUsageData-ToolCallSuccess@@Tests/UsageData.wlt:491,1-499,2"
 ]
 
 VerificationTest[
@@ -369,7 +507,7 @@ VerificationTest[
     ],
     { { "Name", "Success", "Timestamp", "Type" }, True },
     SameTest -> SameQ,
-    TestID   -> "RecordUsageData-ToolCallEventShape@@Tests/UsageData.wlt:363,1-373,2"
+    TestID   -> "RecordUsageData-ToolCallEventShape@@Tests/UsageData.wlt:501,1-511,2"
 ]
 
 (* Neither arguments nor results are recorded *)
@@ -382,7 +520,7 @@ VerificationTest[
     ],
     { True, True, True, True },
     SameTest -> SameQ,
-    TestID   -> "RecordUsageData-ToolCallNoParameters@@Tests/UsageData.wlt:376,1-386,2"
+    TestID   -> "RecordUsageData-ToolCallNoParameters@@Tests/UsageData.wlt:514,1-524,2"
 ]
 
 (* Failures: tool errors, unknown tools (name not recorded), internal failures, and JSON-RPC errors *)
@@ -397,7 +535,7 @@ VerificationTest[
     ],
     { { "PrimeFinder", False }, { Null, False }, { "PrimeFinder", False }, { "PrimeFinder", False }, { Null, False } },
     SameTest -> SameQ,
-    TestID   -> "RecordUsageData-ToolCallFailures@@Tests/UsageData.wlt:389,1-401,2"
+    TestID   -> "RecordUsageData-ToolCallFailures@@Tests/UsageData.wlt:527,1-539,2"
 ]
 
 (* Events accumulate in order, and the file always holds all of them *)
@@ -411,7 +549,7 @@ VerificationTest[
     ],
     { { True, False, True }, 3, True },
     SameTest -> SameQ,
-    TestID   -> "RecordUsageData-EventsAccumulate@@Tests/UsageData.wlt:404,1-415,2"
+    TestID   -> "RecordUsageData-EventsAccumulate@@Tests/UsageData.wlt:542,1-553,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -427,7 +565,7 @@ VerificationTest[
     ],
     { { { "PromptGet", "Greet", True }, { "PromptGet", Null, False } }, True, True },
     SameTest -> SameQ,
-    TestID   -> "RecordUsageData-Prompts@@Tests/UsageData.wlt:420,1-431,2"
+    TestID   -> "RecordUsageData-Prompts@@Tests/UsageData.wlt:558,1-569,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -444,7 +582,7 @@ VerificationTest[
     ],
     { False, 0 },
     SameTest -> SameQ,
-    TestID   -> "RecordUsageData-OtherMethodsIgnored@@Tests/UsageData.wlt:436,1-448,2"
+    TestID   -> "RecordUsageData-OtherMethodsIgnored@@Tests/UsageData.wlt:574,1-586,2"
 ]
 
 VerificationTest[
@@ -462,7 +600,7 @@ VerificationTest[
     ],
     { Null, Null, False, False, Null, 0 },
     SameTest -> SameQ,
-    TestID   -> "RecordUsageData-DisabledRecordsNothing@@Tests/UsageData.wlt:450,1-466,2"
+    TestID   -> "RecordUsageData-DisabledRecordsNothing@@Tests/UsageData.wlt:588,1-604,2"
 ]
 
 (* The number of events per session is capped *)
@@ -475,7 +613,7 @@ VerificationTest[
     ],
     { 3, 3 },
     SameTest -> SameQ,
-    TestID   -> "RecordUsageData-EventLimit@@Tests/UsageData.wlt:469,1-479,2"
+    TestID   -> "RecordUsageData-EventLimit@@Tests/UsageData.wlt:607,1-617,2"
 ]
 
 (* A failure while recording (here: the session file cannot be written) is swallowed and never propagates to the
@@ -488,7 +626,7 @@ VerificationTest[
     ],
     { _Failure, 1 },
     SameTest -> MatchQ,
-    TestID   -> "RecordUsageData-FailuresAreIsolated@@Tests/UsageData.wlt:483,1-492,2"
+    TestID   -> "RecordUsageData-FailuresAreIsolated@@Tests/UsageData.wlt:621,1-630,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -515,7 +653,7 @@ VerificationTest[
         "LastUpdated"       -> _Real
     },
     SameTest -> MatchQ,
-    TestID   -> "UsageData-JSONPayload@@Tests/UsageData.wlt:497,1-519,2"
+    TestID   -> "UsageData-JSONPayload@@Tests/UsageData.wlt:635,1-657,2"
 ]
 
 (* The JSON is exactly what is stored in the session file *)
@@ -529,7 +667,7 @@ VerificationTest[
     ],
     True,
     SameTest -> SameQ,
-    TestID   -> "UsageData-JSONRoundTrip@@Tests/UsageData.wlt:522,1-533,2"
+    TestID   -> "UsageData-JSONRoundTrip@@Tests/UsageData.wlt:660,1-671,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -548,14 +686,14 @@ VerificationTest[
     ],
     { True, True, True, True },
     SameTest -> SameQ,
-    TestID   -> "UsageData-KeepAliveTouchesFile@@Tests/UsageData.wlt:538,1-552,2"
+    TestID   -> "UsageData-KeepAliveTouchesFile@@Tests/UsageData.wlt:676,1-690,2"
 ]
 
 VerificationTest[
     withUsageSession[ { touchUsageStatsFile[ ], FileExistsQ @ usageStatsFile[ ] } ],
     { Null, False },
     SameTest -> SameQ,
-    TestID   -> "UsageData-KeepAliveWithoutFile@@Tests/UsageData.wlt:554,1-559,2"
+    TestID   -> "UsageData-KeepAliveWithoutFile@@Tests/UsageData.wlt:692,1-697,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -577,7 +715,7 @@ VerificationTest[
     ],
     { True, False, False },
     SameTest -> SameQ,
-    TestID   -> "UsageData-StaleUsageFileQ@@Tests/UsageData.wlt:564,1-581,2"
+    TestID   -> "UsageData-StaleUsageFileQ@@Tests/UsageData.wlt:702,1-719,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -612,7 +750,7 @@ VerificationTest[
     ],
     { { "corrupt", "expired", "finished", "older" }, { "older", "finished" }, { "fresh" }, False },
     SameTest -> SameQ,
-    TestID   -> "SubmitUsageData-SubmitsFinishedSessions@@Tests/UsageData.wlt:589,1-616,2"
+    TestID   -> "SubmitUsageData-SubmitsFinishedSessions@@Tests/UsageData.wlt:727,1-754,2"
 ]
 
 (* A failed submission keeps the file and stops the batch *)
@@ -637,7 +775,7 @@ VerificationTest[
     ],
     { { }, 1, { "first", "second" } },
     SameTest -> SameQ,
-    TestID   -> "SubmitUsageData-FailureStopsBatch@@Tests/UsageData.wlt:619,1-641,2"
+    TestID   -> "SubmitUsageData-FailureStopsBatch@@Tests/UsageData.wlt:757,1-779,2"
 ]
 
 (* While another process holds the lock, this one skips its turn without waiting long *)
@@ -662,14 +800,14 @@ VerificationTest[
     ],
     { { }, 0, { "finished" }, True },
     SameTest -> SameQ,
-    TestID   -> "SubmitUsageData-LockHeld@@Tests/UsageData.wlt:644,1-666,2"
+    TestID   -> "SubmitUsageData-LockHeld@@Tests/UsageData.wlt:782,1-804,2"
 ]
 
 VerificationTest[
     submitUsageData @ FileNameJoin @ { $TemporaryDirectory, "does-not-exist-" <> CreateUUID[ ] },
     { },
     SameTest -> SameQ,
-    TestID   -> "SubmitUsageData-NoDirectory@@Tests/UsageData.wlt:668,1-673,2"
+    TestID   -> "SubmitUsageData-NoDirectory@@Tests/UsageData.wlt:806,1-811,2"
 ]
 
 (* The current session's file is never submitted, even when it looks old *)
@@ -687,7 +825,7 @@ VerificationTest[
     ],
     { { }, 0, True },
     SameTest -> SameQ,
-    TestID   -> "SubmitUsageData-CurrentSessionExcluded@@Tests/UsageData.wlt:676,1-691,2"
+    TestID   -> "SubmitUsageData-CurrentSessionExcluded@@Tests/UsageData.wlt:814,1-829,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -705,7 +843,7 @@ VerificationTest[
     ],
     False,
     SameTest -> SameQ,
-    TestID   -> "SubmitUsagePayload-Unreachable@@Tests/UsageData.wlt:698,1-709,2"
+    TestID   -> "SubmitUsagePayload-Unreachable@@Tests/UsageData.wlt:836,1-847,2"
 ]
 
 (* The development endpoint accepts a JSON body (skipped on CI, where network access is not guaranteed) *)
@@ -722,7 +860,7 @@ skipIfGitHubActions @ VerificationTest[
     |>,
     True,
     SameTest -> SameQ,
-    TestID   -> "SubmitUsagePayload-Endpoint@@Tests/UsageData.wlt:712,23-726,2"
+    TestID   -> "SubmitUsagePayload-Endpoint@@Tests/UsageData.wlt:850,23-864,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -743,7 +881,7 @@ skipIfScript @ VerificationTest[
     ],
     _ProcessObject,
     SameTest -> MatchQ,
-    TestID   -> "UsageData-Integration-ServerStarts@@Tests/UsageData.wlt:739,16-747,2"
+    TestID   -> "UsageData-Integration-ServerStarts@@Tests/UsageData.wlt:877,16-885,2"
 ]
 
 skipIfScript @ VerificationTest[
@@ -751,28 +889,28 @@ skipIfScript @ VerificationTest[
     MCPInitialize[ "ClientName" -> $usageClientName ],
     KeyValuePattern[ "result" -> _Association ],
     SameTest -> MatchQ,
-    TestID   -> "UsageData-Integration-Initialize@@Tests/UsageData.wlt:749,16-755,2"
+    TestID   -> "UsageData-Integration-Initialize@@Tests/UsageData.wlt:887,16-893,2"
 ]
 
 skipIfScript @ VerificationTest[
     SendMCPRequest[ "tools/call", <| "name" -> "WolframLanguageEvaluator", "arguments" -> <| "code" -> "Prime[1000]" |> |> ],
     KeyValuePattern[ "result" -> KeyValuePattern[ "isError" -> False ] ],
     SameTest -> MatchQ,
-    TestID   -> "UsageData-Integration-ToolCall@@Tests/UsageData.wlt:757,16-762,2"
+    TestID   -> "UsageData-Integration-ToolCall@@Tests/UsageData.wlt:895,16-900,2"
 ]
 
 skipIfScript @ VerificationTest[
     SendMCPRequest[ "tools/call", <| "name" -> "NoSuchTool", "arguments" -> <| |> |> ],
     KeyValuePattern[ "result" -> KeyValuePattern[ "isError" -> True ] ],
     SameTest -> MatchQ,
-    TestID   -> "UsageData-Integration-UnknownToolCall@@Tests/UsageData.wlt:764,16-769,2"
+    TestID   -> "UsageData-Integration-UnknownToolCall@@Tests/UsageData.wlt:902,16-907,2"
 ]
 
 skipIfScript @ VerificationTest[
     SendMCPRequest[ "prompts/get", <| "name" -> "NoSuchPrompt", "arguments" -> <| |> |> ],
     KeyValuePattern[ "error" -> _Association ],
     SameTest -> MatchQ,
-    TestID   -> "UsageData-Integration-UnknownPrompt@@Tests/UsageData.wlt:771,16-776,2"
+    TestID   -> "UsageData-Integration-UnknownPrompt@@Tests/UsageData.wlt:909,16-914,2"
 ]
 
 skipIfScript @ VerificationTest[
@@ -782,7 +920,7 @@ skipIfScript @ VerificationTest[
     ],
     _String? FileExistsQ,
     SameTest -> MatchQ,
-    TestID   -> "UsageData-Integration-SessionFileWritten@@Tests/UsageData.wlt:778,16-786,2"
+    TestID   -> "UsageData-Integration-SessionFileWritten@@Tests/UsageData.wlt:916,16-924,2"
 ]
 
 skipIfScript @ VerificationTest[
@@ -794,7 +932,7 @@ skipIfScript @ VerificationTest[
         KeyValuePattern @ { "Type" -> "PromptGet", "Name" -> Null, "Success" -> False }
     },
     SameTest -> MatchQ,
-    TestID   -> "UsageData-Integration-Events@@Tests/UsageData.wlt:788,16-798,2"
+    TestID   -> "UsageData-Integration-Events@@Tests/UsageData.wlt:926,16-936,2"
 ]
 
 skipIfScript @ VerificationTest[
@@ -806,7 +944,7 @@ skipIfScript @ VerificationTest[
     },
     { "WolframLanguage", "2024-11-05", True, True },
     SameTest -> SameQ,
-    TestID   -> "UsageData-Integration-Payload@@Tests/UsageData.wlt:800,16-810,2"
+    TestID   -> "UsageData-Integration-Payload@@Tests/UsageData.wlt:938,16-948,2"
 ]
 
 skipIfScript @ VerificationTest[
@@ -815,7 +953,7 @@ skipIfScript @ VerificationTest[
     FileExistsQ @ $usageFile,
     False,
     SameTest -> SameQ,
-    TestID   -> "UsageData-Integration-Cleanup@@Tests/UsageData.wlt:812,16-819,2"
+    TestID   -> "UsageData-Integration-Cleanup@@Tests/UsageData.wlt:950,16-957,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -833,7 +971,7 @@ skipIfScript @ VerificationTest[
     ],
     _Missing,
     SameTest -> MatchQ,
-    TestID   -> "UsageData-Integration-OptedOutWritesNothing@@Tests/UsageData.wlt:824,16-837,2"
+    TestID   -> "UsageData-Integration-OptedOutWritesNothing@@Tests/UsageData.wlt:962,16-975,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -843,7 +981,7 @@ VerificationTest[
     DeleteObject @ $customServer,
     Null,
     SameTest -> MatchQ,
-    TestID   -> "UsageData-Cleanup@@Tests/UsageData.wlt:842,1-847,2"
+    TestID   -> "UsageData-Cleanup@@Tests/UsageData.wlt:980,1-985,2"
 ]
 
 (* :!CodeAnalysis::EndBlock:: *)

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -684,7 +684,7 @@ Controls whether the installed server collects and submits [anonymous usage data
 
 | Value | Behavior |
 |-------|----------|
-| `Automatic` (default) | Nothing is added to the configuration; the server's `"EnableUsageData"` property decides, so built-in servers collect usage data and custom servers do not |
+| `Automatic` (default) | Nothing is added to the configuration; the server's `"EnableUsageData"` property decides, so built-in servers collect usage data (unless it has been turned off globally with the preferences panel's checkbox) and custom servers do not |
 | `False` | Opts out; sets `SUBMIT_USAGE_DATA=false` in the server environment |
 | `True` | Opts in even for a custom server; sets `SUBMIT_USAGE_DATA=true` |
 
@@ -692,7 +692,7 @@ Controls whether the installed server collects and submits [anonymous usage data
 InstallMCPServer["ClaudeCode", "WolframLanguage", "SubmitUsageData" -> False]
 ```
 
-Users who configure toolsets from the system preferences panel can opt out with its checkbox instead (see [preferences-content.md](preferences-content.md)).
+The system preferences panel's checkbox turns usage data off for every built-in server installation on the machine at once — a global setting that each server reads when it starts, so nothing needs to be re-installed — while an explicit `"SubmitUsageData"` value still takes precedence (see [preferences-content.md](preferences-content.md)).
 
 ### ToolOptions
 

--- a/docs/preferences-content.md
+++ b/docs/preferences-content.md
@@ -23,7 +23,7 @@ Selecting a toolset for a client calls `DeployAgentTools[client, server, Overwri
 CreatePreferencesContent[]
 ```
 
-Returns a `Deploy[Pane[...]]` expression suitable for embedding in a preferences panel.
+Returns a `Deploy[Pane[...]]` expression suitable for embedding in a preferences panel. Building it needs a front end (the subtitle is a `StringTemplate` assembled from a front-end string resource rather than a `Dynamic`), so the result is wrapped in `UsingFrontEnd`: a no-op in the preferences dialog's kernel, and a launch of a hidden front end for a headless kernel such as the test suite's.
 
 ## Panel Sections
 
@@ -51,12 +51,12 @@ Each client row contains:
 
 ### Usage Data Checkbox
 
-Below the client list, a checkbox labeled *Share anonymous usage data with Wolfram to help improve these tools* (checked by default, with a tooltip describing what is collected) controls the `"SubmitUsageData"` option of the deployments made from the panel. The state is stored in `CurrentValue[$FrontEnd, {PrivateFrontEndOptions, "InterfaceSettings", "ServicesForAIs", "SubmitUsageData"}]`; only an explicit `False` opts out.
+Below the client list, a checkbox labeled *Share anonymous usage data with Wolfram to help improve these tools* (checked by default, with a tooltip describing what is collected) controls whether the built-in toolsets collect usage data on this machine. Its state is a single global setting stored on disk — the `"SubmitUsageData"` entry of `$rootPath/GlobalSettings.wxf`, accessed through `getGlobalUsageDataSetting` and `setGlobalUsageDataSetting` (see [usage-data.md](usage-data.md)) — rather than anything in the clients' configurations; only an explicit `False` opts out.
 
-- Checked: deployments are made without the option, so the server's default applies (the built-in toolsets collect usage data).
-- Unchecked: deployments are made with `"SubmitUsageData" -> False`, which writes `SUBMIT_USAGE_DATA=false` into the client configuration.
+- Checked: `True` is stored (or nothing yet), so the server's default applies (the built-in toolsets collect usage data).
+- Unchecked: `False` is stored, and every built-in server session started afterward, from any installation, collects nothing.
 
-Toggling the checkbox re-deploys every existing deployment of a built-in toolset (global and per-directory), preserving the other options each deployment was made with, so the change takes effect immediately. The re-deployment is submitted as a session task (`SessionSubmit`) rather than run inside the checkbox's preemptive evaluation. See [usage-data.md](usage-data.md) for what is collected and how.
+Each server reads the setting when it starts, so toggling the checkbox takes effect for all installations without re-deploying any toolset, and deployments made from the panel never pass the `"SubmitUsageData"` option. The checkbox is a `DynamicModule` whose `Initialization` reads the stored value when the panel is displayed and whose `Dynamic` setter writes the new value. An installation that was made with an explicit `"SubmitUsageData"` value (`SUBMIT_USAGE_DATA` in its configuration) keeps that value regardless of the checkbox.
 
 ### Per-Directory Settings
 
@@ -84,6 +84,7 @@ To add new strings or icons, edit `FrontEnd/Assets/AgentTools.wl` and reference 
 ## Related Files
 
 - `Kernel/PreferencesContent.wl` — Implementation of `CreatePreferencesContent` and its helpers (`clientInterfaces`, `clientRow`, `clientControls`, `dirSettingsRow`, `infoLink`, `docsLink`, `usageDataCheckbox`)
+- `Kernel/Server/UsageData.wl` — `getGlobalUsageDataSetting` and `setGlobalUsageDataSetting`, the global setting behind `usageDataCheckbox` (stored in `GlobalSettings.wxf` by the helpers in `Kernel/Files.wl`)
 - `FrontEnd/Assets/AgentTools.wl` — Localized strings and graphics resources
 - `Kernel/DeployAgentTools.wl` — Deployment system used by the panel (see [deploy-agent-tools.md](deploy-agent-tools.md))
 - `Kernel/SupportedClients.wl` — Source of `$SupportedMCPClients` data shown for each client row

--- a/docs/servers.md
+++ b/docs/servers.md
@@ -200,7 +200,7 @@ server["EnableUsageData"]    (* True: the built-in servers collect anonymous usa
 
 ### Usage Data
 
-The predefined servers have `"EnableUsageData" -> True`, so their local sessions record which MCP client is used and which tools and prompts are called (never any content) and submit that data to Wolfram. Installations can opt out with `InstallMCPServer`'s `"SubmitUsageData" -> False` option or the preferences panel's checkbox. Custom servers do not have the property and are not tracked unless installed with `"SubmitUsageData" -> True`. See [usage-data.md](usage-data.md).
+The predefined servers have `"EnableUsageData" -> True`, so their local sessions record which MCP client is used and which tools and prompts are called (never any content) and submit that data to Wolfram. Installations can opt out with `InstallMCPServer`'s `"SubmitUsageData" -> False` option, and the preferences panel's checkbox turns usage data off globally for every built-in server session on the machine. Custom servers do not have the property and are not tracked unless installed with `"SubmitUsageData" -> True`. See [usage-data.md](usage-data.md).
 
 ## Creating Custom Servers
 

--- a/docs/usage-data.md
+++ b/docs/usage-data.md
@@ -39,7 +39,7 @@ Everything else in a request — in particular the `arguments` — is never look
 Whether a session is tracked is decided once, when the server starts (`initializeUsageData` in `Kernel/Server/UsageData.wl`):
 
 1. If the `SUBMIT_USAGE_DATA` environment variable holds a boolean (`true`/`false`, case-insensitive; `yes`/`no`, `on`/`off`, and `1`/`0` are accepted too), that value wins.
-2. Otherwise the session is tracked only if the server's `"EnableUsageData"` property is exactly `True`. The built-in servers set it (see `Kernel/DefaultServers.wl`); servers created with `CreateMCPServer` or defined by paclets do not have the property, so they are not tracked unless the environment variable says otherwise.
+2. Otherwise the session is tracked only if the server's `"EnableUsageData"` property is exactly `True` and usage data has not been turned off globally (see [Opting Out](#opting-out-or-in) below). The built-in servers set the property (see `Kernel/DefaultServers.wl`); servers created with `CreateMCPServer` or defined by paclets do not have it, so they are not tracked unless the environment variable says otherwise.
 
 ```wl
 MCPServerObject["WolframLanguage"]["EnableUsageData"]  (* True *)
@@ -61,7 +61,11 @@ InstallMCPServer["ClaudeCode", "WolframLanguage", "SubmitUsageData" -> False]
 
 Any other value is rejected with `InstallMCPServer::InvalidSubmitUsageData`.
 
-The system preferences panel built by `CreatePreferencesContent` (see [preferences-content.md](preferences-content.md)) has a checkbox, *Share anonymous usage data with Wolfram to help improve these tools*, which is checked by default. Unchecking it re-deploys the currently configured toolsets with `"SubmitUsageData" -> False` (keeping their other options) and applies to toolsets configured from the panel afterward; checking it again re-deploys them without the option.
+The system preferences panel built by `CreatePreferencesContent` (see [preferences-content.md](preferences-content.md)) has a checkbox, *Share anonymous usage data with Wolfram to help improve these tools*, which is checked by default. Its state is a single global setting on this machine rather than anything in the clients' configurations: unchecking it stores `"SubmitUsageData" -> False` in the global settings file (see below), and checking it again stores `True`. Every built-in server session reads the setting when it starts, so the change applies to all existing installations at once without re-deploying anything. Only an explicit `False` opts out, and an explicit `SUBMIT_USAGE_DATA` in a client configuration (from the `"SubmitUsageData"` option) still takes precedence over the global setting, in both directions.
+
+#### The Global Settings File
+
+Settings that apply to everything on the machine live in `$rootPath/GlobalSettings.wxf`, i.e. `$UserBaseDirectory/ApplicationData/Wolfram/AgentTools/GlobalSettings.wxf`: a WXF-encoded association that currently holds only `"SubmitUsageData"` but is meant to take other global settings in the future. `readGlobalSettings`, `getGlobalSetting`, and `setGlobalSetting` in `Kernel/Files.wl` read and write it (a missing or unreadable file counts as no settings; writing merges the new value into the existing ones), and `getGlobalUsageDataSetting`/`setGlobalUsageDataSetting` in `Kernel/Server/UsageData.wl` wrap its `"SubmitUsageData"` entry for the checkbox and for `usageDataEnabledQ`.
 
 Servers started by the test suite never track anything: `GetMCPEnvironment` in `Tests/MCPServerTestUtilities.wl` sets `SUBMIT_USAGE_DATA=false` for every test server.
 
@@ -95,13 +99,14 @@ Usage tracking must never interfere with the server: every hook is wrapped in `u
 
 | File | Role |
 |------|------|
-| `Kernel/Server/UsageData.wl` | Session state, enabling logic, recording, the session file, the keep-alive task, and locked submission |
+| `Kernel/Server/UsageData.wl` | Session state, enabling logic (including the global setting: `getGlobalUsageDataSetting`, `setGlobalUsageDataSetting`), recording, the session file, the keep-alive task, and locked submission |
 | `Kernel/Server/Local.wl` | Calls `initializeUsageData` when the server starts and `recordUsageData` after each handled request |
 | `Kernel/Server/Server.wl` | Declares the session symbols and hooks shared with the local transport |
 | `Kernel/DefaultServers.wl` | `"EnableUsageData" -> True` for the built-in servers |
 | `Kernel/InstallMCPServer.wl` | The `"SubmitUsageData"` option and the `SUBMIT_USAGE_DATA` environment variable |
-| `Kernel/PreferencesContent.wl` | The opt-out checkbox and re-deployment of configured toolsets |
-| `Tests/UsageData.wlt` | Unit tests and server integration tests |
+| `Kernel/Files.wl` | The global settings file: `$globalSettingsFile`, `readGlobalSettings`, `getGlobalSetting`, `setGlobalSetting` |
+| `Kernel/PreferencesContent.wl` | The opt-out checkbox, which reads and writes the global setting |
+| `Tests/UsageData.wlt`, `Tests/Files.wlt`, `Tests/PreferencesContent.wlt` | Unit tests and server integration tests; tests of the global settings file; tests of the checkbox |
 
 Session state lives in the `` Wolfram`AgentTools`Server` `` context: `$mcpSessionID`, `$mcpClientInformation`, `$usageEvents` (an `` Internal`Bag ``), and `$usageDataEnabled`. Tunable settings (endpoint, timeouts, intervals, limits) are file-scoped variables at the top of `Kernel/Server/UsageData.wl`.
 


### PR DESCRIPTION
## Summary

The *Share anonymous usage data* checkbox in the preferences panel (from #237) stored its state in the front end and re-deployed every configured built-in toolset whenever it was toggled — far too slow for a checkbox. This replaces that with a single machine-wide setting on disk that every built-in server reads when it starts, so toggling it is instant and never touches any client configuration.

- **Global settings store** (`Kernel/Files.wl`): `$rootPath/GlobalSettings.wxf` holds a WXF association read and written by `readGlobalSettings`, `getGlobalSetting`, and `setGlobalSetting` (a missing or unreadable file counts as no settings; writes merge into the existing settings). It currently has one entry, `"SubmitUsageData"`, but is meant to take other global settings later.
- **Enabling logic** (`Kernel/Server/UsageData.wl`): `getGlobalUsageDataSetting`/`setGlobalUsageDataSetting` wrap that entry (only an explicit `False` opts out), and `usageDataEnabledQ` now requires `"EnableUsageData" -> True` *and* no global opt-out when `SUBMIT_USAGE_DATA` is unset. An explicit `SUBMIT_USAGE_DATA` in a client configuration still wins in both directions, so the `"SubmitUsageData"` option of `InstallMCPServer` is unchanged.
- **Checkbox** (`Kernel/PreferencesContent.wl`): now a `DynamicModule` whose `Initialization` reads the stored value when the panel is displayed and whose `Dynamic` setter writes it (through `catchAlways`, so a failed write can't surface as an uncaught `Throw` in the front end). The `usageDataOptOutQ`/`usageDataDeployOptions`/`applyUsageDataSetting`/`redeployForUsageData` helpers are gone, and deployments made from the panel no longer pass `"SubmitUsageData"`.
- `CreatePreferencesContent` wraps its result in `UsingFrontEnd`: its subtitle is a `StringTemplate` built from a front-end string resource, so the panel can now be built (and smoke-tested) in a headless kernel without `FrontEndObject::notavail`.
- Tests: a shared `withTemporaryRoot` helper in `Tests/Common.wl` (Blocks `$rootPath` to a temporary directory); new tests in `Files.wlt`, `UsageData.wlt`, and `PreferencesContent.wlt`.
- Docs: `usage-data.md`, `preferences-content.md`, `mcp-clients.md`, `servers.md`, `Specs/UsageData.md`, `AGENTS.md`.

No migration of the old front-end setting is needed: the previous checkbox never shipped in a tagged release.

## Test plan

- [x] `Tests/Files.wlt`: settings file location; unset ⇒ `<||>` / `Missing` / default with nothing created; set/get round trip; merging keeps other keys; unreadable and non-association files count as no settings and are replaced by the next write
- [x] `Tests/UsageData.wlt`: `getGlobalUsageDataSetting` default / opt-out / opt-in, other settings preserved, only an explicit `False` opts out, non-boolean values rejected; `usageDataEnabledQ` honors the global opt-out, the environment variable still takes precedence, opting back in restores the default; `initializeUsageData` reads the opt-out at startup (the existing property-dependent tests now run under a temporary root so a developer's own opt-out can't affect them) — 59/59 including the subprocess integration tests
- [x] `Tests/PreferencesContent.wlt`: checkbox structure (`DynamicModule` whose `Initialization` reads the setting), the setter writes the file and updates the module variable, the checkbox contains no deploy/`SessionSubmit` logic; `CreatePreferencesContent-SmokeTest` now passes headlessly — 7/7
- [x] Regression: `InstallMCPServer.wlt`, `DeployAgentTools.wlt`, `MCPServerObject.wlt` — 689/689; CodeInspector clean on every changed file
- [ ] Preferences panel checkbox in the desktop front end (not verifiable headless here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdo7zY8D9SN5oYaBFvJ4k
