### PR TITLE
Fail gracefully without cloud access and build without the Function Repository

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ See [building.md](docs/building.md) for detailed instructions.
 - `Assets/`: Static assets bundled with the paclet
   - `Apps/`: HTML and JSON files for [MCP Apps](docs/mcp-apps.md) UI resources
   - `Cloud/`: Landing- and admin-page HTML/CSS/JS for [cloud-deployed MCP servers](Specs/CloudDeployment.md) — the dynamic `index.html` + `assets/` (fetches `/api/info`) and the self-contained owner-only `admin.html` (calls `/api/admin`), read via `PacletObject[…]["AssetLocation","Cloud"]`
+- `ResourceFunctions/`: Local copies of the Wolfram Function Repository functions the paclet uses (one `.wl` file per function, each wrapped in its own context), which `importResourceFunction` in `Kernel/Common.wl` prefers over fetching from the repository so that builds and source loads work without cloud access; not declared in `PacletInfo.wl`, so not part of the built paclet (see [building.md](docs/building.md#resource-functions-and-offline-builds) and [ResourceFunctions/README.md](ResourceFunctions/README.md))
 - `FrontEnd/`: FrontEnd extension resources loaded by the notebook front end
   - `Assets/AgentTools.wl`: Localized strings (`AgentToolsStrings`) and graphics (`AgentToolsExpressions`) used by `CreatePreferencesContent` (see [preferences-content.md](docs/preferences-content.md))
 - `Scripts/`: Contains utility scripts for building, testing, and running the paclet

--- a/Kernel/Common.wl
+++ b/Kernel/Common.wl
@@ -251,6 +251,45 @@ endExportedDefinition // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Resource Functions*)
+(* The paclet uses a few functions from the Wolfram Function Repository, pinned to the versions in $resourceVersions.
+   Each is imported with importResourceFunction, which takes the definition from a local copy in the paclet's
+   ResourceFunctions directory when there is one (see ResourceFunctions/README.md) and only otherwise fetches the
+   resource function, so neither building the paclet nor loading it from source requires cloud access.
+
+   When building the MX file, the definitions are inlined into the paclet in the context
+   $resourceFunctionContext<>name<>"`", so the built paclet never touches the Function Repository. When loading from
+   source, the import is resolved at the first use of the imported symbol and memoized only on success: a resource
+   function that is not available (no local copy and no cloud access) yields a resourceFunctionUnavailable placeholder
+   whose use fails with AgentTools::ResourceFunctionUnavailable, and the next use tries again. *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*$localResourceFunctionDirectory*)
+(* Determined from this file's location at load time, like $thisPaclet, since the directory is not part of the built
+   paclet. During an MX build this is the temporary copy of the paclet, which BuildMX.wls copies the directory into. *)
+$localResourceFunctionDirectory = FileNameJoin @ { DirectoryName[ $InputFileName, 2 ], "ResourceFunctions" };
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*localResourceFunctionFile*)
+localResourceFunctionFile // beginDefinition;
+
+localResourceFunctionFile[ name_String ] :=
+    localResourceFunctionFile[ name, $localResourceFunctionDirectory ];
+
+localResourceFunctionFile[ name_String, dir_String ] :=
+    With[ { file = FileNameJoin @ { dir, name<>".wl" } },
+        If[ FileExistsQ @ file, file, Missing[ "NotFound", name ] ]
+    ];
+
+localResourceFunctionFile[ name_String, _ ] :=
+    Missing[ "NotFound", name ];
+
+localResourceFunctionFile // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*importResourceFunction*)
 importResourceFunction // beginDefinition;
 importResourceFunction::failure = "[ERROR] Failed to import resource function `1`. Aborting MX build.";
 importResourceFunction // Attributes = { HoldFirst };
@@ -261,31 +300,29 @@ importResourceFunction[ name_String ] :=
 importResourceFunction[ symbol_Symbol, name_String ] :=
     importResourceFunction[ symbol, name, Lookup[ $resourceVersions, name ] ];
 
+(* MX build: inline the definitions into the paclet *)
 importResourceFunction[ symbol_Symbol, name_String, version_ ] /; $mxFlag := Enclose[
     Block[ { PrintTemporary },
-        Module[ { sourceContext, targetContext, definition, replaced, inlined, newSymbol },
+        Module[ { targetContext, replaced, inlined, newSymbol },
 
-            ConfirmAssert @ StringQ @ version;
-            sourceContext = ConfirmBy[ ResourceFunction[ name, "Context", ResourceVersion -> version ], StringQ ];
+            ConfirmAssert[ StringQ @ version, "Version" ];
             targetContext = $resourceFunctionContext<>name<>"`";
-            definition    = ConfirmMatch[ ResourceFunction[ name, "DefinitionList" ], _Language`DefinitionList ];
 
+            (* The definitions, in the target context: *)
             replaced = ConfirmMatch[
-                ResourceFunction[ "ReplaceContext", ResourceVersion -> $resourceVersions[ "ReplaceContext" ] ][
-                    definition,
-                    sourceContext -> targetContext
-                ],
-                _Language`DefinitionList
+                resourceFunctionDefinitionList[ name, version, targetContext ],
+                _Language`DefinitionList,
+                "DefinitionList"
             ];
 
-            inlined = ConfirmMatch[ inlineDependentResourceFunctions @ replaced, _Language`DefinitionList ];
+            inlined = ConfirmMatch[ inlineDependentResourceFunctions @ replaced, _Language`DefinitionList, "Inlined" ];
 
             $importedResourceFunctions[ name ] = version;
             KeyDropFrom[ $dependentResourceFunctions, Keys @ $importedResourceFunctions ];
 
-            ConfirmMatch[ Language`ExtendedFullDefinition[ ] = inlined, _Language`DefinitionList ];
+            ConfirmMatch[ Language`ExtendedFullDefinition[ ] = inlined, _Language`DefinitionList, "SetDefinition" ];
 
-            newSymbol = ConfirmMatch[ Symbol[ targetContext<>name ], _Symbol? AtomQ ];
+            newSymbol = ConfirmMatch[ Symbol[ targetContext<>name ], _Symbol? AtomQ, "Symbol" ];
 
             importResourceFunction[ symbol, name, version ] =
                 If[ Unevaluated @ symbol === None,
@@ -297,12 +334,213 @@ importResourceFunction[ symbol_Symbol, name_String, version_ ] /; $mxFlag := Enc
     (Message[ importResourceFunction::failure, name ]; Abort[ ]) &
 ];
 
+(* Loading from source: resolve the import at the first use of the symbol, memoizing only on success *)
 importResourceFunction[ symbol: Except[ None, _Symbol ], name_String, version_String ] :=
-    symbol := symbol = Block[ { PrintTemporary }, ResourceFunction[ name, "Function", ResourceVersion -> version ] ];
+    symbol := resolveResourceFunction[ symbol, name, version ];
+
+(* Loading from source: a resource function that a local definition depends on (see inlineDependentResourceFunctions),
+   which then has a local definition itself *)
+importResourceFunction[ None, name_String, version_String ] :=
+    With[ { file = localResourceFunctionFile @ name },
+        loadLocalResourceFunction[ name, file ] /; StringQ @ file
+    ];
 
 importResourceFunction // endDefinition;
 
 $importedResourceFunctions = <| |>;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*resolveResourceFunction*)
+resolveResourceFunction // beginDefinition;
+resolveResourceFunction // Attributes = { HoldFirst };
+
+resolveResourceFunction[ symbol_Symbol, name_String, version_String ] :=
+    Module[ { function },
+        function = Block[ { PrintTemporary }, getResourceFunction[ name, version ] ];
+        If[ resourceFunctionSymbolQ @ function,
+            symbol = function,
+            resourceFunctionUnavailable @ name
+        ]
+    ];
+
+resolveResourceFunction // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*resourceFunctionSymbolQ*)
+(* A resolved resource function is a symbol outside System`, since ResourceFunction gives $Failed on failure *)
+resourceFunctionSymbolQ // beginDefinition;
+resourceFunctionSymbolQ[ s_Symbol ] := Context @ s =!= "System`";
+resourceFunctionSymbolQ[ _ ] := False;
+resourceFunctionSymbolQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*resourceFunctionUnavailable*)
+(* Placeholder for an imported resource function that could not be resolved: applying it to arguments fails with a
+   message instead of producing a garbled expression. It is never memoized (see resolveResourceFunction). *)
+resourceFunctionUnavailable // ClearAll;
+resourceFunctionUnavailable[ name_String ][ ___ ] := throwFailure[ "ResourceFunctionUnavailable", name ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*resourceFunctionAvailableQ*)
+(* Whether an imported resource function symbol (e.g. readableForm) resolved to a usable function *)
+resourceFunctionAvailableQ // beginDefinition;
+resourceFunctionAvailableQ[ _resourceFunctionUnavailable ] := False;
+resourceFunctionAvailableQ[ s_Symbol ] := resourceFunctionSymbolQ @ s;
+resourceFunctionAvailableQ[ _ ] := False;
+resourceFunctionAvailableQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*getResourceFunction*)
+(* The function symbol of a resource function: from a local definition if there is one, otherwise from the Function
+   Repository (which gives $Failed or Missing when it cannot be reached) *)
+getResourceFunction // beginDefinition;
+
+getResourceFunction[ name_String, version_String ] :=
+    getResourceFunction[ name, version, localResourceFunctionFile @ name ];
+
+(* A local definition that was already loaded as a dependency of another one is not loaded again *)
+getResourceFunction[ name_String, version_String, file_String ] :=
+    If[ KeyExistsQ[ $importedResourceFunctions, name ],
+        Symbol[ $resourceFunctionContext<>name<>"`"<>name ],
+        loadLocalResourceFunction[ name, file ]
+    ];
+
+getResourceFunction[ name_String, version_String, _Missing ] :=
+    Quiet @ ResourceFunction[ name, "Function", ResourceVersion -> version ];
+
+getResourceFunction // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*loadLocalResourceFunction*)
+(* Loads a local definition into its target context, rewrites its references to other resource functions to their
+   local symbols (loading those as well) and returns the function's symbol *)
+loadLocalResourceFunction // beginDefinition;
+
+loadLocalResourceFunction[ name_String, file_String ] := Enclose[
+    Module[ { targetContext, definition, inlined },
+        targetContext = $resourceFunctionContext<>name<>"`";
+
+        definition = ConfirmMatch[
+            localResourceFunctionDefinitionList[ name, file, targetContext ],
+            _Language`DefinitionList,
+            "DefinitionList"
+        ];
+
+        inlined = ConfirmMatch[ inlineDependentResourceFunctions @ definition, _Language`DefinitionList, "Inlined" ];
+
+        $importedResourceFunctions[ name ] = Lookup[ $resourceVersions, name, None ];
+        KeyDropFrom[ $dependentResourceFunctions, Keys @ $importedResourceFunctions ];
+
+        ConfirmMatch[ Language`ExtendedFullDefinition[ ] = inlined, _Language`DefinitionList, "SetDefinition" ];
+        importDependentResourceFunctions[ ];
+
+        ConfirmMatch[ Symbol[ targetContext<>name ], _Symbol? AtomQ, "Symbol" ]
+    ],
+    throwInternalFailure
+];
+
+loadLocalResourceFunction // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*resourceFunctionDefinitionList*)
+(* The definitions of a resource function as a DefinitionList in the given context: from the local definition if there
+   is one, otherwise fetched from the Function Repository *)
+resourceFunctionDefinitionList // beginDefinition;
+
+resourceFunctionDefinitionList[ name_String, version_String, targetContext_String ] :=
+    resourceFunctionDefinitionList[ name, version, targetContext, localResourceFunctionFile @ name ];
+
+resourceFunctionDefinitionList[ name_String, version_String, targetContext_String, file_String ] :=
+    localResourceFunctionDefinitionList[ name, file, targetContext ];
+
+resourceFunctionDefinitionList[ name_String, version_String, targetContext_String, _Missing ] := Enclose[
+    Module[ { sourceContext, definition },
+
+        sourceContext = ConfirmBy[ ResourceFunction[ name, "Context", ResourceVersion -> version ], StringQ, "Context" ];
+        definition    = ConfirmMatch[ ResourceFunction[ name, "DefinitionList" ], _Language`DefinitionList, "DefinitionList" ];
+
+        ConfirmMatch[
+            ResourceFunction[ "ReplaceContext", ResourceVersion -> $resourceVersions[ "ReplaceContext" ] ][
+                definition,
+                sourceContext -> targetContext
+            ],
+            _Language`DefinitionList,
+            "Replaced"
+        ]
+    ],
+    throwInternalFailure
+];
+
+resourceFunctionDefinitionList // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*localResourceFunctionDefinitionList*)
+(* Loads a local definition file (which wraps the definition in BeginPackage/EndPackage for the target context, so its
+   symbols are created there) and collects the definitions of the symbols in that context. The Block keeps the file's
+   BeginPackage/EndPackage from leaving the context on the caller's $ContextPath. *)
+localResourceFunctionDefinitionList // beginDefinition;
+
+localResourceFunctionDefinitionList[ name_String, file_String, targetContext_String ] := Enclose[
+    Module[ { names },
+
+        Block[ { $Context = $Context, $ContextPath = $ContextPath, PrintTemporary },
+            ConfirmMatch[ Get @ file, Null, "Get" ]
+        ];
+
+        ConfirmAssert[ NameQ[ targetContext<>name ], "Defined" ];
+        names = ConfirmMatch[ Join[ Names[ targetContext<>"*" ], Names[ targetContext<>"*`*" ] ], { __String }, "Names" ];
+
+        Language`DefinitionList @@ Select[ symbolDefinitionRule /@ names, definedSymbolRuleQ ]
+    ],
+    throwInternalFailure
+];
+
+localResourceFunctionDefinitionList // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*symbolDefinitionRule*)
+(* The definition of a symbol in the format of a DefinitionList element *)
+symbolDefinitionRule // beginDefinition;
+symbolDefinitionRule // Attributes = { HoldAllComplete };
+
+symbolDefinitionRule[ name_String ] :=
+    ToExpression[ name, InputForm, symbolDefinitionRule ];
+
+symbolDefinitionRule[ s_Symbol ] := HoldForm[ s ] -> DeleteCases[
+    {
+        OwnValues     -> OwnValues @ s,
+        DownValues    -> DownValues @ s,
+        UpValues      -> UpValues @ s,
+        SubValues     -> SubValues @ s,
+        NValues       -> NValues @ s,
+        FormatValues  -> FormatValues @ s,
+        DefaultValues -> DefaultValues @ s,
+        Messages      -> Messages @ s,
+        Attributes    -> Attributes @ s
+    },
+    _ -> { }
+];
+
+symbolDefinitionRule // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*definedSymbolRuleQ*)
+(* Symbols without definitions and the Module temporaries that loading leaves behind are not part of the definition *)
+definedSymbolRuleQ // beginDefinition;
+definedSymbolRuleQ[ HoldForm[ _ ] -> { } ] := False;
+definedSymbolRuleQ[ HoldForm[ _ ] -> { ___, Attributes -> { ___, Temporary, ___ }, ___ } ] := False;
+definedSymbolRuleQ[ HoldForm[ _ ] -> { __ } ] := True;
+definedSymbolRuleQ // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
@@ -326,16 +564,18 @@ importDependentResourceFunctions // endDefinition;
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*inlineDependentResourceFunctions*)
+(* Rewrites references to other resource functions in a definition to their local symbols, recording them as
+   dependencies to import (see importDependentResourceFunctions) *)
 inlineDependentResourceFunctions // beginDefinition;
 
 inlineDependentResourceFunctions[ definition_ ] := ReplaceAll[
     definition,
     {
-        HoldPattern @ ResourceFunction[ name_String, OptionsPattern[ ] ] :> RuleCondition[
+        HoldPattern @ ResourceFunction[ name_String? inlinableResourceFunctionQ, OptionsPattern[ ] ] :> RuleCondition[
             $dependentResourceFunctions[ name ] = True;
             Symbol[ $resourceFunctionContext<>name<>"`"<>name ]
         ],
-        HoldPattern @ ResourceFunction[ name_String, "Function", OptionsPattern[ ] ] :> RuleCondition[
+        HoldPattern @ ResourceFunction[ name_String? inlinableResourceFunctionQ, "Function", OptionsPattern[ ] ] :> RuleCondition[
             $dependentResourceFunctions[ name ] = True;
             Symbol[ $resourceFunctionContext<>name<>"`"<>name ]
         ]
@@ -344,8 +584,16 @@ inlineDependentResourceFunctions[ definition_ ] := ReplaceAll[
 
 inlineDependentResourceFunctions // endDefinition;
 
-
 $dependentResourceFunctions = <| |>;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*inlinableResourceFunctionQ*)
+(* In an MX build every reference is inlined (fetching the dependency if it has no local definition); when loading from
+   source only those with a local definition are, leaving the others to the Function Repository at call time *)
+inlinableResourceFunctionQ // beginDefinition;
+inlinableResourceFunctionQ[ name_String ] := TrueQ @ $mxFlag || StringQ @ localResourceFunctionFile @ name;
+inlinableResourceFunctionQ // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Kernel/CommonSymbols.wl
+++ b/Kernel/CommonSymbols.wl
@@ -65,6 +65,7 @@ BeginPackage[ "Wolfram`AgentTools`Common`" ];
 `readWXFFile;
 `relatedDocumentation;
 `relatedWolframAlphaResults;
+`resourceFunctionAvailableQ;
 `relatedWolframContext;
 `throwFailure;
 `throwInternalFailure;

--- a/Kernel/Messages.wl
+++ b/Kernel/Messages.wl
@@ -37,6 +37,14 @@ AgentTools::InvalidProjectDirectory       = "Invalid project directory specifica
 AgentTools::UnsupportedOperatingSystem    = "Unsupported operating system: `1`.";
 AgentTools::MCPTimeout                    = "MCP request `1` timed out after `2` seconds.";
 AgentTools::UnknownTool                   = "Unknown tool: `1`.";
+AgentTools::CloudUnavailable              = "The tool \"`1`\" could not complete because the Wolfram Cloud could not be reached.";
+AgentTools::DocumentationSearchFailed     = "Documentation search is currently unavailable (`1`). This usually means that the Wolfram Cloud could not be reached; try again later.";
+AgentTools::WolframAlphaSearchFailed      = "Wolfram|Alpha search is currently unavailable (`1`). This usually means that the Wolfram Cloud could not be reached; try again later.";
+AgentTools::RequestAborted                = "The evaluation of the `1` request was aborted.";
+AgentTools::ResourceFunctionUnavailable   = "The resource function \"`1`\" is not available: there is no local definition and the Wolfram Function Repository could not be reached.";
+AgentTools::ToolAborted                   = "The evaluation of the tool \"`1`\" was aborted.";
+AgentTools::UncaughtThrow                 = "An uncaught exception occurred while handling the `1` request: `2`";
+AgentTools::UncaughtToolThrow             = "The tool \"`1`\" failed with an uncaught exception: `2`";
 AgentTools::InvalidTOMLFormat             = "Invalid TOML format in file `1` at line `2`: `3`.";
 AgentTools::InvalidYAMLFormat             = "Invalid YAML format in file `1` at line `2`: `3`.";
 

--- a/Kernel/Server/Cloud.wl
+++ b/Kernel/Server/Cloud.wl
@@ -255,14 +255,22 @@ dispatchCloudMethod // beginDefinition;
 dispatchCloudMethod[ method_, id_, message_, req_, contentType_ ] :=
     Module[ { response, respHeaders },
         If[ replyOwedQ[ method, id ],
-            response    = catchAlways @ handleMethod[ method, message, req ];
+            response    = catchUncaughtThrows[
+                catchAlways @ handleMethod[ method, message, req ],
+                uncaughtRequestThrow[ method, ##1 ] &
+            ];
             respHeaders = sessionIDResponseHeaders @ method;
             If[ FailureQ @ response,
                 jsonResponse[ <| req, "error" -> <| "code" -> -32603, "message" -> "Internal error" |> |>, contentType, respHeaders ],
                 jsonResponse[ response, contentType, respHeaders ]
             ],
             (* No reply owed: still dispatch notifications for their side effects, then 202 empty. *)
-            If[ StringQ @ method, catchAlways @ handleMethod[ method, message, req ] ];
+            If[ StringQ @ method,
+                catchUncaughtThrows[
+                    catchAlways @ handleMethod[ method, message, req ],
+                    uncaughtRequestThrow[ method, ##1 ] &
+                ]
+            ];
             emptyResponse[ 202 ]
         ]
     ];

--- a/Kernel/Server/Local.wl
+++ b/Kernel/Server/Local.wl
@@ -87,13 +87,9 @@ startMCPServer[ obj0_MCPServerObject ] := Enclose[
                 response = catchAlways @ processRequest[ ];
                 If[ response =!= EndOfFile, writeLog[ "Response" -> response ] ];
                 If[ AssociationQ @ response,
-                    output = ConfirmBy[
-                        Developer`WriteRawJSONString[ sanitizeResponse @ response, "Compact" -> True ],
-                        StringQ,
-                        "WriteRawJSONString"
-                    ];
+                    output = ConfirmBy[ serializeResponse @ response, StringQ, "SerializeResponse" ];
                     WriteLine[ "stdout", output ];
-                    If[ TrueQ @ $warmupTools, toolWarmup @ $toolList ],
+                    If[ TrueQ @ $warmupTools, warmupTools[ ] ],
                     Pause[ 0.1 ]
                 ]
             ]
@@ -121,6 +117,40 @@ setCloudBaseFromEnvironment[ base_String ] /; StringTrim @ base =!= "" := (Cloud
 setCloudBaseFromEnvironment[ _ ] := Null;
 
 setCloudBaseFromEnvironment // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*serializeResponse*)
+(* A response that cannot be encoded as JSON (e.g. a tool result holding an unexpected expression) must not end the
+   server, so it is replaced by an internal error response to the same request. *)
+serializeResponse // beginDefinition;
+
+serializeResponse[ response_Association ] :=
+    Replace[
+        Developer`WriteRawJSONString[ sanitizeResponse @ response, "Compact" -> True ],
+        Except[ _String ] :> (
+            writeLog[ "SerializationFailure" -> response ];
+            Developer`WriteRawJSONString[
+                <|
+                    "jsonrpc" -> "2.0",
+                    "id"      -> Lookup[ response, "id", Null ],
+                    "error"   -> <| "code" -> -32603, "message" -> "Internal error: the response could not be serialized." |>
+                |>,
+                "Compact" -> True
+            ]
+        )
+    ];
+
+serializeResponse // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*warmupTools*)
+(* Tool warmup runs inside the read loop, so a failure there (e.g. installing the vector databases without cloud
+   access) must not end the server *)
+warmupTools // beginDefinition;
+warmupTools[ ] := catchUncaughtThrows[ catchAlways @ toolWarmup @ $toolList, $Failed & ];
+warmupTools // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -204,7 +234,10 @@ processRequest[ ] :=
         ];
 
         req = <| "jsonrpc" -> "2.0", "id" -> id |>;
-        response = catchAlways @ handleMethod[ method, message, req ];
+        response = catchUncaughtThrows[
+            catchAlways @ handleMethod[ method, message, req ],
+            uncaughtRequestThrow[ method, ##1 ] &
+        ];
         recordUsageData[ method, message, response ];
         If[ method === "tools/list", $warmupTools = True ];
         writeLog[ "Response" -> response ];

--- a/Kernel/Server/Server.wl
+++ b/Kernel/Server/Server.wl
@@ -27,6 +27,11 @@ BeginPackage[ "Wolfram`AgentTools`Server`" ];
    so it is declared here where both subcontexts can bind it. *)
 `stealthCatchTop;
 
+(* Boundary for exceptions that nothing in the paclet catches (foreign Throw tags, tagless Throw, Abort): defined in
+   Shared.wl, used by evaluateTool there and by both transports around handleMethod (see catchUncaughtThrows). *)
+`catchUncaughtThrows;
+`uncaughtRequestThrow;
+
 (* Tool-list construction shared by the transports: defined in Shared.wl and also read by the cloud
    transport (Cloud.wl) to describe a server for the /api/info landing-page endpoint. *)
 `serverToolListData;

--- a/Kernel/Server/Shared.wl
+++ b/Kernel/Server/Shared.wl
@@ -783,6 +783,77 @@ resultToContent // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
+(*catchUncaughtThrows*)
+(* A Throw whose tag nothing in the paclet catches (for example the network-failure tag that CloudObject throws when the
+   Wolfram Cloud cannot be reached), a tagless Throw, or an Abort would otherwise unwind through the entire server: in
+   the local transport that ends the read loop and with it the server process. This evaluates eval and hands any such
+   exception to handler[ value, tag ] (tag is None for a tagless Throw and Abort for an abort), returning its result.
+   The paclet's own $catchTopTag throws are unaffected, since an enclosed catchTop/stealthCatchTop catches them first. *)
+catchUncaughtThrows // beginDefinition;
+catchUncaughtThrows // Attributes = { HoldFirst };
+
+catchUncaughtThrows[ eval_, handler_ ] :=
+    Module[ { completed = False, result },
+        result = CheckAbort[
+            Catch @ Catch[ With[ { r = eval }, completed = True; r ], _, (completed = True; handler[ #1, #2 ]) & ],
+            completed = True; handler[ $Aborted, Abort ]
+        ];
+        If[ completed, result, handler[ result, None ] ]
+    ];
+
+catchUncaughtThrows // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*uncaughtToolThrow*)
+(* Handler for catchUncaughtThrows around a tool call: the failure becomes the tool's error result *)
+uncaughtToolThrow // beginDefinition;
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+uncaughtToolThrow[ toolName_String, _, CloudObject`Private`NetworkCallFailure ] :=
+    messageFailure[ "CloudUnavailable", toolName ];
+(* :!CodeAnalysis::EndBlock:: *)
+
+uncaughtToolThrow[ toolName_String, _, Abort ] :=
+    messageFailure[ "ToolAborted", toolName ];
+
+uncaughtToolThrow[ toolName_String, value_, tag_ ] :=
+    messageFailure[ "UncaughtToolThrow", toolName, throwString[ value, tag ] ];
+
+uncaughtToolThrow // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*uncaughtRequestThrow*)
+(* Handler for catchUncaughtThrows around handleMethod in the transports: the failure becomes a JSON-RPC internal
+   error response, like any other failure from handleMethod *)
+uncaughtRequestThrow // beginDefinition;
+
+uncaughtRequestThrow[ method_, _, Abort ] :=
+    messageFailure[ "RequestAborted", methodString @ method ];
+
+uncaughtRequestThrow[ method_, value_, tag_ ] :=
+    messageFailure[ "UncaughtThrow", methodString @ method, throwString[ value, tag ] ];
+
+uncaughtRequestThrow // endDefinition;
+
+methodString // beginDefinition;
+methodString[ method_String ] := method;
+methodString[ _ ] := "(unknown)";
+methodString // endDefinition;
+
+throwString // beginDefinition;
+throwString[ value_, None ] := "Throw[" <> shortInputString @ value <> "]";
+throwString[ value_, tag_ ] := "Throw[" <> shortInputString @ value <> ", " <> shortInputString @ tag <> "]";
+throwString // endDefinition;
+
+shortInputString // beginDefinition;
+shortInputString[ expr_ ] := StringTake[ ToString[ Unevaluated @ expr, InputForm ], UpTo[ 200 ] ];
+shortInputString // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
 (*evaluateTool*)
 evaluateTool // beginDefinition;
 
@@ -803,7 +874,7 @@ evaluateTool[ msg_, req_ ] := Enclose[
             |>
         ];
 
-        result = stealthCatchTop @ tool @ args;
+        result = catchUncaughtThrows[ stealthCatchTop @ tool @ args, uncaughtToolThrow[ toolName, ##1 ] & ];
 
         content = Which[
             (* Structured result with Content key (from WolframLanguageEvaluator) *)
@@ -847,10 +918,28 @@ safeString[ failure: Failure[ "AgentTools::Internal" | "General::ChatbookInterna
         formatted /; StringQ @ formatted
     ];
 
-safeString[ failure_Failure ] := With[ { s = failure[ "Message" ] }, "[Error] " <> safeString @ s /; StringQ @ s ];
+safeString[ failure_Failure ] := With[ { s = failureMessageString @ failure }, "[Error] " <> safeString @ s /; StringQ @ s ];
 safeString[ string_String ] := convertPUACharacters @ string; (* avoid mangling due to StandardForm strings *)
 safeString[ arg_ ] := convertPUACharacters @ ToString @ Unevaluated @ arg;
 safeString // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*failureMessageString*)
+(* The "Message" property of a Failure wraps the message parameters in boxes (Short) for notebook display, which come out
+   as box syntax in plain text, so the message is formatted from the template and parameters directly *)
+failureMessageString // beginDefinition;
+
+failureMessageString[ failure_Failure ] := Quiet @ Replace[
+    { failure[ "MessageTemplate" ], failure[ "MessageParameters" ] },
+    {
+        { template_String, params_List } :> ToString @ StringForm[ template, Sequence @@ params ],
+        { template_String, _ } :> template,
+        _ :> failure[ "Message" ]
+    }
+];
+
+failureMessageString // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Kernel/Tools/Context.wl
+++ b/Kernel/Tools/Context.wl
@@ -286,16 +286,7 @@ relatedWolframAlphaResults[ context_String, level_String ] := Enclose[
         includeWLResults = Replace[ $waIncludeWLResults, Except[ True|False ] :> Automatic ];
         docOptions = ConfirmMatch[ documentationProvidedOptions[ ], { ___Rule }, "DocumentationProvidedOptions" ];
 
-        result = Quiet[
-            cb`RelatedWolframAlphaResults[
-                context,
-                "Prompt",
-                "MaxItems"         -> maxItems,
-                "IncludeWLResults" -> includeWLResults,
-                Sequence @@ docOptions
-            ],
-            { WolframAlpha::kbserr }
-        ];
+        result = relatedWolframAlphaResults0[ context, maxItems, includeWLResults, docOptions ];
 
         (* A user who has exceeded their LLMKit usage limit gets a Failure here; turn it into a useful
            message instead of letting it become an opaque internal failure. *)
@@ -309,6 +300,9 @@ relatedWolframAlphaResults[ context_String, level_String ] := Enclose[
                 "UsageLimitMessage"
             ],
             (* else *)
+            (* Any other failure from Chatbook (typically because the Wolfram Cloud could not be reached) becomes a tool
+               failure with a useful message rather than an opaque internal failure. *)
+            If[ FailureQ @ result, throwFailure[ "WolframAlphaSearchFailed", failureTag @ result ] ];
             StringTrim @ ConfirmBy[ result, StringQ, "Prompt" ]
         ]
     ],
@@ -316,6 +310,25 @@ relatedWolframAlphaResults[ context_String, level_String ] := Enclose[
 ];
 
 relatedWolframAlphaResults // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*relatedWolframAlphaResults0*)
+relatedWolframAlphaResults0 // beginDefinition;
+
+relatedWolframAlphaResults0[ context_String, maxItems_, includeWLResults_, docOptions_List ] :=
+    Quiet[
+        cb`RelatedWolframAlphaResults[
+            context,
+            "Prompt",
+            "MaxItems"         -> maxItems,
+            "IncludeWLResults" -> includeWLResults,
+            Sequence @@ docOptions
+        ],
+        { WolframAlpha::kbserr }
+    ];
+
+relatedWolframAlphaResults0 // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -384,6 +397,9 @@ relatedDocumentation[ context_String ] := Enclose[
                 "UsageLimitMessage"
             ],
             (* else *)
+            (* Any other failure from Chatbook (typically because the Wolfram Cloud could not be reached to compute
+               embeddings) becomes a tool failure with a useful message rather than an opaque internal failure. *)
+            If[ FailureQ @ result, throwFailure[ "DocumentationSearchFailed", failureTag @ result ] ];
             prompt = ConfirmBy[ result, StringQ, "Prompt" ];
 
             formatted = If[ StringTrim @ prompt === "",
@@ -421,6 +437,16 @@ relatedDocumentation0[ context_, max: $$maxItemsSpec, subscribed: True|False ] :
     ];
 
 relatedDocumentation0 // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*failureTag*)
+(* A short identifier of a Failure for messages, e.g. "General::ChatbookInternal" *)
+failureTag // beginDefinition;
+failureTag[ Failure[ tag_String, _ ] ] := tag;
+failureTag[ Failure[ tag_, _ ] ] := ToString[ Unevaluated @ tag, InputForm ];
+failureTag[ _ ] := "unknown";
+failureTag // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Kernel/Tools/SymbolDefinition.wl
+++ b/Kernel/Tools/SymbolDefinition.wl
@@ -451,14 +451,19 @@ formatDefinition // endDefinition;
 formatDefinitionReadable // beginDefinition;
 
 formatDefinitionReadable[ defs_List, cPath_List, symbolContext_String ] :=
-    TimeConstrained[
-        Block[ { $ContextPath = cPath, $Context = symbolContext },
-            StringRiffle[
-                formatSingleDefinition /@ defs,
-                "\n\n"
-            ]
+    If[ resourceFunctionAvailableQ @ readableForm,
+        TimeConstrained[
+            Block[ { $ContextPath = cPath, $Context = symbolContext },
+                StringRiffle[
+                    formatSingleDefinition /@ defs,
+                    "\n\n"
+                ]
+            ],
+            $readableFormTimeout
         ],
-        $readableFormTimeout
+        (* The ReadableForm resource function could not be imported (see importResourceFunction), so formatDefinition
+           falls back to InputForm *)
+        $Failed
     ];
 
 formatDefinitionReadable // endDefinition;

--- a/ResourceFunctions/ASTPattern.wl
+++ b/ResourceFunctions/ASTPattern.wl
@@ -1,0 +1,900 @@
+(* ::Package:: *)
+
+(*
+    Local copy of the "ASTPattern" resource function (version 1.0.0) from the Wolfram Function Repository.
+
+    Resource: https://resources.wolframcloud.com/FunctionRepository/resources/ASTPattern
+    Source:   generated from the published definition (ResourceFunction["ASTPattern", "DefinitionList"]) and formatted
+              with the ReadableForm resource function; the development source of this function is
+              https://github.com/rhennigan/ResourceFunctions/tree/main/Definitions/ASTPattern
+
+    Kernel/Common.wl (importResourceFunction) loads this file in preference to fetching the resource function from
+    the Function Repository, so the paclet can be built and loaded from source without cloud access. This directory
+    is not part of the built paclet: the MX build inlines these definitions. The definitions are assigned as a
+    definition list, exactly as the Function Repository publishes them (re-evaluating them as ordinary code would
+    merge rules such as f[ args___ ] and its e: HoldPattern[ f[ ___ ] ] fallthrough), wrapped in BeginPackage/EndPackage
+    so the symbols live in the "Wolfram`AgentTools`ResourceFunctions`ASTPattern`" context.
+    Do not edit the definitions here; update the upstream resource function and regenerate the file
+    (see ResourceFunctions/README.md).
+*)
+
+BeginPackage[ "Wolfram`AgentTools`ResourceFunctions`ASTPattern`" ];
+
+Language`ExtendedFullDefinition[ ] = 
+    Language`DefinitionList[
+        HoldForm @ ASTPattern -> {
+            DownValues -> {
+                HoldPattern @ ASTPattern[ patt_ ] :>
+                    catchTop @ Block[ { $ContextPath },
+                        Needs[ "CodeParser`" ];
+                        With[ { p = astBlockPattern @ patt },
+                            checkDuplicatePatterns @ astPattern @ p
+                        ]
+                    ],
+                HoldPattern @ ASTPattern[ patt_, meta_ ] :>
+                    catchTop @ Block[ { $ContextPath },
+                        Needs[ "CodeParser`" ];
+                        With[ { p = astBlockPattern @ patt },
+                            astPattern[ p, meta ]
+                        ]
+                    ]
+            },
+            DefaultValues -> { HoldPattern @ Options @ ASTPattern -> { } },
+            Messages -> {
+                HoldPattern @ ASTPattern::internal -> "An unexpected error occurred. `1`"
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ catchTop -> {
+            DownValues -> {
+                HoldPattern @ catchTop[ eval_ ] :>
+                    Block[ { $catching = True, $failed = False, catchTop = #1 & },
+                        Catch[ eval, $top ]
+                    ],
+                HoldPattern[ e: HoldPattern @ catchTop[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ throwInternalFailure -> {
+            DownValues -> {
+                HoldPattern @ throwInternalFailure[ eval_, a___ ] :>
+                    throwFailure[
+                        ASTPattern::internal,
+                        $bugReportLink,
+                        HoldForm @ eval,
+                        a
+                    ],
+                HoldPattern[ e: HoldPattern @ throwInternalFailure[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ throwFailure -> {
+            DownValues -> {
+                HoldPattern @ throwFailure[ tag_String, params___ ] :>
+                    throwFailure[ MessageName[ ASTPattern, tag ], params ],
+                HoldPattern @ throwFailure[ msg_, args___ ] :>
+                    Module[ { failure },
+                        
+                        failure = 
+                            messageFailure[ msg, Sequence @@ (HoldForm /@ { args }) ];
+
+                        If[ TrueQ @ $catching, Throw[ failure, $top ], failure ]
+                    ],
+                HoldPattern[ e: HoldPattern @ throwFailure[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ messageFailure -> {
+            DownValues -> {
+                HoldPattern @ messageFailure[ args___ ] :>
+                    Module[ { quiet },
+                        quiet = If[ TrueQ @ $failed, Quiet, Identity ];
+                        WithCleanup[
+                            quiet @ ResourceFunction[
+                                "MessageFailure"
+                            ][ args ],
+                            $failed = True
+                        ]
+                    ],
+                HoldPattern[ e: HoldPattern @ messageFailure[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ $bugReportLink -> {
+            OwnValues -> {
+                HoldPattern @ $bugReportLink :>
+                    ($bugReportLink = 
+                        Hyperlink[
+                            "Report this issue »",
+                            URLBuild @ <|
+                                "Scheme" -> "https",
+                                "Domain" -> "resources.wolframcloud.com",
+                                "Path" -> { "FunctionRepository", "feedback-form" },
+                                "Fragment" -> SymbolName @ ASTPattern
+                            |>
+                        ])
+            }
+        },
+        HoldForm @ astBlockPattern -> {
+            DownValues -> {
+                HoldPattern @ astBlockPattern[ patt: Verbatim[
+                    HoldPattern
+                ][ ___ ] ] :> patt,
+                HoldPattern @ astBlockPattern[ patt_ ] :>
+                    Block[ { ASTPattern },
+                        SetAttributes[ ASTPattern, HoldFirst ];
+                        HoldPattern @ Evaluate @ patt
+                    ],
+                HoldPattern[ e: HoldPattern @ astBlockPattern[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ checkDuplicatePatterns -> {
+            DownValues -> {
+                HoldPattern @ checkDuplicatePatterns[ p_ ] :>
+                    Module[ { names, realDups, possibleDups, dups },
+                        
+                        names = 
+                            Cases[
+                                p,
+                                Verbatim[ Pattern ][ s_, _ ] :> HoldPattern @ s,
+                                Infinity
+                            ];
+
+                        realDups = Select[ Counts @ names, GreaterThan[ 1 ] ];
+                        
+                        possibleDups = Association @ Cases[
+                            p,
+                            (Repeated | RepeatedNull)[ a_, ___ ] :>
+                                Cases[
+                                    HoldComplete @ a,
+                                    Verbatim[ Pattern ][ s_, _ ] :>
+                                        (HoldPattern @ s -> Infinity),
+                                    Infinity
+                                ],
+                            Infinity
+                        ];
+
+                        
+                        dups = 
+                            KeyDrop[
+                                Join[ realDups, possibleDups ],
+                                HoldPattern @ e
+                            ];
+
+                        If[ TrueQ[ Length @ dups > 0 ],
+                            rebindConditionPattern[ p, dups ],
+                            p
+                        ]
+                    ],
+                HoldPattern[ e: HoldPattern @ checkDuplicatePatterns[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ rebindConditionPattern -> {
+            DownValues -> {
+                HoldPattern @ rebindConditionPattern[ p_, dups_ ] :>
+                    Module[
+                        {
+                            $replacements,
+                            unseen,
+                            patt,
+                            replaced,
+                            conditions,
+                            flat,
+                            rhsHeld,
+                            lhsHeld
+                        },
+                        $replacements = <| |>;
+                        
+                        unseen = 
+                            AssociationMap[
+                                True &,
+                                Apply[ HoldComplete, Keys @ dups, { 1 } ]
+                            ];
+
+                        patt = Alternatives @@ Keys @ dups;
+                        
+                        replaced = 
+                            ReplaceAll[
+                                p,
+                                {
+                                    s: patt /; unseen @ HoldComplete @ s :>
+                                        With[ { e = Null },
+                                            unseen[ HoldComplete @ s ] = False;
+                                            
+                                            $replacements[ HoldComplete @ s ] = 
+                                                HoldComplete @ s;
+
+                                            s /; True
+                                        ],
+                                    s: patt /; ! unseen @ HoldComplete @ s :>
+                                        With[ { a = newPattSym @ s },
+                                            
+                                            $replacements[ HoldComplete @ a ] = 
+                                                HoldComplete @ s;
+
+                                            a /; True
+                                        ]
+                                }
+                            ];
+
+                        
+                        conditions = 
+                            Cases[
+                                GroupBy[ Normal @ $replacements, Last -> First ],
+                                { syms__ } :>
+                                    Replace[
+                                        Flatten @ HoldComplete @ syms,
+                                        HoldComplete[ a___ ] :>
+                                            HoldComplete @ EquivalentNodeQ @ a
+                                    ]
+                            ];
+
+                        flat = Flatten[ HoldComplete @@ conditions ];
+                        
+                        rhsHeld = 
+                            Replace[
+                                flat,
+                                HoldComplete[ a_, b__ ] :> HoldComplete[ a && b ]
+                            ];
+
+                        lhsHeld = HoldComplete @@ { replaced };
+                        Apply[
+                            Condition,
+                            Flatten[ HoldComplete @@ { lhsHeld, rhsHeld } ]
+                        ]
+                    ],
+                HoldPattern[ e: HoldPattern @ rebindConditionPattern[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ newPattSym -> {
+            DownValues -> {
+                HoldPattern @ newPattSym[ s_? symbolQ ] :>
+                    Module @@ HoldComplete[ { s }, s ],
+                HoldPattern[ e: HoldPattern @ newPattSym[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldAllComplete }
+        },
+        HoldForm @ symbolQ -> {
+            DownValues -> {
+                HoldPattern @ symbolQ[ s_Symbol ] :>
+                    TrueQ @ And[
+                        AtomQ @ Unevaluated @ s,
+                        ! Internal`RemovedSymbolQ @ Unevaluated @ s,
+                        Unevaluated @ s =!= Internal`$EFAIL
+                    ],
+                HoldPattern @ symbolQ[ ___ ] :> False
+            },
+            Attributes -> { HoldAllComplete }
+        },
+        HoldForm @ EquivalentNodeQ -> {
+            DownValues -> {
+                HoldPattern @ EquivalentNodeQ[ nodes___ ] :>
+                    Apply[
+                        SameQ,
+                        DeleteCases[
+                            { nodes },
+                            KeyValuePattern[ CodeParser`Source -> _ ],
+                            Infinity
+                        ]
+                    ],
+                HoldPattern[ e: HoldPattern @ EquivalentNodeQ[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            FormatValues -> {
+                HoldPattern @ MakeBoxes[ EquivalentNodeQ[ a___ ], StandardForm ] :>
+                    With[
+                        {
+                            row = 
+                                RowBox @ Riffle[
+                                    Cases[
+                                        HoldComplete @ a,
+                                        e_ :> MakeBoxes[ e, StandardForm ]
+                                    ],
+                                    StyleBox[
+                                        "≃",
+                                        FontColor -> Orange,
+                                        FontWeight -> "Heavy"
+                                    ]
+                                ],
+                            tt = 
+                                ToBoxes @ HoldForm @ HoldForm[
+                                    EquivalentNodeQ
+                                ][ a ],
+                            col = ColorData[ 97 ][ 3 ]
+                        },
+                        InterpretationBox[
+                            FrameBox[
+                                TooltipBox[ row, tt ],
+                                RoundingRadius -> 3,
+                                FrameStyle -> col,
+                                FrameMargins -> { { 4, 4 }, { 1, 1 } }
+                            ],
+                            EquivalentNodeQ @ a
+                        ]
+                    ]
+            }
+        },
+        HoldForm @ astPattern -> {
+            DownValues -> {
+                HoldPattern[
+                    astPattern[ patt_ ] /;
+                        ! FreeQ[ Unevaluated @ patt, _ASTPattern ]
+                ] :>
+                    Module[ { held, expanded, new },
+                        held = HoldComplete @ patt;
+                        expanded = expandNestedASTPatterns @ held;
+                        new = astPattern @@ expanded;
+                        new /. $astPattern[ a_ ] :> a
+                    ],
+                HoldPattern @ astPattern @ Verbatim[ Pattern ][ sym_Symbol? symbolQ, patt_ ] :>
+                    Pattern @@ Hold[ sym, astPattern @ patt ],
+                HoldPattern @ astPattern[ patt_ASTPattern ] :> patt,
+                HoldPattern @ astPattern[ patt_$astPattern ] :> patt,
+                HoldPattern @ astPattern @ Verbatim[
+                    Verbatim
+                ][ a_ ] :>
+                    verbatimAST @ a,
+                HoldPattern @ astPattern @ Verbatim[
+                    HoldPattern
+                ][ a_ ] :>
+                    astPattern @ a,
+                HoldPattern @ astPattern @ Verbatim[
+                    Alternatives
+                ][ a___ ] :>
+                    Alternatives @@ (astPattern /@ HoldComplete @ a),
+                HoldPattern @ astPattern @ Verbatim[ _ ] :> callOrLeafNode[ ],
+                HoldPattern @ astPattern @ Verbatim[ __ ] :> callOrLeafNode[ ]..,
+                HoldPattern @ astPattern @ Verbatim[ ___ ] :> callOrLeafNode[ ]...,
+                HoldPattern @ astPattern @ Verbatim[
+                    Blank
+                ][ sym_? symbolQ ] :>
+                    blank @ sym,
+                HoldPattern @ astPattern @ Verbatim[
+                    BlankSequence
+                ][ sym_? symbolQ ] :>
+                    blank @ sym..,
+                HoldPattern @ astPattern @ Verbatim[
+                    BlankNullSequence
+                ][ sym_? symbolQ ] :>
+                    blank @ sym...,
+                HoldPattern @ astPattern @ Verbatim[ Repeated ][ x_, a___ ] :>
+                    Repeated[ astPattern @ x, a ],
+                HoldPattern @ astPattern @ Verbatim[ RepeatedNull ][ x_, a___ ] :>
+                    RepeatedNull[ astPattern @ x, a ],
+                HoldPattern @ astPattern @ Verbatim[
+                    Except
+                ][ c_ ] :>
+                    Except[ astPattern @ c ],
+                HoldPattern @ astPattern @ Verbatim[ Except ][ c_, p_ ] :>
+                    Except[ astPattern @ c, astPattern @ p ],
+                HoldPattern @ astPattern @ Verbatim[
+                    PatternSequence
+                ][ a___ ] :>
+                    PatternSequence @@ (astPattern /@ HoldComplete @ a),
+                HoldPattern @ astPattern @ Verbatim[ PatternTest ][
+                    Verbatim[ Pattern ][ s_Symbol? symbolQ, patt_ ],
+                    test_
+                ] :>
+                    With[ { p = astPattern[ patt? test ] },
+                        Pattern @@ HoldComplete[ s, p ]
+                    ],
+                HoldPattern[
+                    astPattern @ Verbatim[ PatternTest ][
+                        Verbatim[
+                            Blank
+                        ][ head_? symbolQ ],
+                        test_
+                    ] /;
+                        leafTestQ[ head, test ]
+                ] :>
+                    leafNode @ head,
+                HoldPattern[
+                    astPattern @ Verbatim[ PatternTest ][
+                        Verbatim[
+                            BlankSequence
+                        ][ head_? symbolQ ],
+                        test_
+                    ] /;
+                        leafTestQ[ head, test ]
+                ] :>
+                    leafNode @ head..,
+                HoldPattern[
+                    astPattern @ Verbatim[ PatternTest ][
+                        Verbatim[
+                            BlankNullSequence
+                        ][ head_? symbolQ ],
+                        test_
+                    ] /;
+                        leafTestQ[ head, test ]
+                ] :>
+                    leafNode @ head...,
+                HoldPattern @ astPattern @ Verbatim[ PatternTest ][ patt_, test_ ] :>
+                    With[ { p = astPattern @ patt },
+                        PatternTest @@ HoldComplete[ p, ASTPatternTest @ test ]
+                    ],
+                HoldPattern @ astPattern[ sym_Symbol? symbolQ ] :>
+                    symNamePatt @ sym,
+                HoldPattern[ astPattern[ r_Rational ] /; AtomQ @ Unevaluated @ r ] :>
+                    rationalPattern @ r,
+                HoldPattern[ astPattern[ c_Complex ] /; AtomQ @ Unevaluated @ c ] :>
+                    complexPattern @ c,
+                HoldPattern[
+                    astPattern[ expr: _Integer | _Real | _String ] /;
+                        AtomQ @ Unevaluated @ expr
+                ] :>
+                    leafNode[ Head @ expr, ToString[ expr, InputForm ] ],
+                HoldPattern @ astPattern @ Verbatim[ Condition ][ patt_, test_ ] :>
+                    (ReplaceAll[
+                        ReplaceAll[
+                            makeASTCondition[ patt, test ],
+                            $ASTCondition[ { }, cond_ ] :> cond
+                        ],
+                        $ASTCondition -> ASTCondition
+                    ]),
+                HoldPattern @ astPattern[ (head_)[ args___ ] ] :>
+                    CodeParser`CallNode[
+                        astPattern @ head,
+                        astPattern /@ Unevaluated @ { args },
+                        _
+                    ],
+                HoldPattern @ astPattern[ patt_, meta_ ] :>
+                    insertMetaPatt[
+                        checkDuplicatePatterns @ astPattern @ patt,
+                        meta
+                    ],
+                HoldPattern @ astPattern[ a___ ] :>
+                    throwInternalFailure @ astPattern @ a
+            },
+            Attributes -> { HoldAllComplete }
+        },
+        HoldForm @ expandNestedASTPatterns -> {
+            DownValues -> {
+                HoldPattern @ expandNestedASTPatterns[ expr_ ] :>
+                    (ReplaceAll[
+                        expandNestedResourceFunctions @ expr,
+                        {
+                            Verbatim[
+                                Verbatim
+                            ][ a___ ] :> Verbatim[a],
+                            HoldPattern @ ASTPattern[ a___ ] :>
+                                With[ { p = astPattern @ a },
+                                    $astPattern @ p /; True
+                                ]
+                        }
+                    ]),
+                HoldPattern[ e: HoldPattern @ expandNestedASTPatterns[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ expandNestedResourceFunctions -> {
+            DownValues -> {
+                HoldPattern[ expandNestedResourceFunctions[ expr_ ] /; $rfTest ] :>
+                    (ReplaceAll[
+                        expr,
+                        rf: $rfPatt :>
+                            With[ { sym = rfSymExpand @ rf },
+                                sym /; sym === ASTPattern
+                            ]
+                    ]),
+                HoldPattern @ expandNestedResourceFunctions[ expr_ ] :> expr,
+                HoldPattern[ e: HoldPattern @ expandNestedResourceFunctions[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ $rfTest -> {
+            OwnValues -> {
+                HoldPattern @ $rfTest :>
+                    ($rfTest = 
+                        StringStartsQ[
+                            Context @ ASTPattern,
+                            "FunctionRepository`"
+                        ])
+            }
+        },
+        HoldForm @ $rfPatt -> {
+            OwnValues ->
+                (HoldPattern @ $rfPatt :>
+                    HoldPattern[ ResourceFunction ][
+                        Alternatives[
+                            Alternatives[
+                                "ASTPattern",
+                                Association[ ___, "Name" -> "ASTPattern", ___ ]
+                            ],
+                            HoldPattern[ ResourceObject ][
+                                Alternatives[
+                                    "ASTPattern",
+                                    Association[
+                                        ___,
+                                        "Name" -> "ASTPattern",
+                                        ___
+                                    ]
+                                ],
+                                OptionsPattern[ ]
+                            ]
+                        ],
+                        OptionsPattern[ ]
+                    ]
+)
+        },
+        HoldForm @ rfSymExpand -> {
+            DownValues -> {
+                HoldPattern @ rfSymExpand[ rf_ ] :>
+                    (rfSymExpand[ rf ] = Quiet @ ResourceFunction[ rf, "Function" ])
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ $astPattern -> { Attributes -> { HoldAllComplete } },
+        HoldForm @ verbatimAST -> {
+            DownValues -> {
+                HoldPattern @ verbatimAST[ sym_Symbol? symbolQ ] :>
+                    symNamePatt @ sym,
+                HoldPattern[ verbatimAST[ r_Rational ] /; AtomQ @ Unevaluated @ r ] :>
+                    rationalPattern @ r,
+                HoldPattern[ verbatimAST[ c_Complex ] /; AtomQ @ Unevaluated @ c ] :>
+                    complexPattern @ c,
+                HoldPattern[
+                    verbatimAST[ expr: _Integer | _Real | _String ] /;
+                        AtomQ @ Unevaluated @ expr
+                ] :>
+                    leafNode[ Head @ expr, ToString[ expr, InputForm ] ],
+                HoldPattern @ verbatimAST[ (head_)[ args___ ] ] :>
+                    CodeParser`CallNode[
+                        astPattern @ head,
+                        astPattern /@ Unevaluated @ { args },
+                        _
+                    ],
+                HoldPattern[ e: HoldPattern @ verbatimAST[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldAllComplete }
+        },
+        HoldForm @ symNamePatt -> {
+            DownValues -> {
+                HoldPattern @ symNamePatt[ sym_Symbol? symbolQ ] :>
+                    With[
+                        {
+                            name = SymbolName @ Unevaluated @ sym,
+                            ctx = Context @ Unevaluated @ sym
+                        },
+                        CodeParser`LeafNode[
+                            Symbol,
+                            name | ctx <> name,
+                            _
+                        ]
+                    ],
+                HoldPattern[ e: HoldPattern @ symNamePatt[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldAllComplete }
+        },
+        HoldForm @ rationalPattern -> {
+            DownValues -> {
+                HoldPattern @ rationalPattern[ r_ ] :>
+                    rationalPattern[ Numerator @ r, Denominator @ r ],
+                HoldPattern @ rationalPattern[ n_, d_ ] :>
+                    Module[ { na, da, mo, pw },
+                        na = astPattern @ n;
+                        da = astPattern @ d;
+                        mo = leafNode[ Integer, "-1" ];
+                        pw = callNode[ symbolNode[ "Power" ], { da, mo } ];
+                        callNode[ symbolNode[ "Times" ], { na, pw } ]
+                    ],
+                HoldPattern[ e: HoldPattern @ rationalPattern[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ leafNode -> {
+            DownValues -> {
+                HoldPattern @ leafNode[ ] :> CodeParser`LeafNode[ _, _, _ ],
+                HoldPattern @ leafNode[ a_ ] :> CodeParser`LeafNode[ a, _, _ ],
+                HoldPattern @ leafNode[ a_, b_ ] :> CodeParser`LeafNode[ a, b, _ ],
+                HoldPattern @ leafNode[ a_, b_, c_ ] :>
+                    CodeParser`LeafNode[ a, b, c ],
+                HoldPattern[ e: HoldPattern @ leafNode[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ callNode -> {
+            DownValues -> {
+                HoldPattern @ callNode[ ] :> CodeParser`CallNode[ _, _, _ ],
+                HoldPattern @ callNode[ a_ ] :> CodeParser`CallNode[ a, _, _ ],
+                HoldPattern @ callNode[ a_, b_ ] :> CodeParser`CallNode[ a, b, _ ],
+                HoldPattern @ callNode[ a_, b_, c_ ] :>
+                    CodeParser`CallNode[ a, b, c ],
+                HoldPattern[ e: HoldPattern @ callNode[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ symbolNode -> {
+            DownValues -> {
+                HoldPattern @ symbolNode[ name_String ] :>
+                    CodeParser`LeafNode[ Symbol, name, _ ],
+                HoldPattern @ symbolNode[ sym_? symbolQ ] :> symNamePatt @ sym,
+                HoldPattern[ e: HoldPattern @ symbolNode[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ complexPattern -> {
+            DownValues -> {
+                HoldPattern @ complexPattern[ c_ ] :> complexPattern[ Re @ c, Im @ c ],
+                HoldPattern @ complexPattern[ r_, i_ ] :>
+                    Module[ { ra, ia, im },
+                        ra = astPattern @ r;
+                        ia = astPattern @ i;
+                        
+                        im = 
+                            callNode[
+                                symbolNode[ "Times" ],
+                                { ia, symbolNode[ "I" ] }
+                            ];
+
+                        callNode[ symbolNode[ "Plus" ], { ra, im } ]
+                    ],
+                HoldPattern[ e: HoldPattern @ complexPattern[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ callOrLeafNode -> {
+            DownValues -> {
+                HoldPattern @ callOrLeafNode[ ] :>
+                    (CodeParser`CallNode | CodeParser`LeafNode)[ _, _, _ ],
+                HoldPattern @ callOrLeafNode[ a_ ] :>
+                    (CodeParser`CallNode | CodeParser`LeafNode)[ a, _, _ ],
+                HoldPattern @ callOrLeafNode[ a_, b_ ] :>
+                    (CodeParser`CallNode | CodeParser`LeafNode)[ a, b, _ ],
+                HoldPattern @ callOrLeafNode[ a_, b_, c_ ] :>
+                    (CodeParser`CallNode | CodeParser`LeafNode)[ a, b, c ],
+                HoldPattern[ e: HoldPattern @ callOrLeafNode[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ blank -> {
+            DownValues -> {
+                HoldPattern @ blank[ sym_? leafHeadQ ] :>
+                    callOrLeafNode[ sym | symNamePatt @ sym, _, _ ],
+                HoldPattern @ blank[ sym_ ] :> callNode @ symNamePatt @ sym,
+                HoldPattern[ e: HoldPattern @ blank[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldAllComplete }
+        },
+        HoldForm @ leafHeadQ -> {
+            DownValues -> {
+                HoldPattern @ leafHeadQ[
+                    Complex | Integer | Rational | Real | String | Symbol
+                ] :> True,
+                HoldPattern @ leafHeadQ[ ___ ] :> False
+            },
+            Attributes -> { HoldAllComplete }
+        },
+        HoldForm @ leafTestQ -> {
+            DownValues -> {
+                HoldPattern @ leafTestQ[ Integer, IntegerQ ] :> True,
+                HoldPattern @ leafTestQ[ Real, Developer`RealQ ] :> True,
+                HoldPattern @ leafTestQ[ String, StringQ ] :> True,
+                HoldPattern @ leafTestQ[ _? leafHeadQ, AtomQ ] :> True,
+                HoldPattern @ leafTestQ[ ___ ] :> False
+            },
+            Attributes -> { HoldAllComplete }
+        },
+        HoldForm @ ASTPatternTest -> {
+            SubValues -> { HoldPattern @ ASTPatternTest[ (func_) ][ node_ ] :> FromAST[ node, func ] },
+            FormatValues -> {
+                HoldPattern @ MakeBoxes[ ASTPatternTest[ f_ ], StandardForm ] :>
+                    With[
+                        {
+                            row = MakeBoxes[ f, StandardForm ],
+                            tt = 
+                                MakeBoxes[
+                                    HoldForm[
+                                        ASTPatternTest
+                                    ][ f ],
+                                    StandardForm
+                                ],
+                            col = ColorData[ 97 ][ 1 ]
+                        },
+                        InterpretationBox[
+                            FrameBox[
+                                TooltipBox[ row, tt ],
+                                RoundingRadius -> 3,
+                                FrameStyle -> col,
+                                FrameMargins -> { { 4, 4 }, { 1, 1 } }
+                            ],
+                            ASTPatternTest @ f
+                        ]
+                    ]
+            }
+        },
+        HoldForm @ FromAST -> {
+            DownValues -> {
+                HoldPattern @ FromAST[ ast_ ] :> FromAST[ ast, ##1 & ],
+                HoldPattern @ FromAST[
+                    ast: _CodeParser`LeafNode | _CodeParser`CallNode,
+                    wrapper_
+                ] :>
+                    ToExpression[
+                        CodeParser`ToFullFormString @ ast,
+                        InputForm,
+                        wrapper
+                    ],
+                HoldPattern @ FromAST[ CodeParser`ContainerNode[ _, ast_List, _ ], wrapper_ ] :>
+                    FromAST[ ast, wrapper ],
+                HoldPattern @ FromAST[ ast_List, wrapper_ ] :>
+                    (FromAST[ #1, wrapper ] &) /@ ast,
+                HoldPattern[ e: HoldPattern @ FromAST[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ makeASTCondition -> {
+            DownValues -> {
+                HoldPattern @ makeASTCondition[ lhs_, rhs_ ] :>
+                    Module[ { syms, bound, vals, hs, cvRules, cv },
+                        syms = DeleteDuplicates @ patternSymbols @ lhs;
+                        bound = Select[ syms, appearsIn @ rhs ];
+                        vals = Array[ ASTConditionValue, Length @ bound ];
+                        hs = Cases[ bound, e_ :> HoldPattern @ e ];
+                        cvRules = Thread[ hs -> vals ];
+                        cv = HoldComplete @ rhs /. cvRules;
+                        Apply[
+                            Condition,
+                            Replace[
+                                { bound, cv },
+                                { HoldComplete[ s___ ], HoldComplete[ c_ ] } :> {
+                                    checkDuplicatePatterns @ astPattern @ lhs,
+                                    $ASTCondition[ { s }, c ]
+                                }
+                            ]
+                        ]
+                    ],
+                HoldPattern[ e: HoldPattern @ makeASTCondition[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldAll }
+        },
+        HoldForm @ patternSymbols -> {
+            DownValues -> {
+                HoldPattern @ patternSymbols[ patt_ ] :>
+                    Flatten[ HoldComplete @@ patternSymbols0 @ patt ],
+                HoldPattern[ e: HoldPattern @ patternSymbols[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ patternSymbols0 -> {
+            DownValues -> {
+                HoldPattern @ patternSymbols0[ patt_ ] :>
+                    Cases[
+                        HoldComplete @ patt,
+                        Verbatim[ Pattern ][ s_Symbol? symbolQ, _ ] :>
+                            HoldComplete @ s,
+                        Infinity,
+                        Heads -> True
+                    ],
+                HoldPattern[ e: HoldPattern @ patternSymbols0[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ appearsIn -> {
+            DownValues -> {
+                HoldPattern @ appearsIn[ rhs_ ] :>
+                    (Function[
+                        s,
+                        ! FreeQ[ Unevaluated @ rhs, HoldPattern @ s ],
+                        HoldFirst
+                    ]),
+                HoldPattern[ e: HoldPattern @ appearsIn[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ $ASTCondition -> { Attributes -> { HoldAllComplete } },
+        HoldForm @ ASTCondition -> {
+            DownValues -> {
+                HoldPattern @ ASTCondition[ vals_List, cond_ ] :>
+                    Module[ { rules, replaced },
+                        rules = MapIndexed[ astCVRule, vals ];
+                        replaced = HoldComplete @ cond /. rules;
+                        ReleaseHold[ replaced /. $conditionHold[ e_ ] :> e ]
+                    ],
+                HoldPattern[ e: HoldPattern @ ASTCondition[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            FormatValues -> {
+                HoldPattern @ MakeBoxes[ ASTCondition[ vals_List, cond_ ], StandardForm ] :>
+                    Module[ { rules, replaced },
+                        rules = MapIndexed[ astCVBoxRule, vals ];
+                        replaced = HoldComplete @ cond /. rules;
+                        Replace[
+                            replaced /. $conditionHold[ e_ ] :> e,
+                            HoldComplete[ e_ ] :>
+                                With[
+                                    {
+                                        box = 
+                                            MakeBoxes[
+                                                Tooltip[
+                                                    e,
+                                                    HoldForm[ ASTCondition ][
+                                                        vals,
+                                                        cond
+                                                    ]
+                                                ],
+                                                StandardForm
+                                            ],
+                                        col = ColorData[ 97 ][ 2 ]
+                                    },
+                                    InterpretationBox[
+                                        FrameBox[
+                                            box,
+                                            RoundingRadius -> 3,
+                                            FrameStyle -> col,
+                                            FrameMargins -> { { 4, 4 }, { 1, 1 } }
+                                        ],
+                                        ASTCondition[ vals, cond ]
+                                    ]
+                                ]
+                        ]
+                    ]
+            },
+            Attributes -> { HoldRest }
+        },
+        HoldForm @ astCVRule -> {
+            DownValues -> {
+                HoldPattern @ astCVRule[ node_, { pos_ } ] :>
+                    (ASTConditionValue @ pos -> FromAST[ node, $conditionHold ]),
+                HoldPattern[ e: HoldPattern @ astCVRule[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ $conditionHold -> { Attributes -> { HoldAllComplete } },
+        HoldForm @ astCVBoxRule -> {
+            DownValues -> {
+                HoldPattern @ astCVBoxRule[ node_, { pos_ } ] :>
+                    (ASTConditionValue @ pos -> node),
+                HoldPattern[ e: HoldPattern @ astCVBoxRule[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ insertMetaPatt -> {
+            DownValues -> {
+                HoldPattern @ insertMetaPatt[
+                    (h: CodeParser`CallNode | CodeParser`LeafNode)[ a_, b_, _ ],
+                    meta_
+                ] :>
+                    h[ a, b, meta ],
+                HoldPattern @ insertMetaPatt[
+                    (h: Verbatim[ CodeParser`CallNode | CodeParser`LeafNode ])[
+                        a_,
+                        b_,
+                        _
+                    ],
+                    meta_
+                ] :>
+                    h[ a, b, meta ],
+                HoldPattern @ insertMetaPatt[ Verbatim[ Pattern ][ s_, p_ ], meta_ ] :>
+                    With[ { ins = insertMetaPatt[ p, meta ] },
+                        Pattern @@ Hold[ s, ins ]
+                    ],
+                HoldPattern @ insertMetaPatt[ patt_Alternatives, meta_ ] :>
+                    (insertMetaPatt[ #1, meta ] &) /@ patt,
+                HoldPattern @ insertMetaPatt[ Verbatim[ Condition ][ lhs_, rhs_ ], meta_ ] :>
+                    With[ { ins = insertMetaPatt[ lhs, meta ] },
+                        Condition @@ Hold[ ins, rhs ]
+                    ],
+                HoldPattern[ e: HoldPattern @ insertMetaPatt[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        }
+    ];
+
+EndPackage[ ];

--- a/ResourceFunctions/ExportMarkdownString.wl
+++ b/ResourceFunctions/ExportMarkdownString.wl
@@ -1,0 +1,537 @@
+(* ::Package:: *)
+
+(*
+    Local copy of the "ExportMarkdownString" resource function (version 1.0.0) from the Wolfram Function Repository.
+
+    Resource: https://resources.wolframcloud.com/FunctionRepository/resources/ExportMarkdownString
+    Source:   generated from the published definition (ResourceFunction["ExportMarkdownString", "DefinitionList"]) and formatted
+              with the ReadableForm resource function; the development source of this function is
+              https://github.com/rhennigan/ResourceFunctions/tree/main/Definitions/ExportMarkdownString
+
+    Kernel/Common.wl (importResourceFunction) loads this file in preference to fetching the resource function from
+    the Function Repository, so the paclet can be built and loaded from source without cloud access. This directory
+    is not part of the built paclet: the MX build inlines these definitions. The definitions are assigned as a
+    definition list, exactly as the Function Repository publishes them (re-evaluating them as ordinary code would
+    merge rules such as f[ args___ ] and its e: HoldPattern[ f[ ___ ] ] fallthrough), wrapped in BeginPackage/EndPackage
+    so the symbols live in the "Wolfram`AgentTools`ResourceFunctions`ExportMarkdownString`" context.
+    Do not edit the definitions here; update the upstream resource function and regenerate the file
+    (see ResourceFunctions/README.md).
+*)
+
+BeginPackage[ "Wolfram`AgentTools`ResourceFunctions`ExportMarkdownString`" ];
+
+Language`ExtendedFullDefinition[ ] = 
+    Language`DefinitionList[
+        HoldForm @ ExportMarkdownString -> {
+            DownValues -> {
+                HoldPattern @ ExportMarkdownString[ ] :>
+                    catchTop @ throwFailure[ "ArgumentCount", 0, 2 ],
+                HoldPattern @ ExportMarkdownString[ expr_, opts0: OptionsPattern[ ] ] :>
+                    catchTop @ Enclose[
+                        Module[
+                            {
+                                converted,
+                                boxes,
+                                opts,
+                                imageExportMethod,
+                                contentTypes,
+                                string
+                            },
+                            Needs[ "Wolfram`Chatbook`" -> None ];
+                            
+                            converted = 
+                                ConfirmMatch[
+                                    convertInput @ expr,
+                                    $$supported,
+                                    "ConvertInput"
+                                ];
+
+                            
+                            boxes = 
+                                Replace[
+                                    converted,
+                                    RawBoxes[ b_ ] :> b,
+                                    If[ ListQ @ converted, { 1 }, { 0 } ]
+                                ];
+
+                            opts = FilterRules[ { opts0 }, Options @ cellToString ];
+                            
+                            imageExportMethod = 
+                                OptionValue[ "ImageExportMethod" ];
+
+                            
+                            contentTypes = 
+                                ConfirmMatch[
+                                    determineContentTypes @ imageExportMethod,
+                                    { __String },
+                                    "ContentTypes"
+                                ];
+
+                            
+                            string = 
+                                ConfirmBy[
+                                    cellToString[
+                                        boxes,
+                                        opts,
+                                        "ContentTypes" -> contentTypes
+                                    ],
+                                    StringQ,
+                                    "Result"
+                                ];
+
+                            ConfirmBy[
+                                exportImages[ string, imageExportMethod ],
+                                StringQ,
+                                "ExportImages"
+                            ]
+                        ],
+                        throwInternalFailure
+                    ],
+                HoldPattern[
+                    e: ExportMarkdownString[
+                        _,
+                        invalid: Except[ OptionsPattern[ ] ],
+                        ___
+                    ]
+                ] :>
+                    catchTop @ throwFailure[ "OptionsExpected", invalid, 2, HoldForm @ e ],
+                HoldPattern[ e: ExportMarkdownString[ ___ ] ] :>
+                    catchTop @ throwInternalFailure @ e
+            },
+            DefaultValues -> {
+                HoldPattern @ Options @ ExportMarkdownString -> {
+                    "ImageExportMethod" -> None,
+                    ConversionRules -> { },
+                    PageWidth -> 100,
+                    WindowWidth -> Automatic
+                }
+            },
+            Messages -> {
+                HoldPattern @ ExportMarkdownString::ArgumentCount -> "ExportMarkdownString called with `1` arguments; 1 argument is expected.",
+                HoldPattern @ ExportMarkdownString::ExportNotString -> "Expected a string when applying image export function `1` to `2` instead of `3`.",
+                HoldPattern @ ExportMarkdownString::Internal -> "An unexpected error occurred. `1`",
+                HoldPattern @ ExportMarkdownString::NamedExportNotString -> "Failed to produce valid output for `2` using export method `1`.",
+                HoldPattern @ ExportMarkdownString::NotDirectory -> "`1` is not a valid directory.",
+                HoldPattern @ ExportMarkdownString::OptionsExpected -> "Options expected (instead of `1`) beyond position `2` in `3`. An option must be a rule or a list of rules."
+            }
+        },
+        HoldForm @ catchTop -> {
+            DownValues -> {
+                HoldPattern @ catchTop[ eval_ ] :>
+                    Block[ { $catching = True, $failed = False, catchTop = #1 & },
+                        Catch[ eval, $top ]
+                    ],
+                HoldPattern[ e: HoldPattern @ catchTop[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ throwInternalFailure -> {
+            DownValues -> {
+                HoldPattern @ throwInternalFailure[ eval_, a___ ] :>
+                    throwFailure[
+                        ExportMarkdownString::Internal,
+                        $bugReportLink,
+                        HoldForm @ eval,
+                        a
+                    ],
+                HoldPattern[ e: HoldPattern @ throwInternalFailure[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ throwFailure -> {
+            DownValues -> {
+                HoldPattern @ throwFailure[ tag_String, params___ ] :>
+                    throwFailure[
+                        MessageName[ ExportMarkdownString, tag ],
+                        params
+                    ],
+                HoldPattern @ throwFailure[ msg_, args___ ] :>
+                    Module[ { failure },
+                        
+                        failure = 
+                            messageFailure[ msg, Sequence @@ (HoldForm /@ { args }) ];
+
+                        If[ TrueQ @ $catching, Throw[ failure, $top ], failure ]
+                    ],
+                HoldPattern[ e: HoldPattern @ throwFailure[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ messageFailure -> {
+            DownValues -> {
+                HoldPattern @ messageFailure[ args___ ] :>
+                    Module[ { quiet },
+                        quiet = If[ TrueQ @ $failed, Quiet, Identity ];
+                        WithCleanup[
+                            quiet @ ResourceFunction[
+                                "MessageFailure"
+                            ][ args ],
+                            $failed = True
+                        ]
+                    ],
+                HoldPattern[ e: HoldPattern @ messageFailure[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ $bugReportLink -> {
+            OwnValues -> {
+                HoldPattern @ $bugReportLink :>
+                    ($bugReportLink = 
+                        Hyperlink[
+                            "Report this issue »",
+                            URLBuild @ <|
+                                "Scheme" -> "https",
+                                "Domain" -> "resources.wolframcloud.com",
+                                "Path" -> { "FunctionRepository", "feedback-form" },
+                                "Fragment" -> "ExportMarkdownString"
+                            |>
+                        ])
+            }
+        },
+        HoldForm @ convertInput -> {
+            DownValues -> {
+                HoldPattern @ convertInput[ expr_ ] :> convertInput0 @ expr,
+                HoldPattern[ e: HoldPattern @ convertInput[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ convertInput0 -> {
+            DownValues -> {
+                HoldPattern @ convertInput0[ cell: _TextCell | _ExpressionCell ] :>
+                    convertCell @ cell,
+                HoldPattern @ convertInput0[ group_CellGroup ] :>
+                    convertCellGroup @ group,
+                HoldPattern @ convertInput0[
+                    notebook: _DialogNotebook | _DocumentNotebook | _PaletteNotebook
+                ] :>
+                    convertNotebook @ notebook,
+                HoldPattern @ convertInput0[ cells: { ___Cell } ] :> Notebook @ cells,
+                HoldPattern @ convertInput0[
+                    expr: Alternatives[
+                        Alternatives[
+                            _Cell | _CellObject,
+                            _Notebook | _NotebookObject,
+                            _TextData | _BoxData | _RawData,
+                            _String? StringQ,
+                            _RawBoxes
+                        ],
+                        {
+                            (Alternatives[
+                                _Cell | _CellObject,
+                                _Notebook | _NotebookObject,
+                                _TextData | _BoxData | _RawData,
+                                _String? StringQ,
+                                _RawBoxes
+                            ])..
+                        }
+                    ]
+                ] :> expr,
+                HoldPattern @ convertInput0[ expr_ ] :>
+                    RawBoxes @ StyleBox[ MakeBoxes @ expr, ShowStringCharacters -> False ],
+                HoldPattern[ e: HoldPattern @ convertInput0[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ convertCell -> {
+            DownValues -> {
+                HoldPattern @ convertCell[ cell: _TextCell | _ExpressionCell ] :>
+                    convertCell @ ToBoxes @ cell,
+                HoldPattern @ convertCell @ InterpretationBox[ cell_Cell, ___ ] :>
+                    convertCell @ cell,
+                HoldPattern @ convertCell[ cell_Cell ] :> cell,
+                HoldPattern[ e: HoldPattern @ convertCell[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ convertCellGroup -> {
+            DownValues -> {
+                HoldPattern @ convertCellGroup @ CellGroup[ group_List ] :>
+                    Cell @ CellGroupData[ convertInput /@ group, Open ],
+                HoldPattern @ convertCellGroup @ CellGroup[ group_List, n: _Integer? Positive ] :>
+                    cellGroupData[ group, { n } ],
+                HoldPattern @ convertCellGroup @ CellGroup[ group_List, n: { _Integer? Positive... } ] :>
+                    cellGroupData[ group, n ],
+                HoldPattern @ convertCellGroup[ group_CellGroup ] :>
+                    feParseCellGroup @ group,
+                HoldPattern[ e: HoldPattern @ convertCellGroup[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ cellGroupData -> {
+            DownValues -> {
+                HoldPattern @ cellGroupData[ group_List, spec_ ] :>
+                    Cell @ CellGroupData[ convertInput /@ group, spec ],
+                HoldPattern[ e: HoldPattern @ cellGroupData[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ feParseCellGroup -> {
+            DownValues -> {
+                HoldPattern @ feParseCellGroup[ group_CellGroup ] :>
+                    Enclose[
+                        Module[ { nbo, nb, cells },
+                            
+                            WithCleanup[
+                                nbo = 
+                                    ConfirmMatch[
+                                        CreateDocument[
+                                            group,
+                                            CellGrouping -> Manual,
+                                            Visible -> False
+                                        ],
+                                        _NotebookObject,
+                                        "NotebookObject"
+                                    ],
+                                nb = 
+                                    ConfirmMatch[
+                                        NotebookGet @ nbo,
+                                        _Notebook,
+                                        "Notebook"
+                                    ],
+                                NotebookClose @ nbo
+                            ];
+
+                            
+                            cells = 
+                                ConfirmMatch[
+                                    Flatten @ { First[ nb, $Failed ] },
+                                    { Cell[ _CellGroupData, ___ ] },
+                                    "Cells"
+                                ];
+
+                            First @ cells
+                        ],
+                        throwInternalFailure
+                    ],
+                HoldPattern[ e: HoldPattern @ feParseCellGroup[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ convertNotebook -> {
+            DownValues -> {
+                HoldPattern @ convertNotebook[ notebook_ ] :>
+                    Enclose[
+                        Module[ { nbo, nb },
+                            
+                            WithCleanup[
+                                nbo = 
+                                    ConfirmMatch[
+                                        CreateWindow[
+                                            notebook,
+                                            Visible -> False
+                                        ],
+                                        _NotebookObject,
+                                        "NotebookObject"
+                                    ],
+                                nb = 
+                                    ConfirmMatch[
+                                        NotebookGet @ nbo,
+                                        _Notebook,
+                                        "Notebook"
+                                    ],
+                                NotebookClose @ nbo
+                            ];
+
+                            nb
+                        ],
+                        throwInternalFailure
+                    ],
+                HoldPattern[ e: HoldPattern @ convertNotebook[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ $$supported -> {
+            OwnValues ->
+                (HoldPattern @ $$supported :>
+                    Alternatives[
+                        Alternatives[
+                            _Cell | _CellObject,
+                            _Notebook | _NotebookObject,
+                            _TextData | _BoxData | _RawData,
+                            _String? StringQ,
+                            _RawBoxes
+                        ],
+                        {
+                            (Alternatives[
+                                _Cell | _CellObject,
+                                _Notebook | _NotebookObject,
+                                _TextData | _BoxData | _RawData,
+                                _String? StringQ,
+                                _RawBoxes
+                            ])..
+                        }
+                    ]
+)
+        },
+        HoldForm @ cellToString -> {
+            OwnValues -> {
+                HoldPattern @ cellToString :>
+                    Symbol[ "Wolfram`Chatbook`Serialization`CellToString" ]
+            }
+        },
+        HoldForm @ determineContentTypes -> {
+            DownValues -> {
+                HoldPattern @ determineContentTypes @ None :> { "Text" },
+                HoldPattern @ determineContentTypes[ Automatic | "Chatbook" ] :> { "Text", "Image" },
+                HoldPattern @ determineContentTypes[ f_ ] :> { "Text", "Image" },
+                HoldPattern[ e: HoldPattern @ determineContentTypes[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ exportImages -> {
+            DownValues -> {
+                HoldPattern @ exportImages[ markdown_String, None | Automatic ] :> markdown,
+                HoldPattern @ exportImages[ markdown_String, f_ ] :>
+                    Enclose[
+                        Module[ { expanded, exported },
+                            Needs[ "Wolfram`Chatbook`" -> None ];
+                            
+                            expanded = 
+                                StringSplit[
+                                    markdown,
+                                    StringExpression[
+                                        link: "\\!\\(\\*MarkdownImageBox[\"![",
+                                        Except[ "]" ]..,
+                                        "](",
+                                        uri: Except[ "\"" ]..,
+                                        ")\"]\\)"
+                                    ] :>
+                                        markdownImage[
+                                            Symbol[
+                                                "Wolfram`Chatbook`GetExpressionURI"
+                                            ][ uri ],
+                                            link
+                                        ]
+                                ];
+
+                            
+                            exported = 
+                                ConfirmMatch[
+                                    Replace[
+                                        expanded,
+                                        markdownImage[ expr_, s_ ] :>
+                                            With[ { e = applyImageExport[ f, expr ] },
+                                                If[ StringQ @ e, e, s ]
+                                            ],
+                                        { 1 }
+                                    ],
+                                    { ___String },
+                                    "Exported"
+                                ];
+
+                            StringJoin @ exported
+                        ],
+                        throwInternalFailure
+                    ],
+                HoldPattern[ e: HoldPattern @ exportImages[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ applyImageExport -> {
+            DownValues -> {
+                HoldPattern @ applyImageExport[ "CloudObject", expr_ ] :>
+                    checkExported[
+                        "CloudObject",
+                        expr,
+                        defaultCloudObjectExport @ expr
+                    ],
+                HoldPattern @ applyImageExport[ dir: _File | _CloudObject, expr_ ] :>
+                    directoryExport[ dir, expr ],
+                HoldPattern @ applyImageExport[ f_, expr_ ] :>
+                    checkExported[ f, expr, f @ expr ],
+                HoldPattern[ e: HoldPattern @ applyImageExport[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ checkExported -> {
+            DownValues -> {
+                HoldPattern @ checkExported[ f_, expr_, exported_String? FileExistsQ ] :>
+                    toMarkdownLink @ exported,
+                HoldPattern @ checkExported[ f_, expr_, exported_String ] :> exported,
+                HoldPattern @ checkExported[ f_, expr_, (CloudObject | URL)[ url_String, ___ ] ] :>
+                    toMarkdownLink @ url,
+                HoldPattern @ checkExported[ f_, expr_, File[ file_String ] ] :>
+                    toMarkdownLink @ file,
+                HoldPattern @ checkExported[ name_String, expr_, other_ ] :>
+                    messageFailure[ "NamedExportNotString", name, expr, other ],
+                HoldPattern @ checkExported[ f_, expr_, other_ ] :>
+                    messageFailure[ "ExportNotString", f, expr, other ],
+                HoldPattern[ e: HoldPattern @ checkExported[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ toMarkdownLink -> {
+            DownValues -> {
+                HoldPattern @ toMarkdownLink[ uri_String ] :>
+                    "![image](" <> uri <> ")",
+                HoldPattern[ e: HoldPattern @ toMarkdownLink[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ defaultCloudObjectExport -> {
+            DownValues -> {
+                HoldPattern @ defaultCloudObjectExport[ e_ ] :>
+                    CloudExport[ e, "PNG", Permissions -> "Public" ],
+                HoldPattern[ e: HoldPattern @ defaultCloudObjectExport[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        },
+        HoldForm @ directoryExport -> {
+            DownValues -> {
+                HoldPattern @ directoryExport[ File[ dir_ ], expr_ ] :>
+                    directoryExport[ dir, expr ],
+                HoldPattern @ directoryExport[ dir_? DirectoryQ, expr_ ] :>
+                    Enclose[
+                        Module[ { hash, name, target, exported },
+                            
+                            hash = 
+                                ConfirmBy[
+                                    Hash @ Unevaluated @ expr,
+                                    IntegerQ,
+                                    "Hash"
+                                ];
+
+                            
+                            name = 
+                                StringJoin[
+                                    ConfirmBy[
+                                        IntegerString[ hash, 36 ],
+                                        StringQ,
+                                        "Name"
+                                    ],
+                                    ".png"
+                                ];
+
+                            target = FileNameJoin @ { dir, name };
+                            
+                            exported = 
+                                ConfirmBy[
+                                    Export[ target, expr, "PNG" ],
+                                    FileExistsQ,
+                                    "Export"
+                                ];
+
+                            checkExported[ "Directory", expr, exported ]
+                        ],
+                        throwInternalFailure
+                    ],
+                HoldPattern @ directoryExport[ target_? FileExistsQ, expr_ ] :>
+                    throwFailure[ "NotDirectory", target ],
+                HoldPattern @ directoryExport[ target_, expr_ ] :>
+                    With[ { dir = CreateDirectory @ target },
+                        If[ ! DirectoryQ @ dir,
+                            throwFailure[ "NotDirectory", dir ],
+                            directoryExport[ dir, expr ]
+                        ]
+                    ],
+                HoldPattern[ e: HoldPattern @ directoryExport[ ___ ] ] :>
+                    throwInternalFailure @ HoldForm @ e
+            }
+        }
+    ];
+
+EndPackage[ ];

--- a/ResourceFunctions/ImportMarkdownString.wl
+++ b/ResourceFunctions/ImportMarkdownString.wl
@@ -1,0 +1,341 @@
+(* ::Package:: *)
+
+(*
+    Local copy of the "ImportMarkdownString" resource function (version 1.0.0) from the Wolfram Function Repository.
+
+    Source:   https://github.com/rhennigan/ResourceFunctions/blob/main/Definitions/ImportMarkdownString/Definition.wl (commit 08ee812)
+    Resource: https://resources.wolframcloud.com/FunctionRepository/resources/ImportMarkdownString
+
+    Kernel/Common.wl (importResourceFunction) loads this file in preference to fetching the resource function from
+    the Function Repository, so the paclet can be built and loaded from source without cloud access. This directory
+    is not part of the built paclet: the MX build inlines these definitions. The original definition is wrapped in
+    BeginPackage/EndPackage so its symbols live in the "Wolfram`AgentTools`ResourceFunctions`ImportMarkdownString`" context.
+    Do not edit the definitions here; update the upstream resource function and copy the file again.
+*)
+
+BeginPackage[ "Wolfram`AgentTools`ResourceFunctions`ImportMarkdownString`" ];
+
+(* !Excluded
+This notebook was automatically generated from [Definitions/ImportMarkdownString](https://github.com/rhennigan/ResourceFunctions/blob/main/Definitions/ImportMarkdownString).
+*)
+
+(* TODO:
+    * Additional import elements:
+        * CodeBlocks
+        * Images
+        * Links
+        * Expressions
+        * HeldExpressions
+*)
+
+ImportMarkdownString // ClearAll;
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+$inDef = False;
+$debug = True;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*beginDefinition*)
+beginDefinition // ClearAll;
+beginDefinition // Attributes = { HoldFirst };
+beginDefinition::Unfinished =
+"Starting definition for `1` without ending the current one.";
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+beginDefinition[ s_Symbol ] /; $debug && $inDef :=
+    WithCleanup[
+        $inDef = False
+        ,
+        Print @ TemplateApply[ beginDefinition::Unfinished, HoldForm @ s ];
+        beginDefinition @ s
+        ,
+        $inDef = True
+    ];
+(* :!CodeAnalysis::EndBlock:: *)
+
+beginDefinition[ s_Symbol ] :=
+    WithCleanup[ Unprotect @ s; ClearAll @ s, $inDef = True ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*endDefinition*)
+endDefinition // beginDefinition;
+endDefinition // Attributes = { HoldFirst };
+
+endDefinition[ s_Symbol ] := endDefinition[ s, DownValues ];
+
+endDefinition[ s_Symbol, None ] := $inDef = False;
+
+endDefinition[ s_Symbol, DownValues ] :=
+    WithCleanup[
+        AppendTo[ DownValues @ s,
+                  e: HoldPattern @ s[ ___ ] :>
+                      throwInternalFailure @ HoldForm @ e
+        ],
+        $inDef = False
+    ];
+
+endDefinition[ s_Symbol, SubValues  ] :=
+    WithCleanup[
+        AppendTo[ SubValues @ s,
+                  e: HoldPattern @ s[ ___ ][ ___ ] :>
+                      throwInternalFailure @ HoldForm @ e
+        ],
+        $inDef = False
+    ];
+
+endDefinition[ s_Symbol, list_List ] :=
+    endDefinition[ s, # ] & /@ list;
+
+endDefinition // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section:: *)
+(*Messages*)
+ImportMarkdownString::Internal =
+"An unexpected error occurred. `1`";
+
+ImportMarkdownString::ArgumentCount =
+"ImportMarkdownString called with `1` arguments; 1 argument is expected.";
+
+ImportMarkdownString::OptionsExpected =
+"Options expected (instead of `1`) beyond position `2` in `3`. An option must be a rule or a list of rules.";
+
+ImportMarkdownString::NotAString =
+"Argument `1` is not a string.";
+
+ImportMarkdownString::InvalidImportElement =
+"Invalid import element `1`. Valid elements are \"Cell\", \"Notebook\", or Automatic.";
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section:: *)
+(*Options*)
+ImportMarkdownString // Options = {
+
+};
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section:: *)
+(*Main definition*)
+ImportMarkdownString[ string_String? StringQ, opts: OptionsPattern[ ] ] :=
+    ImportMarkdownString[ string, Automatic, opts ];
+
+ImportMarkdownString[ string_String? StringQ, Automatic, opts: OptionsPattern[ ] ] := catchTop @ Enclose[
+    Module[ { formatted, inlined, replaced },
+        formatted = ConfirmMatch[ formatChatOutput @ string, _RawBoxes, "Formatted" ];
+        replaced = ConfirmMatch[ replaceBoxes @ formatted, _RawBoxes, "Replaced" ];
+        inlined = ConfirmMatch[ inlineTemplateBoxes @ replaced, _RawBoxes, "Inlined" ];
+        ConfirmMatch[ setStyle @ inlined, _RawBoxes, "SetStyle" ]
+    ],
+    throwInternalFailure
+];
+
+ImportMarkdownString[ string_String? StringQ, "Cell", opts: OptionsPattern[ ] ] :=
+    catchTop @ toCell @ ImportMarkdownString[ string, Automatic, opts ];
+
+ImportMarkdownString[ string_String? StringQ, "Notebook", opts: OptionsPattern[ ] ] :=
+    catchTop @ toNotebook @ ImportMarkdownString[ string, Automatic, opts ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section:: *)
+(*Error cases*)
+
+(* Not a string: *)
+ImportMarkdownString[ invalid: Except[ _String? StringQ ], ___ ] :=
+    catchTop @ throwFailure[ "NotAString", invalid, 1 ];
+
+(* Not a valid import element: *)
+ImportMarkdownString[ _, invalid: Except[ "Cell" | "Notebook" | Automatic ], ___ ] :=
+    catchTop @ throwFailure[ "InvalidImportElement", invalid, 2 ];
+
+(* Invalid argument count: *)
+ImportMarkdownString[ ] :=
+    catchTop @ throwFailure[ "ArgumentCount", 0, 2 ];
+
+e: ImportMarkdownString[ _, _, invalid: Except[ OptionsPattern[ ] ], ___ ] :=
+    catchTop @ throwFailure[ "OptionsExpected", invalid, 2, HoldForm @ e ];
+
+(* Missed something that needs to be fixed: *)
+e: ImportMarkdownString[ ___ ] :=
+    catchTop @ throwInternalFailure @ e;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section:: *)
+(*Dependencies*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*formatChatOutput*)
+formatChatOutput // beginDefinition;
+formatChatOutput[ string_String? StringQ ] := formatChatOutput[ string, formatChatOutput0 @ string ];
+formatChatOutput[ string_, boxes_RawBoxes ] := boxes;
+formatChatOutput // endDefinition;
+
+formatChatOutput0 := (
+    Needs[ "Wolfram`Chatbook`" -> None ];
+    formatChatOutput0 = Symbol[ "Wolfram`Chatbook`FormatChatOutput" ]
+);
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*replaceBoxes*)
+replaceBoxes // beginDefinition;
+replaceBoxes[ boxes_ ] := boxes /. $boxReplacements;
+replaceBoxes // endDefinition;
+
+
+$boxReplacements := $boxReplacements = Dispatch @ {
+    TemplateBox[ { boxes_ }, "ChatCodeBlockTemplate", opts___ ] :>
+        With[ { new = FirstCase[ boxes, Cell[ __, "ChatCode", ___ ], Missing[ ], Infinity ] },
+            TemplateBox[ { new }, "ChatCodeBlockTemplate", opts ] /; ! MissingQ @ new
+        ]
+};
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*inlineTemplateBoxes*)
+inlineTemplateBoxes // beginDefinition;
+inlineTemplateBoxes[ boxes_ ] := inlineTemplateBoxes[ boxes, inlineTemplateBoxes0 @ boxes ];
+inlineTemplateBoxes[ boxes_, inlined_RawBoxes ] := inlined;
+inlineTemplateBoxes // endDefinition;
+
+inlineTemplateBoxes0 := (
+    Needs[ "Wolfram`Chatbook`" -> None ];
+    inlineTemplateBoxes0 = Symbol @ SelectFirst[
+        { "Wolfram`Chatbook`InlineTemplateBoxes", "Wolfram`Chatbook`Common`inlineTemplateBoxes" },
+        definedQ,
+        throwInternalFailure @ inlineTemplateBoxes0
+    ]
+);
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*setStyle*)
+setStyle // beginDefinition;
+setStyle[ RawBoxes[ cell_ ] ] := RawBoxes @ setStyle @ cell;
+setStyle[ Cell[ a___ ] ] := Cell[ a, "Text", Background -> None ];
+setStyle // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*toCell*)
+toCell // beginDefinition;
+toCell[ RawBoxes[ cell_ ] ] := toCell @ cell;
+toCell[ cell_Cell ] := cell;
+toCell // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*toNotebook*)
+toNotebook // beginDefinition;
+toNotebook[ RawBoxes[ cell_ ] ] := toNotebook @ cell;
+toNotebook[ cell_Cell ] := toNotebook[ cell, explodeCell @ cell ];
+toNotebook[ cell_, cells: { ___Cell } ] := Notebook @ cells;
+toNotebook // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*explodeCell*)
+explodeCell // beginDefinition;
+explodeCell[ RawBoxes[ cell_ ] ] := explodeCell @ cell;
+explodeCell[ cell_Cell ] := explodeCell[ cell, explodeCell0 @ cell ];
+explodeCell[ cell_, cells: { ___Cell } ] := cells;
+explodeCell // endDefinition;
+
+explodeCell0 := (
+    Needs[ "Wolfram`Chatbook`" -> None ];
+    explodeCell0 = Symbol @ SelectFirst[
+        { "Wolfram`Chatbook`ExplodeCell", "Wolfram`Chatbook`Common`explodeCell" },
+        definedQ,
+        throwInternalFailure @ explodeCell0
+    ]
+);
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*definedQ*)
+definedQ // beginDefinition;
+definedQ[ name_String ] := ToExpression[ name, InputForm, System`Private`HasAnyEvaluationsQ ];
+definedQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Error handling*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*catchTop*)
+catchTop // beginDefinition;
+catchTop // Attributes = { HoldFirst };
+
+catchTop[ eval_ ] :=
+    Block[ { $catching = True, $failed = False, catchTop = # & },
+        Catch[ eval, $top ]
+    ];
+
+catchTop // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*throwFailure*)
+throwFailure // beginDefinition;
+throwFailure // Attributes = { HoldFirst };
+
+throwFailure[ tag_String, params___ ] :=
+    throwFailure[ MessageName[ ImportMarkdownString, tag ], params ];
+
+throwFailure[ msg_, args___ ] :=
+    Module[ { failure },
+        failure = messageFailure[ msg, Sequence @@ HoldForm /@ { args } ];
+        If[ TrueQ @ $catching,
+            Throw[ failure, $top ],
+            failure
+        ]
+    ];
+
+throwFailure // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*messageFailure*)
+messageFailure // beginDefinition;
+messageFailure // Attributes = { HoldFirst };
+
+messageFailure[ args___ ] :=
+    Module[ { quiet },
+        quiet = If[ TrueQ @ $failed, Quiet, Identity ];
+        WithCleanup[
+            quiet @ ResourceFunction[ "MessageFailure" ][ args ],
+            $failed = True
+        ]
+    ];
+
+messageFailure // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*throwInternalFailure*)
+throwInternalFailure // beginDefinition;
+throwInternalFailure // Attributes = { HoldFirst };
+
+throwInternalFailure[ eval_, a___ ] :=
+    throwFailure[ ImportMarkdownString::Internal, $bugReportLink, HoldForm @ eval, a ];
+
+throwInternalFailure // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$bugReportLink*)
+$bugReportLink := $bugReportLink = Hyperlink[
+    "Report this issue \[RightGuillemet]",
+    URLBuild @ <|
+        "Scheme"   -> "https",
+        "Domain"   -> "resources.wolframcloud.com",
+        "Path"     -> { "FunctionRepository", "feedback-form" },
+        "Fragment" -> "ImportMarkdownString"
+    |>
+];
+EndPackage[ ];

--- a/ResourceFunctions/MessageFailure.wl
+++ b/ResourceFunctions/MessageFailure.wl
@@ -1,0 +1,1289 @@
+(* ::Package:: *)
+
+(*
+    Local copy of the "MessageFailure" resource function (version 1.0.1) from the Wolfram Function Repository.
+
+    Source:   https://github.com/rhennigan/ResourceFunctions/blob/main/Definitions/MessageFailure/Definition.wl (commit 08ee812)
+    Resource: https://resources.wolframcloud.com/FunctionRepository/resources/MessageFailure
+
+    Kernel/Common.wl (importResourceFunction) loads this file in preference to fetching the resource function from
+    the Function Repository, so the paclet can be built and loaded from source without cloud access. This directory
+    is not part of the built paclet: the MX build inlines these definitions. The original definition is wrapped in
+    BeginPackage/EndPackage so its symbols live in the "Wolfram`AgentTools`ResourceFunctions`MessageFailure`" context.
+    Do not edit the definitions here; update the upstream resource function and copy the file again.
+*)
+
+BeginPackage[ "Wolfram`AgentTools`ResourceFunctions`MessageFailure`" ];
+
+(* !Excluded
+This notebook was automatically generated from [Definitions/MessageFailure](https://github.com/rhennigan/ResourceFunctions/blob/main/Definitions/MessageFailure).
+*)
+
+MessageFailure // ClearAll;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Messages*)
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Messages for normal evaluation*)
+MessageFailure::empty =
+"An evaluation failed.";
+
+MessageFailure::tagged =
+"A failure of type \"`1`\" occurred.";
+
+MessageFailure::expression =
+"An evaluation failed with expression `1`.";
+
+MessageFailure::arguments =
+"An evaluation failed with arguments `1`.";
+
+MessageFailure::message =
+"`1`";
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Messages for errors*)
+MessageFailureInternal // ClearAll;
+
+MessageFailureInternal::invfailargs =
+"Internal Error: Could not construct a valid Failure object from arguments: \
+`2`. `1`";
+
+MessageFailureInternal::invfail =
+"Internal Error: `2` is not a valid Failure object. `1`";
+
+MessageFailureInternal::undefined =
+"Internal Error: No definition found for `2`. `1`";
+
+MessageFailureInternal::unknown =
+"Internal Error: An unexpected error occurred. `1`";
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Attributes*)
+MessageFailure // Attributes = { HoldFirst };
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Options*)
+MessageFailure // Options = {
+    "MessageFunction" -> Automatic,
+    "Verbose"         -> False,
+    "Stack"           -> False,
+    "TestMode"        -> False
+};
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Definition utilities*)
+endDefinition // ClearAll;
+endDefinition // Attributes = { HoldFirst };
+endDefinition[ s_Symbol? symbolQ ] :=
+    expr: s[ ___ ] := throwInternalFailure[ "undefined", HoldForm @ expr ];
+
+
+
+catch // ClearAll;
+catch // Attributes = { HoldFirst };
+catch[ eval_ ] :=
+    stacked @ Block[ { $catching = True, catch = # & },
+        Catch[ eval, $top ]
+    ];
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+debugPrint // ClearAll;
+debugPrint // Attributes = { HoldAllComplete };
+debugPrint[ args___ ] /; $debug := Print @ args;
+(* :!CodeAnalysis::EndBlock:: *)
+
+stacked // ClearAll;
+stacked[ a_, ___ ] := a;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Flags set by option values*)
+$stack   = Automatic;
+$verbose = False;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Argument patterns*)
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PatternTest:: *)
+$failureOpts = OptionsPattern @ Failure;
+$mfOpts      = OptionsPattern @ MessageFailure;
+$opts        = OptionsPattern[ { MessageFailure, Failure } ]? optionsQ;
+$symbol      = _Symbol? symbolQ;
+$string      = _String? stringQ;
+$params      = { ___ } | _Association? AssociationQ;
+(* :!CodeAnalysis::EndBlock:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Options handling*)
+$optKey // ClearAll;
+$optKey := $optKey = Alternatives @@ (
+    ToString /@ Keys @ Options @ MessageFailure
+);
+
+
+
+optNameQ // ClearAll;
+optNameQ // Attributes = { HoldFirst };
+optNameQ[ s_? stringQ ] := MatchQ[ s, $optKey ];
+optNameQ[ s_? symbolQ ] := MatchQ[ SymbolName @ Unevaluated @ s, $optKey ];
+optNameQ[ ___         ] := False;
+
+
+
+optionQ // ClearAll;
+optionQ // Attributes = { HoldFirst };
+optionQ[ (Rule|RuleDelayed)[ _? optNameQ, _ ] ] := True;
+optionQ[ ___ ] := False;
+
+
+
+optionsQ // ClearAll;
+optionsQ // Attributes = { HoldFirst };
+optionsQ[ ___? optionQ ] := True;
+optionsQ[ ___ ] := False;
+
+
+
+notOptionQ // ClearAll;
+notOptionQ // Attributes = { HoldFirst };
+notOptionQ[ arg_ ] := TrueQ[ ! optionQ @ arg ];
+notOptionQ[ ___  ] := False;
+
+
+
+paramsQ // ClearAll;
+paramsQ // Attributes = { HoldFirst };
+paramsQ[ arg_ ] := MatchQ[ Unevaluated @ arg, $params ];
+paramsQ[ ___  ] := False;
+
+
+
+paramsAndOptions // ClearAll;
+
+paramsAndOptions[ params:___? notOptionQ, opts___? optionQ ] :=
+    <| "MessageParameters" :> { params }, "Options" :> { opts } |>;
+
+paramsAndOptions[ params___ ] :=
+    <| "MessageParameters" :> { params } |>;
+
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Main definition*)
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*From MessageName*)
+MessageFailure[ msg: MessageName[ sym_, tag_, tags___ ], params___ ] /;
+    messageNameQ @ msg :=
+        catch @ messageFailure @ Join[
+            <|
+                "MessageTemplate" :> msg,
+                "MessageTag"      -> { tag, tags },
+                "MessageSymbol"   :> sym,
+                "FailureTag"      -> makeFailureTag @ msg
+            |>,
+            paramsAndOptions @ params
+        ];
+
+
+makeFailureTag // ClearAll;
+makeFailureTag // Attributes = { HoldFirst };
+
+makeFailureTag[ MessageName[ sym_? symbolQ, tag__? stringQ ] ] :=
+    StringRiffle[ { SymbolName @ Unevaluated @ sym, tag }, "::" ];
+
+makeFailureTag[ sym_Symbol? symbolQ ] := symbolToFailTag @ sym;
+
+makeFailureTag[ ___ ] := "MessageFailure";
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*From Failure*)
+MessageFailure[ Failure[ tag_, assoc_Association? AssociationQ ] ] :=
+    catch @ messageFailure @ Append[ assoc, "FailureTag" -> tag ];
+
+MessageFailure[ Failure[ tag_, assoc_Association? AssociationQ ] ] :=
+    MessageFailure[ tag, assoc ];
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Failure-like syntax*)
+MessageFailure[ tag_? tagQ, assoc_? AssociationQ, opts: $opts ] :=
+    catch @ messageFailure @ Join[
+        assoc,
+        <| "FailureTag" :> tag, "Options" :> { opts } |>
+    ];
+
+
+MessageFailure[ assoc_Association? AssociationQ, opts: $opts ] :=
+    catch @ messageFailure @ Join[ <| "Options" :> { opts } |>, assoc ];
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Check value of first argument*)
+MessageFailure[ arg: Except[ _MessageName ], rest___ ] :=
+    With[ { eval = arg },
+        MessageFailure[ eval, rest ] /; ! MatchQ[ eval, HoldPattern @ arg ]
+    ];
+
+
+MessageFailure[ message_? notOptionQ, opts: $opts ] :=
+    catch @ messageFailure @ <|
+        "FailureTag"      :> "MessageFailure",
+        "Options"         :> { opts },
+        "MessageTemplate" :> message,
+        "MessageSymbol"   :> MessageFailure,
+        "MessageTag"      :> { "message" }
+    |>;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Basic argument forms*)
+MessageFailure[ tag_? tagQ, Automatic, opts: $opts ] :=
+    catch @ messageFailure @ <|
+        "FailureTag"        :> tag,
+        "Options"           :> { opts },
+        "MessageTemplate"   :> MessageFailure::tagged,
+        "MessageTag"        :> { "tagged" },
+        "MessageParameters" :> { tag }
+    |>;
+
+
+MessageFailure[ tag_? tagQ, message_, opts: $opts ] :=
+    MessageFailure[ tag, <| "Message" :> message, "Options" :> { opts } |> ];
+
+
+MessageFailure[ Evaluate[ opts: $opts ] ] :=
+    MessageFailure[ "MessageFailure", <| "Options" :> { opts } |> ];
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Fallback definitions*)
+MessageFailure[ other_ ] :=
+    catch @ messageFailure @ <|
+        "MessageParameters" :> { other },
+        "MessageTemplate"   :> MessageFailure::expression,
+        "MessageTag"        :> { "expression" }
+    |>;
+
+MessageFailure[ other___ ] :=
+    catch @ messageFailure @ <|
+        "MessageParameters" :> { { other } },
+        "MessageTemplate"   :> MessageFailure::arguments,
+        "MessageTag"        :> { "arguments" }
+    |>;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*messageFailure*)
+messageFailure // ClearAll;
+
+messageFailure[ info: KeyValuePattern[ "MessageTemplate" :> msg_ ] ] :=
+    Block[ { $msgBlocked = True }, msgBlock[ msg, messageFailure @ info ] ] /;
+        ! TrueQ @ $msgBlocked;
+
+messageFailure[ info: KeyValuePattern @ {
+    "MessageTemplate"   :> msg_,
+    "MessageParameters" :> _? paramsQ,
+    "MessageTag"        :> { msgTag__ },
+    "MessageSymbol"     :> sym_,
+    "FailureTag"        :> tag_,
+    "Options"           :> Evaluate @ { opts: $opts }
+} ] :=
+    withOptions[ makeFailureObject @ issueMessage @ info, opts ];
+
+messageFailure[ info: KeyValuePattern @ { } ] :=
+    With[ { new = standardizeInfo @ info },
+        messageFailure @ new /; new =!= info
+    ];
+
+messageFailure[ args___ ] :=
+    messageFailure @ Join[
+        $defaultMessageFailureArgs,
+        <|
+            "MessageParameters" :> { args }
+        |>
+    ];
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*msgBlock*)
+msgBlock // ClearAll;
+msgBlock // Attributes = { HoldAll };
+
+msgBlock[ MessageName[ sym_? symbolQ, ___ ], eval_ ] :=
+    With[ { $sym := sym },
+        WithCleanup[
+            debugPrint[ "before: ", Messages @ sym ],
+            Internal`InheritedBlock[ { $sym }, eval ],
+            debugPrint[ "after: ", Messages @ sym ]
+        ]
+    ];
+
+msgBlock[ _, eval_ ] := eval;
+
+msgBlock // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*withOptions*)
+withOptions // ClearAll;
+withOptions // Attributes = { HoldFirst };
+
+withOptions[ eval_, opts___ ] :=
+    Block[
+        {
+            $stack   = OptionValue[ MessageFailure, { opts }, "Stack"   ],
+            $verbose = OptionValue[ MessageFailure, { opts }, "Verbose" ]
+        },
+        If[ TrueQ @ $stack,
+            StackComplete @ eval,
+            eval
+        ]
+    ];
+
+
+withOptions // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*issueMessage*)
+issueMessage // ClearAll;
+issueMessage[ info_ ] := applyWithTemplateWrapper[ issueMessage0, info ];
+issueMessage // endDefinition;
+
+
+issueMessage0 // ClearAll;
+
+issueMessage0[ info: KeyValuePattern @ {
+    "MessageTemplate"   :> str_String,
+    "MessageParameters" :> params_List
+} ] :=
+    Module[ { msg, new },
+        msg = TemplateApply[ str, params ];
+        new = Join[
+            info,
+            <|
+                "MessageTemplate"   :> MessageFailure::message,
+                "MessageParameters" :> Evaluate @ { msg },
+                "MessageTag"        :> { "message" }
+            |>
+        ];
+        issueMessage0 @ new
+    ];
+
+
+issueMessage0[ info: KeyValuePattern @ {
+    "MessageTemplate"   :> msg_,
+    "MessageParameters" :> params_Association,
+    "MessageTag"        :> { msgTag__ },
+    "MessageSymbol"     :> sym_Symbol? symbolQ,
+    "Options"           :> Evaluate @ { opts: $opts }
+} ] :=
+    Module[ { message, string },
+        message = getMessageFunction[ MessageName[ sym, msgTag ], opts ];
+        string  = messageString[ msg, params ];
+
+        (* TODO: set up override for list params too *)
+        messageOverride[ MessageName[ sym, msgTag ], message, string, params ];
+
+        (* message[ msg, params ]; *)
+        info
+    ];
+
+
+issueMessage0[ info: KeyValuePattern @ {
+    "MessageTemplate"   :> msg_,
+    "MessageParameters" :> { params___ },
+    "MessageTag"        :> { msgTag__ },
+    "MessageSymbol"     :> sym_,
+    "Options"           :> Evaluate @ { opts: $opts }
+} ] :=
+    Module[ { mName, message, string },
+        mName   = MessageName[ sym, msgTag ];
+        message = getMessageFunction[ MessageName[ sym, msgTag ], opts ];
+        If[ mName =!= msg,
+            string = messageString[ msg, params ];
+            messageOverride[ MessageName[ sym, msgTag ],
+                             message,
+                             string,
+                             params
+            ],
+            message[ msg, params ]
+        ];
+        info
+    ];
+
+
+issueMessage0 // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*applyWithTemplateWrapper*)
+applyWithTemplateWrapper // ClearAll;
+applyWithTemplateWrapper // Attributes = { HoldAll };
+applyWithTemplateWrapper[ f_, info_ ] :=
+    stripTemplateWrapper @ f @ addTemplateWrapper @ info;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*addTemplateWrapper*)
+addTemplateWrapper // ClearAll;
+
+
+addTemplateWrapper[ info: KeyValuePattern[ "MessageTemplate" :> template_ ] ] :=
+    If[ ! FreeQ[ HoldComplete @ template, $templateSymbols ],
+        Join[
+            info,
+            <|
+                "MessageTemplate" :> TemplateExpression @ template,
+                "TemplateWrapper" :> TemplateExpression
+            |>
+        ],
+        info
+    ];
+
+
+addTemplateWrapper[ info_ ] := info;
+
+
+addTemplateWrapper // endDefinition;
+
+
+$templateSymbols = HoldPattern @ Alternatives[
+    TemplateEvaluate,
+    TemplateExpression,
+    TemplateIf,
+    TemplateObject,
+    TemplateSequence,
+    TemplateSlot,
+    TemplateSlotSequence,
+    TemplateUnevaluated,
+    TemplateVerbatim,
+    TemplateWith
+];
+
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*stripTemplateWrapper*)
+stripTemplateWrapper // ClearAll;
+
+
+stripTemplateWrapper[ info: KeyValuePattern @ {
+    "MessageTemplate" :> wrapper_[ template_ ],
+    "TemplateWrapper" :> wrapper_
+} ] :=
+    Append[ KeyDrop[ info, "TemplateWrapper" ],
+            "MessageTemplate" :> template
+    ];
+
+
+stripTemplateWrapper[ info_ ] := info;
+
+
+stripTemplateWrapper // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*messageOverride*)
+messageOverride // ClearAll;
+messageOverride // Attributes = { HoldFirst };
+
+
+messageOverride[
+    msg: MessageName[ sym_, __ ],
+    message_,
+    string_String,
+    params___
+] :=
+    With[ { $sym := sym },
+        Block[ { $sym, Internal`$MessageFormatter = msgFormatter },
+            msg = string;
+            message[ msg, params ]
+        ]
+    ];
+
+
+messageOverride // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*msgFormatter*)
+msgFormatter // ClearAll;
+msgFormatter // Attributes = { HoldAllComplete };
+
+
+msgFormatter[ msg_, StringForm[ str_String ] ] :=
+    msgFormatter[ msg, StringForm[ "`1`", str ] ];
+
+
+msgFormatter[ args___ ] :=
+    Internal`MessageMenuFormatter @ args;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*templateType*)
+templateType // ClearAll;
+templateType[ template_String ] := templateType @ StringTemplate @ template;
+templateType[ template_ ] :=
+    If[ FreeQ[ template, TemplateSlot[ _String ] | _TemplateExpression ],
+        "Positional",
+        "Named"
+    ];
+
+
+templateType // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*getMessageTemplate*)
+getMessageTemplate // ClearAll;
+
+
+getMessageTemplate[ HoldPattern @ MessageName[ sym_, tag__ ], args___ ] :=
+    getMessageTemplate[ MessageName[ General, tag ], args ];
+
+
+getMessageTemplate[ HoldPattern @ MessageName[ General, __ ], args___ ] :=
+    StringJoin[
+        "-- Message text not found --",
+        Table[
+            { " (`", ToString @ i, "`)" },
+            { i, Length @ HoldComplete @ args }
+        ]
+    ];
+
+
+getMessageTemplate[ template_, args___ ] :=
+    template;
+
+
+getMessageTemplate // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*messageString*)
+messageString // ClearAll;
+
+
+messageString[ HoldPattern @ MessageName[ sym_, tag__ ], args___ ] :=
+    messageString[ MessageName[ General, tag ], args ];
+
+
+messageString[ HoldPattern @ MessageName[ General, __ ], args___ ] :=
+    StringJoin[
+        "-- Message text not found --",
+        Table[
+            { " (`", ToString @ i, "`)" },
+            { i, Length @ HoldComplete @ args }
+        ]
+    ];
+
+
+messageString[ string_String, args___ ] :=
+    Module[ { template, type },
+        template = messageStringTemplate @ string;
+        type = templateType @ template;
+        messageString0[ type, template, args ]
+    ];
+
+
+messageString[ template_, args_Association ] :=
+    toString @ TemplateApply[ template, args ];
+
+
+messageString[ template_, args___ ] :=
+    toString @ TemplateApply[ template, { args } ];
+
+
+messageString[ ___ ] :=
+    "-- Message text not found --";
+
+
+
+messageString0 // ClearAll;
+
+
+messageString0[ "Named", template_, assoc_Association ] :=
+    TemplateApply[ template, assoc ];
+
+
+messageString0[ "Named", template_, ___ ] := TemplateApply @ template;
+
+
+messageString0[ "Positional", template_, assoc_Association ] :=
+    TemplateApply[ template, Values @ assoc ];
+
+
+messageString0[ "Positional", ___ ] := Missing[ "WrongTemplateType" ];
+
+
+messageString0 // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*messageStringTemplate*)
+messageStringTemplate // ClearAll;
+
+
+messageStringTemplate[ template_String ] /; $Notebooks :=
+    StringTemplate[
+        template,
+        InsertionFunction -> Function @ ToString[ #, StandardForm ]
+    ];
+
+
+messageStringTemplate[ template_String ] :=
+    StringTemplate[ template, InsertionFunction -> toString ];
+
+
+messageStringTemplate[ ___ ] :=
+    "-- Message text not found --";
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*toString*)
+toString // ClearAll;
+toString[ string_String? StringQ ] := string;
+toString[ expr_ ] /; $Notebooks := ToString[ expr, StandardForm ];
+toString[ expr_ ] := ToString @ expr;
+toString // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*standardizeInfo*)
+standardizeInfo // ClearAll;
+
+
+standardizeInfo[ info: KeyValuePattern[ _ -> _ ] ] :=
+    standardizeInfo @ AssociationMap[
+        Apply @ RuleDelayed,
+        Association @ info
+    ];
+
+
+standardizeInfo[ info: KeyValuePattern[ "Message" :> msg_ ] ] :=
+    standardizeInfo @ Append[
+        KeyDrop[ info, "Message" ],
+        "MessageTemplate" :> msg
+    ];
+
+
+standardizeInfo[ info: KeyValuePattern @ { } ] :=
+    AssociationMap[
+        Apply @ RuleDelayed,
+        Join[ $defaultMessageFailureArgs,
+              $standardizer @ info
+        ]
+    ];
+
+
+standardizeInfo // endDefinition;
+
+
+$standardizer = Composition[
+    validateInfo,
+    addSymbolAndTag,
+    addMessageTemplate,
+    checkFailureTag,
+    checkTemplateType,
+    Association
+];
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*addSymbolAndTag*)
+addSymbolAndTag // ClearAll;
+
+
+addSymbolAndTag[ info: KeyValuePattern[
+    "MessageTemplate" :> MessageName[ sym_Symbol, tag___ ]
+] ] :=
+    Join[
+        <|
+            "MessageSymbol" :> sym,
+            "MessageTag"    :> { tag }
+        |>,
+        info
+    ];
+
+
+addSymbolAndTag[ info_ ] := info;
+
+
+addSymbolAndTag // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*checkTemplateType*)
+checkTemplateType // ClearAll;
+
+
+checkTemplateType[ info: KeyValuePattern @ {
+     "MessageTemplate"   :> template_,
+     "MessageParameters" :> { params_Association }
+} ] :=
+    If[ templateType @ getMessageTemplate @ template === "Named",
+        Append[ info, "MessageParameters" :> params ],
+        info
+    ];
+
+checkTemplateType[ info: KeyValuePattern @ {
+     "MessageTemplate"   :> template_,
+     "MessageParameters" :> { }
+} ] :=
+    If[ templateType @ getMessageTemplate @ template === "Named",
+        Append[ info, "MessageParameters" :> Evaluate[ <| |> ] ],
+        info
+    ];
+
+checkTemplateType[ info_ ] := info;
+
+
+checkTemplateType // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*checkFailureTag*)
+checkFailureTag // ClearAll;
+
+
+checkFailureTag[ info: KeyValuePattern[ "Tag" :> tag_? tagQ ] ] :=
+    Append[ info, "FailureTag" :> tag ];
+
+
+checkFailureTag[ info_ ] := info;
+
+
+checkFailureTag // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*addMessageTemplate*)
+addMessageTemplate // ClearAll;
+
+
+addMessageTemplate[ info: KeyValuePattern[ "Message" :> msg_ ] ] :=
+    Append[ KeyDrop[ info, "Message" ], "MessageTemplate" :> msg ];
+
+
+addMessageTemplate[ info_ ] := info;
+
+
+addMessageTemplate // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*validateInfo*)
+validateInfo // ClearAll;
+
+
+validateInfo[ info: KeyValuePattern @ { } ] :=
+    DeleteMissing @ Association @ AssociationMap[
+        validateRule,
+        Association @ info
+    ];
+
+
+validateInfo[ ___ ] := <| |>;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*validateRule*)
+validateRule // ClearAll;
+validateRule // Attributes = { HoldRest };
+
+
+validateRule[ (Rule|RuleDelayed)[ a_, b_ ] ] :=
+    validateRule[ a, b ];
+
+
+validateRule[ "FailureTag", tag_? tagQ ] :=
+    "FailureTag" :> tag;
+
+
+validateRule[ "MessageParameters", p: Except[ _? paramsQ ] ] :=
+    "MessageParameters" :> { p };
+
+
+validateRule[ "MessageSymbol", Except[ _? symbolQ ] ] := Nothing;
+
+
+validateRule[ "MessageTag", str_String? stringQ ] :=
+    "MessageTag" :> { str };
+
+
+validateRule[
+    "MessageTag",
+    Except[ { _? stringQ }|{ _? stringQ, _? stringQ } ]
+] :=
+    Nothing;
+
+
+validateRule[ "Options", opts: { ___? optionQ } ] :=
+    "Options" :> opts;
+
+
+validateRule[ "Options", opts___ ] :=
+    "Options" :> Evaluate @ Lookup[ paramsAndOptions @ opts, "Options", { } ];
+
+
+validateRule[ key_, value_ ] := key :> value;
+
+
+validateRule[ ___ ] := Nothing;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$defaultMessageFailureArgs*)
+$defaultMessageFailureArgs // ClearAll;
+
+
+$defaultMessageFailureArgs := $defaultMessageFailureArgs = <|
+    "FailureTag"        :> "MessageFailure",
+    "MessageParameters" :> { },
+    "MessageSymbol"     :> MessageFailure,
+    "MessageTag"        :> { "empty" },
+    "MessageTemplate"   :> MessageFailure::empty,
+    "Options"           :> { }
+|>;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*symbolToFailTag*)
+symbolToFailTag // ClearAll;
+symbolToFailTag // Attributes = { HoldFirst };
+
+
+symbolToFailTag[ MessageFailure ] := "MessageFailure";
+
+
+symbolToFailTag[ symbol_Symbol ] :=
+    Module[ { code, eval },
+        code = TrueQ @ System`Private`HasOwnCodeQ @ Unevaluated @ symbol;
+        eval = TrueQ @ System`Private`HasOwnEvaluationsQ @ symbol;
+        If[ code || eval,
+            ToString @ Unevaluated @ FullForm @ symbol,
+            symbol
+        ]
+    ];
+
+
+symbolToFailTag // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*makeFailureObject*)
+makeFailureObject // ClearAll;
+
+
+makeFailureObject[ Failure[ tag_ ], opts: $failureOpts ] :=
+    makeFailureObject @ Failure[ tag, <| |>, opts ];
+
+
+makeFailureObject[ failure_Failure? failureObjectQ, opts: $failureOpts ] :=
+    Append[ failure, Unevaluated @ Sequence @ opts ];
+
+
+makeFailureObject[ info: KeyValuePattern[ "FailureTag" :> tag_ ] ] :=
+    Module[ { withStack, cleaned, failure },
+
+        withStack = includeStack @ info;
+        cleaned   = If[ TrueQ @ $verbose,
+                        withStack,
+                        KeyDrop[
+                            withStack,
+                            {
+                                "FailureTag",
+                                "MessageSymbol",
+                                "MessageTag",
+                                "Options"
+                            }
+                        ]
+                    ];
+
+        failure = Failure[ tag, cleaned ];
+
+        If[ tagQ @ tag,
+            Failure[ tag, cleaned ]
+        ]
+    ];
+
+
+makeFailureObject[ tag_? tagQ, opts: $failureOpts ] :=
+    makeFailureObject @ Failure[ tag, <| |>, opts ];
+
+
+makeFailureObject[ args___ ] :=
+    With[ { fail = Failure @ args },
+        If[ failureObjectQ @ fail,
+            fail,
+            internalFailure[ "invfail", fail ]
+        ]
+    ];
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*internalFailure*)
+internalFailure // ClearAll;
+internalFailure // Attributes = { HoldFirst };
+
+
+internalFailure[ tag_String? stringQ, params___ ] :=
+    With[ { msg := MessageName[ MessageFailureInternal, tag ] },
+        Failure[ makeFailureTag @ msg,
+                 <|
+                     "MessageTemplate"   :> msg,
+                     "MessageParameters" :> { $bugReportLink, params }
+                 |>
+        ] /; StringQ @ msg
+    ];
+
+
+internalFailure[ args___ ] := defaultInternalFailure @ args;
+
+
+$bugReportLink := Hyperlink[
+    "Report this issue \[RightGuillemet]",
+    $bugReportURL
+];
+
+
+$bugReportURL := $bugReportURL =
+    URLBuild @ <|
+        "Scheme"   -> "https",
+        "Domain"   -> "resources.wolframcloud.com",
+        "Path"     -> { "FunctionRepository", "feedback-form" },
+        "Fragment" -> "MessageFailure"
+    |>;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*throwInternalFailure*)
+throwInternalFailure // ClearAll;
+
+
+throwInternalFailure[ args___ ] :=
+    With[ { fail = internalFailure @ args },
+        Message @ fail;
+        If[ TrueQ @ $catching,
+            Throw[ fail, $top ],
+            fail
+        ]
+    ];
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*defaultInternalFailure*)
+defaultInternalFailure // ClearAll;
+
+
+defaultInternalFailure[ args___ ] :=
+    Failure[ "MessageFailureInternal::unknown",
+             <|
+                 "MessageTemplate"   :> MessageFailureInternal::unknown,
+                 "MessageParameters" :> { $bugReportLink, args }
+             |>
+    ];
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*checkFailureObject*)
+checkFailureObject // ClearAll;
+
+
+checkFailureObject[ failure_Failure? failureObjectQ ] := failure;
+
+
+checkFailureObject[ other___ ] := internalFailure[ "invfail", other ];
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*includeStack*)
+includeStack // ClearAll;
+
+
+includeStack[ info_ ] :=
+    includeStack[ info, $verbose, $stack ];
+
+
+includeStack[ info_, verbose_, Full ] :=
+    includeStack[ info, verbose, Full, Stack[ _ ] ];
+
+
+includeStack[ info_, True, True ] :=
+    includeStack[ info, True, True, Stack[ _ ] ];
+
+
+includeStack[ info_, verbose_, type: True|Automatic ] :=
+    includeStack[ info, verbose, type, HoldForm /@ Stack[ ] ];
+
+
+includeStack[ info_, verbose_, _, stack_ ] :=
+    Join[
+        info,
+        <|
+            "IncludeStack" :> True,
+            "Stack"        :> Evaluate @ trimStack[ stack, verbose ]
+        |>
+    ];
+
+
+includeStack[ info_, ___ ] := info;
+
+
+includeStack // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*trimStack*)
+trimStack // ClearAll;
+
+
+trimStack[ stack_, True ] := stack;
+
+
+trimStack[
+    {
+        a___,
+        HoldForm @ MessageFailure,
+        ___
+    },
+    _
+] := { a, HoldForm @ MessageFailure };
+
+
+trimStack[
+    {
+        a___,
+        HoldForm @ stacked,
+        ___
+    },
+    _
+] := { a };
+
+
+trimStack[ { a___, b: _[ _MessageFailure ], ___ }, _ ] := { a, b };
+
+
+trimStack[ { a___, HoldForm[ _stacked ], ___ }, _ ] := { a };
+
+
+trimStack[ stack_, _ ] := stack;
+
+
+trimStack // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*failureObjectQ*)
+failureObjectQ // ClearAll;
+
+
+failureObjectQ[ fail_Failure ] :=
+    ! MatchQ[ fail[ "Tag" ], HoldPattern @ fail[ "Tag" ] ];
+
+
+failureObjectQ[ ___ ] := False;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Utilities*)
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*getMessageFunction*)
+getMessageFunction // ClearAll;
+getMessageFunction // Attributes = { HoldFirst };
+
+
+getMessageFunction[ template_, opts: $mfOpts ] :=
+    chooseMessageFunction[
+        template,
+        OptionValue[ MessageFailure, { opts }, "MessageFunction" ],
+        OptionValue[ MessageFailure, { opts }, "TestMode"        ]
+    ];
+
+
+getMessageFunction // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*chooseMessageFunction*)
+chooseMessageFunction // ClearAll;
+chooseMessageFunction // Attributes = { HoldFirst };
+
+
+chooseMessageFunction[ _, None, _ ] :=
+    Function[ Null, Null, { HoldAllComplete } ];
+
+
+chooseMessageFunction[ template_String, Automatic, _ ] :=
+    templateMessageFunction[
+        template,
+        ResourceFunction[ "ResourceFunctionMessage", "Function" ]
+    ];
+
+
+chooseMessageFunction[ template_, rf: HoldPattern[ _ResourceFunction ], testing_ ] :=
+    With[ { sym = ResourceFunction[ rf, "Function" ] },
+        If[ symbolQ @ sym,
+            chooseMessageFunction[ template, sym, testing ]
+        ]
+    ];
+
+
+chooseMessageFunction[ template_String, mf_, _ ] :=
+    templateMessageFunction[ template, mf ];
+
+
+chooseMessageFunction[ MessageName[ sym_Symbol, __ ], Automatic, testing_ ] :=
+    Block[ { $testMode = testing },
+        If[ rfSymbolQ @ sym,
+            ResourceFunction[ "ResourceFunctionMessage", "Function" ],
+            Message
+        ]
+    ];
+
+
+chooseMessageFunction[ _, mf_, _ ] := mf;
+
+
+chooseMessageFunction // endDefinition;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*messageNameQ*)
+messageNameQ // ClearAll;
+messageNameQ // Attributes = { HoldAllComplete };
+
+messageNameQ[ msg_MessageName ] :=
+    MatchQ[ Unevaluated @ msg,
+            Alternatives[
+                _[ $symbol, $string ],
+                _[ $symbol, $string, $string ]
+            ]
+    ];
+
+messageNameQ[ ___ ] := False;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*symbolQ*)
+symbolQ // ClearAll;
+symbolQ // Attributes = { HoldAllComplete };
+
+symbolQ[ s_Symbol ] :=
+    And[ AtomQ @ Unevaluated @ s,
+         ! Internal`RemovedSymbolQ @ Unevaluated @ s,
+         ! MatchQ[ Unevaluated @ s, Internal`$EFAIL ]
+    ];
+
+symbolQ[ ___ ] := False;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*stringQ*)
+stringQ // ClearAll;
+stringQ // Attributes = { HoldAllComplete };
+stringQ[ s_String ] := StringQ @ Unevaluated @ s;
+stringQ[ ___      ] := False;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*tagQ*)
+tagQ // ClearAll;
+tagQ // Attributes = { HoldAllComplete };
+tagQ[ _? stringQ ] := True;
+tagQ[ _? symbolQ ] := True;
+tagQ[ ___        ] := False;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*rfSymbolQ*)
+rfSymbolQ // ClearAll;
+rfSymbolQ // Attributes = { HoldAllComplete };
+rfSymbolQ[ MessageFailure|MessageFailureInternal ] := ! TrueQ @ $testMode;
+rfSymbolQ[ sym_Symbol? symbolQ ] /; $testMode := False;
+rfSymbolQ[ sym_Symbol? symbolQ ] := TrueQ @ StringStartsQ[ Context @ sym, "FunctionRepository`" ];
+rfSymbolQ[ ___ ] := False;
+
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*templateMessageFunction*)
+templateMessageFunction // ClearAll;
+
+
+templateMessageFunction[ template_, mf_ ] :=
+    Function[ Null,
+              mf[ MessageFailure::message, StringForm[ template, ##2 ] ],
+              { HoldAllComplete }
+    ];
+
+
+templateMessageFunction // endDefinition;
+EndPackage[ ];

--- a/ResourceFunctions/README.md
+++ b/ResourceFunctions/README.md
@@ -1,0 +1,53 @@
+# Local Resource Function Definitions
+
+AgentTools uses a few functions from the [Wolfram Function Repository](https://resources.wolframcloud.com/FunctionRepository/), pinned to the versions listed in `$resourceVersions` in `Kernel/Common.wl`. This directory holds a local copy of each of their definitions, so that the paclet can be built and loaded from source without access to the Wolfram Cloud.
+
+`importResourceFunction` (`Kernel/Common.wl`) prefers a file in this directory over fetching the resource function. When building the MX file, the definitions are inlined into the paclet in the context ``Wolfram`AgentTools`ResourceFunctions`<Name>` `` exactly as fetched definitions would be; when loading from source, the file is loaded into that context at the first use of the imported symbol. `Scripts/BuildMX.wls` copies this directory into the temporary build copy of the paclet and uses the local `ASTPattern` for its own source annotations.
+
+This directory is not declared in `PacletInfo.wl` and is not part of the built paclet.
+
+## Files
+
+| File | Version | Source |
+|------|---------|--------|
+| `ASTPattern.wl` | 1.0.0 | Generated from the published definition |
+| `ExportMarkdownString.wl` | 1.0.0 | Generated from the published definition |
+| `ImportMarkdownString.wl` | 1.0.0 | Copied from [rhennigan/ResourceFunctions](https://github.com/rhennigan/ResourceFunctions) |
+| `MessageFailure.wl` | 1.0.1 | Copied from [rhennigan/ResourceFunctions](https://github.com/rhennigan/ResourceFunctions) |
+| `ReadableForm.wl` | 2.1.1 | Copied from [rhennigan/ResourceFunctions](https://github.com/rhennigan/ResourceFunctions) |
+| `ResourceFunctionMessage.wl` | 2.1.1 | Generated from the published definition (a dependency of `MessageFailure`) |
+
+`ReplaceContext` (also in `$resourceVersions`) has no local copy: it is only used to move fetched definitions into their target context, which a local copy does not need.
+
+Each file wraps the definition in `BeginPackage`/`EndPackage` for its own context so that the helper symbols of the different functions do not clash with each other or with the paclet. References to other resource functions inside a definition (e.g. `ResourceFunction[ "MessageFailure" ]`) are left as they are in the file; `importResourceFunction` rewrites them to the local symbols when it loads the file, and loads those definitions as well.
+
+## Updating a copy
+
+The copies must match the pinned versions in `$resourceVersions`. When a version is bumped, replace the copy:
+
+- **Copied files** (`ImportMarkdownString`, `MessageFailure`, `ReadableForm`): copy `Definitions/<Name>/Definition.wl` from the [rhennigan/ResourceFunctions](https://github.com/rhennigan/ResourceFunctions) repository verbatim between the header and the `BeginPackage`/`EndPackage` lines. The commit it was copied from is recorded in the header. The repository's development version may be newer than the published one; only copy a version that has been published (`ASTPattern` and `ExportMarkdownString` were generated instead for this reason).
+
+- **Generated files** (`ASTPattern`, `ExportMarkdownString`, `ResourceFunctionMessage`): these assign the published definition list directly (`Language`ExtendedFullDefinition[ ] = Language`DefinitionList[ ... ]`) rather than re-stating the definitions as code, because re-evaluating a definition such as `f[ args___ ] := ...` together with its `e: HoldPattern[ f[ ___ ] ] := ...` fallthrough merges the two rules, whereas the published definition list keeps both. Regenerate from the published definition, with cloud access:
+
+  ```wl
+  name    = "ASTPattern";
+  target  = "Wolfram`AgentTools`ResourceFunctions`" <> name <> "`";
+  version = ResourceObject[ name ][ "Version" ];
+  defs    = ResourceFunction[ "ReplaceContext" ][
+      ResourceFunction[ name, "DefinitionList" ],
+      ResourceFunction[ name, "Context" ] -> target
+  ];
+  (* drop the repository's box formatting and usage message *)
+  defs = DeleteCases[ defs, Verbatim[ RuleDelayed ][ Verbatim[ HoldPattern ][ HoldPattern[ MakeBoxes ][ _, _ ] ], FunctionResource`MakeResourceFunctionBoxes[ _ ] ], Infinity ];
+  defs = DeleteCases[ defs, (Rule|RuleDelayed)[ Verbatim[ HoldPattern ][ MessageName[ _, "usage" ] ], _ ], Infinity ];
+  defs = DeleteCases[ defs, (FormatValues|Messages) -> { }, Infinity ];
+  code = Block[ { $Context = target, $ContextPath = { target, "System`" } },
+      With[ { d = defs },
+          ToString[ ResourceFunction[ "ReadableForm" ] @ Unevaluated[ Language`ExtendedFullDefinition[ ] = d ] ]
+      ]
+  ];
+  ```
+
+  then write `code` (followed by `;`) between the header and the `BeginPackage`/`EndPackage` lines of the existing file, updating the version in the header.
+
+After updating, run `Tests/ResourceFunctions.wlt` and rebuild the MX file.

--- a/ResourceFunctions/ReadableForm.wl
+++ b/ResourceFunctions/ReadableForm.wl
@@ -1,0 +1,2461 @@
+(* ::Package:: *)
+
+(*
+    Local copy of the "ReadableForm" resource function (version 2.1.1) from the Wolfram Function Repository.
+
+    Source:   https://github.com/rhennigan/ResourceFunctions/blob/main/Definitions/ReadableForm/Definition.wl (commit 08ee812)
+    Resource: https://resources.wolframcloud.com/FunctionRepository/resources/ReadableForm
+
+    Kernel/Common.wl (importResourceFunction) loads this file in preference to fetching the resource function from
+    the Function Repository, so the paclet can be built and loaded from source without cloud access. This directory
+    is not part of the built paclet: the MX build inlines these definitions. The original definition is wrapped in
+    BeginPackage/EndPackage so its symbols live in the "Wolfram`AgentTools`ResourceFunctions`ReadableForm`" context.
+    Do not edit the definitions here; update the upstream resource function and copy the file again.
+*)
+
+BeginPackage[ "Wolfram`AgentTools`ResourceFunctions`ReadableForm`" ];
+
+(* !Excluded
+This notebook was automatically generated from [Definitions/ReadableForm](https://github.com/rhennigan/ResourceFunctions/blob/main/Definitions/ReadableForm).
+*)
+
+ReadableForm // ClearAll;
+(* ::**********************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+$inDef = False;
+$debug = True;
+
+System`MapApply;
+
+(* ::**********************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*beginDefinition*)
+beginDefinition // ClearAll;
+beginDefinition // Attributes = { HoldFirst };
+beginDefinition::unfinished = "\
+Starting definition for `1` without ending the current one.";
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+beginDefinition[ s_Symbol ] /; $debug && $inDef :=
+    WithCleanup[
+        $inDef = False
+        ,
+        Print @ TemplateApply[ beginDefinition::unfinished, HoldForm @ s ];
+        beginDefinition @ s
+        ,
+        $inDef = True
+    ];
+(* :!CodeAnalysis::EndBlock:: *)
+
+beginDefinition[ s_Symbol ] :=
+    WithCleanup[ Unprotect @ s; ClearAll @ s, $inDef = True ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*endDefinition*)
+endDefinition // beginDefinition;
+endDefinition // Attributes = { HoldFirst };
+
+endDefinition[ s_Symbol ] := endDefinition[ s, DownValues ];
+
+endDefinition[ s_Symbol, None ] := $inDef = False;
+
+endDefinition[ s_Symbol, DownValues ] :=
+    WithCleanup[
+        AppendTo[ DownValues @ s,
+                  e: HoldPattern @ s[ ___ ] :>
+                      throwInternalFailure @ HoldForm @ e
+        ],
+        $inDef = False
+    ];
+
+endDefinition[ s_Symbol, SubValues  ] :=
+    WithCleanup[
+        AppendTo[ SubValues @ s,
+                  e: HoldPattern @ s[ ___ ][ ___ ] :>
+                      throwInternalFailure @ HoldForm @ e
+        ],
+        $inDef = False
+    ];
+
+endDefinition[ s_Symbol, list_List ] :=
+    endDefinition[ s, # ] & /@ list;
+
+endDefinition // endDefinition;
+
+(* ::**********************************************************************:: *)
+(* ::Section:: *)
+(*Messages*)
+ReadableForm::internal =
+"An unexpected error occurred. `1`";
+
+(* ::**********************************************************************:: *)
+(* ::Section:: *)
+(*Attributes*)
+ReadableForm // Attributes = { };
+
+(* ::**********************************************************************:: *)
+(* ::Section:: *)
+(*Options*)
+$defaultTokens = <| "Comment" -> CommentToken |>;
+
+ReadableForm // Options = {
+    "DynamicAlignment" -> False,
+    "FormatHeads"      -> Automatic,
+    "IndentSize"       -> 4,
+    "InitialIndent"    -> 0,
+    "PrefixForm"       -> True,
+    "RealAccuracy"     -> Automatic,
+    "RelativeWidth"    -> False,
+    "StrictMode"       -> False,
+    "Tokens"           -> $defaultTokens,
+    CachePersistence   -> Automatic,
+    CharacterEncoding  -> "Unicode",
+    PageWidth          -> 80,
+    PerformanceGoal    -> "Quality",
+    Trace              -> False
+};
+
+(* ::**********************************************************************:: *)
+(* ::Section:: *)
+(*Main definition*)
+
+(* ::**********************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*InputForm*)
+ReadableForm /:
+    Format[ ReadableForm[ expr_, opts: OptionsPattern[ ] ], InputForm ] :=
+        catchTop @ OutputForm @ formatDataString[
+            expr,
+            OptionValue[ ReadableForm, { opts }, "IndentSize"       ],
+            OptionValue[ ReadableForm, { opts }, PageWidth          ],
+            OptionValue[ ReadableForm, { opts }, CharacterEncoding  ],
+            OptionValue[ ReadableForm, { opts }, "RelativeWidth"    ],
+            OptionValue[ ReadableForm, { opts }, "PrefixForm"       ],
+            OptionValue[ ReadableForm, { opts }, PerformanceGoal    ],
+            OptionValue[ ReadableForm, { opts }, "RealAccuracy"     ],
+            OptionValue[ ReadableForm, { opts }, "InitialIndent"    ],
+            OptionValue[ ReadableForm, { opts }, CachePersistence   ],
+            OptionValue[ ReadableForm, { opts }, "DynamicAlignment" ],
+            OptionValue[ ReadableForm, { opts }, "StrictMode"       ],
+            OptionValue[ ReadableForm, { opts }, "Tokens"           ],
+            OptionValue[ ReadableForm, { opts }, Trace              ]
+        ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*OutputForm*)
+ReadableForm /:
+    Format[ ReadableForm[ expr_, opts: OptionsPattern[ ] ], OutputForm ] :=
+        catchTop @ formatDataString[
+            expr,
+            OptionValue[ ReadableForm, { opts }, "IndentSize"       ],
+            OptionValue[ ReadableForm, { opts }, PageWidth          ],
+            OptionValue[ ReadableForm, { opts }, CharacterEncoding  ],
+            OptionValue[ ReadableForm, { opts }, "RelativeWidth"    ],
+            OptionValue[ ReadableForm, { opts }, "PrefixForm"       ],
+            OptionValue[ ReadableForm, { opts }, PerformanceGoal    ],
+            OptionValue[ ReadableForm, { opts }, "RealAccuracy"     ],
+            OptionValue[ ReadableForm, { opts }, "InitialIndent"    ],
+            OptionValue[ ReadableForm, { opts }, CachePersistence   ],
+            OptionValue[ ReadableForm, { opts }, "DynamicAlignment" ],
+            OptionValue[ ReadableForm, { opts }, "StrictMode"       ],
+            OptionValue[ ReadableForm, { opts }, "Tokens"           ],
+            OptionValue[ ReadableForm, { opts }, Trace              ]
+        ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*StandardForm*)
+ReadableForm /:
+    MakeBoxes[ ReadableForm[ expr_, opts: OptionsPattern[ ] ], StandardForm ] :=
+        catchTop @ Module[
+            { boxes, formatNames, fSyms, $$c, n, held, dataString, newBoxes },
+
+            formatNames = Cases[
+                Map[
+                    ToString,
+                    Union @ Flatten @ ReplaceAll[
+                        {
+                            OptionValue[
+                                ReadableForm,
+                                { opts },
+                                "FormatHeads"
+                            ]
+                        },
+                        Automatic :> $defaultFormatHeads
+                    ]
+                ],
+                _String? NameQ
+            ];
+
+            fSyms = Alternatives @@ ToExpression[
+                formatNames,
+                InputForm,
+                Blank
+            ];
+            n = 1;
+
+            held = ReplaceAll[
+                HoldComplete @ expr,
+                e: fSyms :>
+                    With[ { i = Increment @ n },
+                        $$c[ i ] := e;
+                        $$c @ i /; True
+                    ]
+            ];
+
+
+            dataString = Replace[
+                held,
+                HoldComplete[ e_ ] :> formatDataString[
+                    e,
+                    OptionValue[ ReadableForm, { opts }, "IndentSize"       ],
+                    OptionValue[ ReadableForm, { opts }, PageWidth          ],
+                    OptionValue[ ReadableForm, { opts }, CharacterEncoding  ],
+                    OptionValue[ ReadableForm, { opts }, "RelativeWidth"    ],
+                    OptionValue[ ReadableForm, { opts }, "PrefixForm"       ],
+                    OptionValue[ ReadableForm, { opts }, PerformanceGoal    ],
+                    OptionValue[ ReadableForm, { opts }, "RealAccuracy"     ],
+                    OptionValue[ ReadableForm, { opts }, "InitialIndent"    ],
+                    OptionValue[ ReadableForm, { opts }, CachePersistence   ],
+                    OptionValue[ ReadableForm, { opts }, "DynamicAlignment" ],
+                    OptionValue[ ReadableForm, { opts }, "StrictMode"       ],
+                    OptionValue[ ReadableForm, { opts }, "Tokens"           ],
+                    OptionValue[ ReadableForm, { opts }, Trace              ]
+                ]
+            ];
+
+
+            boxes = StyleBox[
+                Replace[ r_List :> RowBox @ r ][
+                    UsingFrontEnd @ First @ First @ MathLink`CallFrontEnd @
+                        FrontEnd`UndocumentedTestFEParserPacket[
+                            dataString,
+                            False
+                        ]
+                ],
+                "Input",
+                ShowAutoStyles       -> True,
+                ShowStringCharacters -> True,
+                StripOnInput         -> True
+            ];
+
+
+            newBoxes = ReplaceAll[
+                ReplaceAll[
+                    boxes,
+                    Cases[
+                        DownValues @ $$c,
+                        HoldPattern[
+                            Verbatim[ HoldPattern ][ lhs_$$c ] :> rhs_
+                        ] :>
+                            MakeBoxes[ lhs, StandardForm ] ->
+                                MakeBoxes[ rhs, StandardForm ]
+                    ]
+                ],
+                With[ { s = MakeBoxes[ $$c, StandardForm ] },
+                    rb: RowBox @ { s, ___ } :> With[
+                        {
+                            cexp = ReplaceAll[
+                                ToExpression[
+                                    rb,
+                                    StandardForm,
+                                    HoldComplete
+                                ],
+                                DownValues @ $$c
+                            ]
+                        },
+                        Replace[
+                            cexp,
+                            HoldComplete[ e_ ] :> makeSpecialBoxes @ e
+                        ]
+                    ]
+                ]
+            ];
+
+            Remove @ $$c;
+
+            newBoxes
+        ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*CopyToClipboard*)
+ReadableForm /:
+    HoldPattern[ CopyToClipboard[ data_ReadableForm ] ] :=
+        catchTop @ CopyToClipboard @ ToString @ data;
+
+(* ::**********************************************************************:: *)
+(* ::Section:: *)
+(*Dependencies*)
+
+(* ::**********************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Macros*)
+
+(* ::****************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*symbolQ*)
+symbolQ // ClearAll;
+symbolQ // Attributes = { HoldAllComplete };
+symbolQ[ sym_Symbol ] := AtomQ @ Unevaluated @ sym;
+symbolQ[ ___ ] := False;
+
+
+(* ::****************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*inline*)
+inline // beginDefinition;
+inline // Attributes = { HoldAllComplete };
+
+inline[ x_Symbol? symbolQ, expr_ ] :=
+    ReleaseHold[ HoldComplete[ expr ] /. OwnValues @ x ];
+
+inline[ { x_Symbol? symbolQ, xs___ }, expr_ ] :=
+    inline[ x, inline[ { xs }, expr ] ];
+
+inline[ { }, expr_ ] := expr;
+
+inline /: HoldPattern[ SetDelayed ][ lhs_, inline[ x_, rhs_ ] ] :=
+    inline[ x, SetDelayed[ lhs, rhs ] ];
+
+inline // endDefinition;
+
+(* ::****************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*defineLeftOp*)
+defineLeftOp // beginDefinition;
+
+defineLeftOp[ sym_, op_ ] := (
+    format[ e: Verbatim[ sym ][ arg_ ] ] /; fitsOnLineQ @ e :=
+        StringJoin[ op, formatArg[ sym, arg ] ]
+);
+
+defineLeftOp // endDefinition;
+
+(* ::****************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*defineRightOp*)
+defineRightOp // beginDefinition;
+
+defineRightOp[ sym_, op_ ] := (
+    format[ e: Verbatim[ sym ][ arg_ ] ] /; fitsOnLineQ @ e :=
+        StringJoin[ formatArg[ sym, arg ], op ]
+);
+
+defineRightOp // endDefinition;
+
+(* ::****************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*defineBinaryOp*)
+defineBinaryOp // beginDefinition;
+
+defineBinaryOp[ sym_, op_ ] := (
+    format[ e: Verbatim[ sym ][ lhs_, rhs_ ] ] /; fitsOnLineQ @ e :=
+        verifyLength[
+            StringJoin[ formatLHS[ sym, lhs ], op, formatRHS[ sym, rhs ] ],
+            cFormat @ e
+        ]
+);
+
+defineBinaryOp // endDefinition;
+
+(* ::****************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*defineMultiOp*)
+defineMultiOp // beginDefinition;
+
+defineMultiOp[ sym_, op_ ] := (
+    format[ e: Verbatim[ sym ][ first_, rest__ ] ] /; fitsOnLineQ @ e :=
+        StringJoin[
+            formatArg[ sym, first ],
+            op,
+            StringRiffle[ formatArgList[ sym, rest ], op ]
+        ]
+);
+
+defineMultiOp // endDefinition;
+
+(* ::**********************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Caching*)
+
+(* ::******************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*cached*)
+cached // beginDefinition;
+cached // Attributes = { HoldAllComplete };
+
+cached[ eval_ ] := With[ { st = $state }, cached[ st, eval ] ];
+cached[ state_, eval_ ] := cached[ state, Verbatim @ eval ] = eval;
+
+cached // endDefinition;
+
+(* ::******************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*cFormat*)
+cFormat // beginDefinition;
+cFormat // Attributes = { HoldAllComplete };
+cFormat[ arg_ ] /; $fCache := cached @ trace @ format @ arg;
+cFormat[ arg_ ] := trace @ format @ arg;
+cFormat // endDefinition;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*trace*)
+trace // beginDefinition;
+trace // Attributes = { HoldFirst };
+
+trace[ eval_ ] /; $trace :=
+    With[ { uuid = CreateUUID[ ] },
+        Internal`StuffBag[ $traces, uuid -> HoldForm @ eval ];
+        With[ { res = eval },
+            Internal`StuffBag[ $traces, uuid -> HoldForm @ res ];
+            res
+        ]
+    ];
+
+trace[ eval_ ] := eval;
+
+$traces = Internal`Bag[ ];
+
+trace // endDefinition;
+
+(* ::******************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$state*)
+$state // ClearAll;
+
+$state := {
+    $fancyAlign,
+    $fastMode,
+    $formatEncoding,
+    $indentSize,
+    $level,
+    $pageWidth,
+    $prefix,
+    $prefixEnabled,
+    $relativeWidth,
+    $retry,
+    $trace
+};
+
+(* ::**********************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Formatting*)
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*formatDataString*)
+formatDataString // beginDefinition;
+
+formatDataString[
+    data_,
+    indSize_,
+    pageWidth_,
+    enc_,
+    rel_,
+    prefix_,
+    perf_,
+    prec_,
+    init_,
+    cache_,
+    fancy_,
+    strict_,
+    tokens_,
+    trace_
+] :=
+    Block[
+        {
+            $NumberMarks    = False,
+            $formatEncoding = enc,
+            $level          = init,
+            $indentSize     = indSize,
+            $pageWidth      = pageWidth,
+            $relativeWidth  = rel,
+            $prefixEnabled  = prefix,
+            $fastMode       = perf === "Speed",
+            $fCache         = MatchQ[ cache, Full|True ],
+            $sCache         = MatchQ[ cache, Full|Automatic|True ],
+            $fancyAlign     = TrueQ @ fancy,
+            $retry          = TrueQ @ strict,
+            $trace          = TrueQ @ trace
+        },
+
+        If[ TrueQ @ $trace, $traces = Internal`Bag[ ] ];
+
+        indent[ ] <> StringTrim @ Apply[
+            cFormat,
+            replaceTokens[ HoldComplete @ data, tokens ] /. {
+                Slot -> $$slot,
+                (r_Real)?realQ :> numberForm[r, prec]
+            }
+        ]
+    ];
+
+formatDataString // endDefinition;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*replaceTokens*)
+replaceTokens // beginDefinition;
+
+replaceTokens[ expr_, tokens_Association? AssociationQ ] :=
+    ReplaceAll[
+        expr,
+        Rule @@@ (Values @ Merge[ { tokens, $defaultTokens }, Identity ])
+    ];
+
+replaceTokens[ expr_, ___ ] := expr;
+
+replaceTokens // endDefinition;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*withIndent*)
+withIndent // beginDefinition;
+withIndent // Attributes = { HoldAllComplete };
+withIndent[ eval_ ] := Internal`WithLocalSettings[ $level++, eval, $level-- ];
+withIndent // endDefinition;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*formatArgLines*)
+formatArgLines // ClearAll;
+formatArgLines // Attributes = { HoldAllComplete };
+formatArgLines[ args___ ] :=
+    Cases[ HoldComplete @ args,
+           a_ :> StringJoin[ indent[ ], cFormat @ a ]
+    ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*verifyLength*)
+verifyLength // beginDefinition;
+verifyLength // Attributes = { HoldRest };
+
+verifyLength[ str_, retry_ ] /; $retry := verifyLength[ str, retry, 0 ];
+
+verifyLength[ str_, retry_, n_ ] /; n <= 3 && $retryDepth <= 10 :=
+    Module[ { split, max, over, newWidth },
+        split = StringSplit[ str, "\n" ];
+        max = Max[ StringLength /@ split ];
+        over = max - currentLineWidth[ ];
+        (* Echo[ str, <| "over"->over, "$pageWidth" -> $pageWidth, "n" -> n |> ]; *)
+        If[ Positive @ over,
+            newWidth = $pageWidth - $indentSize;
+            Block[ { $pageWidth = newWidth, $retryDepth = $retryDepth + 1 },
+                verifyLength[ retry, retry, n+1 ]
+            ],
+            str
+        ]
+    ];
+
+verifyLength[ str_, __ ] := str;
+
+$retryDepth = 0;
+
+verifyLength // endDefinition;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*format*)
+
+format // ClearAll;
+
+
+format // Attributes = { HoldAllComplete };
+
+
+format[ numberForm[ r_, a_ ] ] :=
+  numberFormString[ r, a ];
+
+
+format[ ReadableForm[ a___ ] ] :=
+  StringReplace[ cFormat @ $ReadableForm @ a,
+                 ToString @ $ReadableForm -> "ReadableForm"
+  ];
+
+
+format[ s_String ] :=
+  toString @ s;
+
+
+format[<||>] := "<| |>";
+With[ { a = <| |> },
+    format[ a ] := "<| |>";
+];
+
+
+format[{}] := "{ }";
+
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*Symbol Definitions*)
+
+(* !ClearAll *)
+format[ ClearAll[ s_Symbol? symbolQ ] ] /; ! $fastMode :=
+    StringJoin[ toString @ s, " // ClearAll" ];
+
+
+(* !Attributes *)
+format[ Attributes[ s_Symbol? symbolQ ] = attrs_ ] /; ! $fastMode :=
+    StringJoin[ toString @ s, " // Attributes = ", cFormat @ attrs ];
+
+
+(* !Options *)
+format[ Options[ s_Symbol? symbolQ ] = opts_ ] /; ! $fastMode :=
+    StringJoin[ toString @ s, " // Options = ", cFormat @ opts ];
+
+
+(* !TagSetDelayed *)
+format[ TagSetDelayed[ sym_Symbol, lhs_, rhs_ ] ] :=
+    StringJoin[
+        "\n",
+        indent[ ],
+        toString @ sym,
+        " /:\n",
+        Internal`WithLocalSettings[
+            Increment @ $level,
+            StringJoin[
+                indent[ ],
+                formatLHS[ TagSetDelayed, lhs ],
+                " := ",
+                formatRHS[ SetDelayed, rhs ]
+            ],
+            Decrement @ $level
+        ]
+    ];
+
+(* !TagSet *)
+format[ TagSet[ sym_Symbol, lhs_, rhs_ ] ] :=
+    StringJoin[
+        "\n",
+        indent[ ],
+        toString @ sym,
+        " /:\n",
+        Internal`WithLocalSettings[
+            Increment @ $level,
+            StringJoin[
+                indent[ ],
+                formatLHS[ TagSet, lhs ],
+                " = ",
+                formatRHS[ Set, rhs ]
+            ],
+            Decrement @ $level
+        ]
+    ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*Patterns*)
+
+$bHead = (Blank|BlankSequence|BlankNullSequence);
+$blank = $bHead[ _Symbol ] | $bHead[ ];
+
+
+(* !Condition *)
+format[ Verbatim[ Condition ][ patt_, test_ ] ] /;
+    fitsOnLineQ[ patt /; test ] :=
+        Module[ { f1, f2 },
+
+            f1 = If[ lhsParenQ[ Condition, patt ],
+                     StringJoin[ "(", cFormat @ patt, ")" ],
+                     cFormat @ patt
+                 ];
+
+            f2 = If[ rhsParenQ[ Condition, test ],
+                     StringJoin[ "(", cFormat @ test, ")" ],
+                     cFormat @ test
+                 ];
+
+            verifyLength[
+                StringJoin[ f1, " /; ", f2 ],
+                cFormat @ Condition[ patt, test ]
+            ]
+        ];
+
+continueSameLineQ[ s1_String, s2_String ] :=
+    stringFitsOnLineQ[
+        StringJoin[
+            Last @ StringSplit[ s1, "\n" ],
+            First @ StringSplit[ s2, "\n" ]
+        ]
+    ];
+
+(* TODO: finish and generalize continuations like this *)
+format[ Verbatim[ Condition ][ patt_, test_ ] ] :=
+    Module[ { p1, p2, l1, r1, l2, r2, f1, f2, full, next, reflow },
+
+        p1 = lhsParenQ[ Condition, patt ];
+        p2 = rhsParenQ[ Condition, test ];
+
+        l1 = If[ p1, "(", "" ];
+        r1 = If[ p1, ")", "" ];
+        l2 = If[ p2, "(", "" ];
+        r2 = If[ p2, ")", "" ];
+
+        f1 = StringJoin[ l1, cFormat @ patt, r1 ];
+        f2 = StringJoin[ l2, cFormat @ test, r2 ];
+
+        full = StringJoin[ f1, " /; ", f2 ];
+
+        If[ stringFitsOnLineQ @ full, Throw[ full, $tag ] ];
+
+        If[ StringFreeQ[ f2, "\n" ],
+            next = StringJoin[ indent[ 1 ], f2 ];
+            If[ stringFitsOnLineQ @ next,
+                Throw[
+                    StringJoin[ f1, " /;\n", indent[ ], next ],
+                    $tag
+                ],
+                Throw[
+                    StringJoin[
+                        f1,
+                        " /; ", l2, "\n",
+                        withIndent @ StringJoin[ indent[ ], cFormat @ test ],
+                        If[ p2,
+                            StringJoin[ "\n", indent[ ], r2 ],
+                            ""
+                        ]
+                    ],
+                    $tag
+                ]
+            ]
+        ];
+
+        (* reflow = If[
+            stringFitsOnLineQ @ full,
+            full,
+            StringJoin[
+                f1, " /;\n",
+                withIndent @ StringJoin[
+                    indent[ ],
+                    formatRHS[ Condition, test ]
+                ]
+            ]
+        ]; *)
+
+        reflow = full;
+
+        verifyLength[
+            reflow,
+            cFormat @ Condition[ patt, test ]
+        ]
+    ] ~Catch~ $tag;
+
+
+
+verifiedLength // ClearAll;
+verifiedLength // Attributes = { HoldAllComplete };
+
+verifiedLength /: HoldPattern[ SetDelayed ][ lhs_, verifiedLength[ rhs_ ] ] :=
+    e: lhs := verifyLength[ rhs, e ];
+
+
+
+(* !Pattern *)
+format[ Verbatim[ Pattern ][ s_Symbol, p: $blank ] ] :=
+    inline[ $blank, StringJoin[ toString @ s, toString @ p ] ];
+
+
+format[ Verbatim[ Pattern ][ s_Symbol, patt_ ] ] :=
+    StringJoin[ toString @ s, ": ", formatRHS[ Pattern, patt ] ];
+
+
+(* !Blank, !BlankSequence, and !BlankNullSequence *)
+format[ p: $blank ] :=
+    inline[ $blank, toString @ p ];
+
+
+(* !Repeated *)
+format[ Verbatim[ Repeated ][ a_ ] ] :=
+    Module[ { str },
+        str = formatArg[ Repeated, a ];
+        (* https://bugs.wolfram.com/show?number=408503 *)
+        If[ StringEndsQ[ str, "_" ],
+            StringJoin[ "(", str, ").." ],
+            StringJoin[ str, ".." ]
+        ]
+    ];
+
+
+(* !RepeatedNull *)
+format[ Verbatim[ RepeatedNull ][ a_ ] ] :=
+    Module[ { str },
+        str = formatArg[ RepeatedNull, a ];
+        (* https://bugs.wolfram.com/show?number=408503 *)
+        If[ StringEndsQ[ str, "_" ],
+            StringJoin[ "(", str, ")..." ],
+            StringJoin[ str, "..." ]
+        ]
+    ];
+
+
+(* !PatternTest *)
+format[ Verbatim[ PatternTest ][
+    p: Verbatim[ Pattern ][ _? symbolQ, $blank ],
+    f_? symbolQ
+] ] :=
+    inline[
+        $blank,
+        StringJoin[ toString @ p, "? ", toString @ f ]
+    ];
+
+format[ Verbatim[ PatternTest ][ p_, f_? symbolQ ] ] :=
+    StringJoin[ formatLHS[ PatternTest, p ], "? ", toString @ f ];
+
+format[ Verbatim[ PatternTest ][ p_, f_ ] ] :=
+    StringJoin[ formatLHS[ PatternTest, p ], "? (", cFormat @ f, ")" ];
+
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*Flow Control*)
+
+(*
+    TODO:
+        WithLocalSettings
+        WithCleanup
+        Which
+        Switch
+        Catch/Module
+        Enclose/Module
+*)
+
+(* TODO: try to generalize this *)
+(* Experimental! *)
+format[ e: Verbatim[ Set ][ lhs_, If[ a_, b_, c_ ] ] ] /; $fancyAlign :=
+    Module[ { before, offset, after, aligned },
+
+        before   = StringJoin[ formatLHS[ Set, lhs ], " = " ];
+        offset   = StringLength @ before;
+        after    = Block[ { $pageWidth = Max[ 10, $pageWidth - offset - 4 ] }, cFormat @ If[ a, b, c ] ];
+        aligned  = tryOffsetAlign[ offset, 4, after ];
+        (* joined   = If[ StringQ @ aligned, StringJoin[ before, aligned ], "" ];
+        expected = toString @ e;
+        success  = equivStringsQ[ joined, expected ]; *)
+
+        (* If[ ! success,
+            Message[ tryOffsetAlign::offsetfailure, HoldForm @ e, joined ];
+        ]; *)
+
+        verifyLength[ StringJoin[ before, aligned ], cFormat @ e ] /;
+            StringQ @ aligned
+    ];
+
+
+
+
+
+tryOffsetAlign::offsetfailure = "Offset alignment failed for `1` -> `2`";
+
+tryOffsetAlign[ _, _, string_String ] /; StringFreeQ[ string, "\n" ] :=
+    $Failed;
+
+tryOffsetAlign[ baseOffset_, indentOffset_, string_ ] :=
+    Enclose @ Module[ { lines, pad, ind, first, last, mid, align },
+
+        lines = StringSplit[ string, "\n" ];
+        pad   = ConstantArray[ " ", baseOffset ];
+        ind   = ConstantArray[ " ", ConfirmBy[ baseOffset + indentOffset - $indentSize, NonNegative ] ];
+        first = First @ lines;
+        last  = Last @ lines;
+        mid   = Function[ StringJoin[ ind, # ] ] /@ lines[[ 2;;-2 ]];
+        align = AllTrue[ mid, Function[ StringLength[ # ] <= $pageWidth ] ];
+        (* align = True; *)
+        ConfirmAssert @ align;
+        StringTrim[
+            StringJoin[ first, "\n", StringRiffle[ mid, "\n" ], "\n", StringJoin[ pad, last ] ],
+            "\n"
+        ]
+    ];
+
+
+(* !If (two arguments) *)
+format[ if: If[ a_, b_ ] ] /; fitsOnLineQ @ if :=
+    StringJoin[
+        "If[ ", cFormat @ a, ", ", cFormat @ b, " ]"
+    ];
+
+
+format[ if: If[ cond_, expr_ ] ] :=
+  StringJoin[ (* TODO: insert additional linebreak around comma for multiline *)
+      "If[ ", withIndent @ cFormat[cond], ",\n",
+      Internal`WithLocalSettings[
+          $level++,
+          StringJoin[ indent[], cFormat@expr, "\n" ],
+          $level--
+      ],
+      indent[], "]"
+  ];
+
+
+(* !If (three arguments) *)
+format[ if: If[ a_, b_, c_ ] ] /; fitsOnLineQ @ if :=
+    StringJoin[
+        "If[ ", cFormat @ a, ", ", cFormat @ b, ", ", cFormat @ c,  " ]"
+    ];
+
+format[ if: If[ cond_, then_, else_ ] ] :=
+  StringJoin[
+      "If[ ", withIndent @ cFormat[cond], ",\n",
+      Internal`WithLocalSettings[
+          $level++,
+          StringJoin[
+              indent[], cFormat@then, ",\n",
+              indent[], cFormat@else, "\n"
+          ],
+          $level--
+      ],
+      indent[], "]"
+  ];
+
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*Scoping Constructs*)
+
+
+$scopeFunc = Alternatives[
+    Block,
+    DynamicModule,
+    Internal`InheritedBlock,
+    Module,
+    With
+];
+
+
+(* !With, !Block, and !Module *)
+format[ e: (h:$scopeFunc)[ args___ ] ] /; fitsOnLineQ[ e, 2 ] :=
+    inline[
+        $scopeFunc,
+        StringJoin[
+            ToString @ h,
+            "[ ",
+            StringRiffle[ formatArgList[ None, args ], ", " ],
+            " ]"
+        ]
+    ];
+
+
+format[ (h: $scopeFunc)[ { syms___ }, args__ ] ] :=
+    inline[
+        $scopeFunc,
+        Module[ { symStrings, symLen, symStr, lines },
+            $prefix = True;
+            symStrings = Riffle[ formatArgList[ None, syms ], ", " ];
+            symLen = Total[ StringLength /@ symStrings ];
+            symStr = If[ TrueQ[ symLen < currentLineWidth[ ] ],
+                        StringJoin[ " { ", symStrings, " }" ],
+                        StringJoin[
+                            "\n",
+                            withIndent @ StringJoin[
+                                indent[ ],
+                                cFormat @ { syms }
+                            ]
+                        ]
+                    ];
+
+            lines = withIndent @ formatArgLines @ args;
+
+            StringJoin[
+                toString[h], "[", symStr, ",\n",
+                StringRiffle[ StringTrim[ lines, Longest[ "\n" ..] ], ",\n"],
+                "\n", indent[ ], "]"
+            ]
+        ]
+    ];
+
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*Other*)
+format[ $key[ k_ ] -> $value[ v_ ] ] := cFormat @ Rule[ k, v ];
+format[ $key[ k_ ] -> $delayed[ v_] ] := cFormat @ RuleDelayed[ k, v ];
+
+format[ $key[     expr_ ] ] := formatLHS[ Rule, expr ];
+format[ $value[   expr_ ] ] := formatRHS[ Rule, expr ];
+format[ $delayed[ expr_ ] ] := formatRHS[ RuleDelayed, expr ];
+
+(* !Rule *)
+format[ r: Rule[ a_, b_ ] /; fitsOnLineQ @ r || AtomQ @ Unevaluated @ b ] :=
+    StringJoin[
+        formatLHS[ Rule, a ],
+        " -> ",
+        formatRHS[ Rule, b ]
+    ];
+
+(* !RuleDelayed *)
+format[ r: RuleDelayed[ a_, b_ ] /; fitsOnLineQ @ r || AtomQ @ Unevaluated @ b ] :=
+    StringJoin[
+        formatLHS[ RuleDelayed, a ],
+        " :> ",
+        formatRHS[ RuleDelayed, b ]
+    ];
+
+(* !List/!Association continuations *)
+format[
+    (cont: Rule | RuleDelayed | Set | SetDelayed)[
+        a_,
+        b: _List | _Association
+    ]
+] :=
+    StringJoin[ formatLHS[ Rule, a ], " ", contOp @ cont, " ", cFormat @ b ];
+
+(* !KeyValuePattern continuations *)
+format[ Verbatim[ KeyValuePattern ][ list_List ] ] :=
+    If[ TrueQ @ $prefix,
+        StringJoin[ "KeyValuePattern @ ", cFormat @ list ],
+        StringJoin[ "KeyValuePattern[ ", cFormat @ list, " ]" ]
+    ];
+
+contOp[ Rule        ] := "->";
+contOp[ RuleDelayed ] := ":>";
+contOp[ Set         ] := "=" ;
+contOp[ SetDelayed  ] := ":=";
+
+
+format[ Rule[ a_, b_ ] ] :=
+    StringJoin[
+        formatLHS[ Rule, a ],
+        " ->\n",
+        Internal`WithLocalSettings[
+            $level++,
+            StringTrim[StringJoin[ indent[], formatRHS[ Rule, b ] ], "\n"],
+            $level--
+        ],
+        "\n"
+    ];
+
+
+format[ RuleDelayed[ a_, b_ ] ] :=
+    StringJoin[
+        formatLHS[ RuleDelayed, a ],
+        " :>\n",
+        Internal`WithLocalSettings[
+            $level++,
+            StringTrim[StringJoin[ indent[], formatRHS[ RuleDelayed, b ] ], "\n"],
+            $level--
+        ],
+        "\n"
+    ];
+
+format[ na_NumericArray? Developer`NumericArrayQHold ] :=
+  ToExpression[ ToString[ na, InputForm ],
+                InputForm,
+                cFormat
+  ];
+
+
+format[ PacletObject[ info_Association ] ] :=
+    StringJoin[ "PacletObject[ ", cFormat @ info, " ]" ];
+
+
+ceAppend // ClearAll;
+ceAppend[ str_ ] :=
+    StringJoin[
+        StringDelete[ str, Longest[ WhitespaceCharacter... ]~~EndOfString ],
+        ";"
+    ];
+
+
+
+format[ CompoundExpression[ a_, Null ] ] :=
+    ceAppend @ formatArg[ CompoundExpression, a ];
+
+format[ CompoundExpression[ a__, b_, Null ] ] :=
+    ceAppend @ ceFormat @ CompoundExpression[ a, b ];
+
+format[ CompoundExpression[ a_, b__ ] ] :=
+    ceFormat @ CompoundExpression[ a, b ];
+
+
+
+ceFormat // ClearAll;
+ceFormat // Attributes = { HoldAllComplete };
+
+
+ceFormat[ CompoundExpression[ a___ ] ] :=
+    Module[ { strings, lines },
+
+        strings = StringDelete[
+            formatArgList[ CompoundExpression, a ],
+            Longest[WhitespaceCharacter...]~~EndOfString
+        ];
+
+        lines = Map[
+            Function[
+                If[ StringFreeQ[ #1, "\n" ],
+                    StringJoin[ #1, ";\n", indent[ ] ],
+                    StringJoin[ "\n", indent[ ], #1, ";\n\n", indent[ ] ]
+                ]
+            ],
+            Most @ strings
+        ];
+
+        StringJoin[ lines, Last @ strings ]
+    ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*Arithmetic Weirdness*)
+
+(* !Plus *)
+format[ e: Verbatim[ Plus ][ a_ ] ] /; fitsOnLineQ @ e :=
+    With[ { str = formatArg[ Plus, a ] },
+        If[ StringStartsQ[ str, "-" ],
+            "+(" <> str <> ")",
+            "+" <> str
+        ]
+    ];
+
+format[ e: Verbatim[ Plus ][ a_, b__ ] ] /; fitsOnLineQ @ e :=
+    Module[ { args, formatted },
+        args = formatArgList[ Plus, a, b ];
+        formatted = formatOrderlessStrings[ args, "+" ];
+        StringJoin @ formatted /; MatchQ[ formatted, { __String } ]
+    ];
+
+(* !Times *)
+format[ e: Verbatim[ Times ][ a_, Power[ b_, -1 ] ] ] /; fitsOnLineQ @ e :=
+    verifyLength[
+        formatLHS[ Times, a ] <> " / " <> formatRHS[ Times, b ],
+        cFormat @ e
+    ];
+
+format[ e: Verbatim[ Times ][ -1, a_ ] ] /; fitsOnLineQ @ e :=
+    "-" <> formatArg[ Times, a ];
+
+format[ e: Verbatim[ Times ][ a_, b__ ] ] /; fitsOnLineQ @ e :=
+    Module[ { args, formatted },
+        args = formatArgList[ Times, a, b ];
+        formatted = formatOrderlessStrings[ args, "*" ];
+        StringJoin @ formatted /; MatchQ[ formatted, { __String } ]
+    ];
+
+formatOrderlessStrings[ { x_ }, op_ ] :=
+    {
+        If[ StringStartsQ[ x, "-" ],
+            StringReplace[
+                x,
+                StringExpression[
+                    StartOfString,
+                    "-",
+                    c: Except[ " " ]
+                ] :> StringJoin[ "-", c ]
+            ],
+            StringJoin[ op, x ]
+        ]
+    };
+
+formatOrderlessStrings[ { x_, xs__ }, op_ ] :=
+    Flatten @ { x, formatPlusString[ #, op ] & /@ { xs } };
+
+formatPlusString[ x_String, op_String ] :=
+    If[ StringStartsQ[ x, "-" ],
+        StringReplace[
+            x,
+            StringExpression[
+                StartOfString,
+                "-",
+                c: Except[ " " ]
+            ] :> StringJoin[ " - ", c ]
+        ],
+        StringJoin[ " "<>op<>" ", x ]
+    ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*Misc Operators*)
+defineBinaryOp[ AddTo        , " += "  ]; (* !AddTo        *)
+defineBinaryOp[ Apply        , " @@ "  ]; (* !Apply        *)
+defineBinaryOp[ MapApply     , " @@@ " ]; (* !MapApply     *)
+defineBinaryOp[ ApplyTo      , " //= " ]; (* !ApplyTo      *)
+defineBinaryOp[ DivideBy     , " /= "  ]; (* !DivideBy     *)
+defineBinaryOp[ Greater      , " > "   ]; (* !Greater      *)
+defineBinaryOp[ GreaterEqual , " >= "  ]; (* !GreaterEqual *)
+defineBinaryOp[ Less         , " < "   ]; (* !Less         *)
+defineBinaryOp[ LessEqual    , " <= "  ]; (* !LessEqual    *)
+defineBinaryOp[ Map          , " /@ "  ]; (* !Map          *)
+defineBinaryOp[ ReplaceAll   , " /. "  ]; (* !ReplaceAll   *)
+defineBinaryOp[ SubtractFrom , " -= "  ]; (* !SubtractFrom *)
+defineBinaryOp[ TimesBy      , " *= "  ]; (* !TimesBy      *)
+
+defineMultiOp[ Alternatives    , " | "   ]; (* !Alternatives     *)
+defineMultiOp[ And             , " && "  ]; (* !And              *)
+defineMultiOp[ Plus            , " + "   ]; (* !Plus             *)
+defineMultiOp[ SameQ           , " === " ]; (* !SameQ            *)
+defineMultiOp[ Span            , ";;"    ]; (* !Span             *)
+defineMultiOp[ StringExpression, " ~~ "  ]; (* !StringExpression *)
+defineMultiOp[ StringJoin      , " <> "  ]; (* !StringJoin       *)
+defineMultiOp[ UnsameQ         , " =!= " ]; (* !UnsameQ          *)
+
+defineLeftOp[ Not         , "! " ]; (* !Not          *)
+defineLeftOp[ PreDecrement, "--" ]; (* !PreDecrement *)
+defineLeftOp[ PreIncrement, "++" ]; (* !PreIncrement *)
+
+defineRightOp[ Decrement, "--" ]; (* !Decrement *)
+defineRightOp[ Increment, "++" ]; (* !Increment *)
+defineRightOp[ Function , " &" ]; (* !Function  *)
+
+
+
+format[ e: Power[ ___ ] ] /; fitsOnLineQ @ e := toString @ e;
+
+
+(* !Part *)
+format[ e: Part[ a_, b___ ] ] :=
+    Module[ { lhs, rhs, str },
+        lhs = formatLHS[ Part, a ];
+        rhs = Riffle[ List @@ cFormat /@ HoldComplete[ b ], ", " ];
+        str = StringJoin[ lhs, "[[ ", rhs, " ]]" ];
+        str /; stringFitsOnLineQ @ str
+    ];
+
+(* !Slot *)
+format[ ($$slot|Slot)[ 1 ] ] /; TrueQ @ $singleSlot := "#";
+
+format[ ($$slot|Slot)[ i_Integer ] ] /;
+    ! TrueQ @ $singleSlot && IntegerQ @ Unevaluated @ i && NonNegative @ i :=
+        "#" <> toString @ i;
+
+
+format[ ($$slot|Slot)[ str_String ] ] /;
+    ! TrueQ @ $singleSlot && StringQ @ Unevaluated @ str :=
+    If[ StringMatchQ[
+            str,
+            LetterCharacter~~(LetterCharacter | DigitCharacter)...
+        ],
+        StringJoin[ "#", str ],
+        StringJoin[ "#", toString @ str ]
+    ];
+
+$singleSlot = False;
+
+
+(* !SlotSequence *)
+format[ Verbatim[ SlotSequence ][ 1 ] ] /; $singleSlot := "##";
+
+format[ Verbatim[ SlotSequence ][ i_Integer ] ] /;
+    ! $singleSlot && IntegerQ @ Unevaluated @ i && NonNegative @ i :=
+        "##" <> toString @ i;
+
+
+(* !Rational *)
+format[ e: Rational[ lhs_, rhs_ ] ] /; And[
+    fitsOnLineQ @ e,
+    AtomQ @ Unevaluated @ e,
+    NumericQ @ Unevaluated @ lhs,
+    NumericQ @ Unevaluated @ rhs
+] :=
+    StringJoin[ formatLHS[ Rational, lhs ], " / ", formatRHS[ Rational, rhs ] ];
+
+(* !MessageName *)
+format[ e: MessageName[ sym_? symbolQ, tag_String ] ] /;
+    StringQ @ Unevaluated @ tag && fitsOnLineQ @ e :=
+        StringJoin[
+            toString @ sym,
+            "::",
+            If[ StringMatchQ[ tag, (LetterCharacter|DigitCharacter)... ],
+                tag,
+                toString @ tag
+            ]
+        ];
+
+
+format[ e: (f_[ a___ ])[ g_ ] ] /; prefixQ @ f @ a :=
+  Module[ { fs, h, fas, gs },
+      fs = Block[ { $prefix = False }, formatHead @ f ];
+      fas = StringReplace[ Block[ { $prefix = False }, cFormat @ h @ a ], toString @ h -> fs ];
+      gs = cFormat @ g;
+      StringJoin[ fas, "[ ", gs, " ]" ]
+  ];
+
+
+format[ e: f_[ g_[ args___ ] ] ] /; prefixQ @ e && AtomQ @ Unevaluated @ f :=
+  Module[ { full, fs, gs, hs },
+      full = Block[ { $prefix = False }, cFormat @ e ];
+      If[ stringFitsOnLineQ @ full, Throw[ makePrefix[ e, 0 ], $tag ]];
+      fs = cFormat @ f;
+      gs = cFormat @ g;
+      hs = fs <> " @ " <> gs;
+      If[ stringFitsOnLineQ @ hs,
+          makePrefix[ e, 0 ],
+          If[ stringFitsOnLineQ @ gs,
+              makePrefix[ e, 1 ],
+              makePrefix[ e, 2 ]
+          ]
+      ]
+  ] ~Catch~ $tag;
+
+
+format[ e: f_[ x_ ] ] /; prefixQ @ e && AtomQ @ Unevaluated @ f && AtomQ @ Unevaluated @ x :=
+  Module[ { full },
+      full = Block[ { $prefix = False }, cFormat @ e ];
+      If[ stringFitsOnLineQ @ full,
+          makePrefix[ e, 0 ],
+          makePrefix[ e, 1 ]
+      ]
+  ] ~Catch~ $tag;
+
+
+format[ a: f_[ ___ ] ] /; $fastMode :=
+  With[{str = toString @ a},
+      str /; stringFitsOnLineQ @ str
+  ];
+
+(* !Set *)
+format[ r: Verbatim[ Set ][ a_, b_ ] ] :=
+    Module[ { fits, g },
+
+        fits  = fitsOnLineQ @ r;
+        g = rhsParenQ[ Set, b ];
+
+        StringJoin[
+            Block[ { $prefix = False }, formatLHS[ Set, a ] ],
+            If[ g,  " = (", " = " ],
+            If[ fits,
+                cFormat @ b,
+                StringJoin[
+                    "\n",
+                    withIndent @ formatArgLines @ b,
+                    If[ g, "\n", "" ]
+                ]
+            ],
+            If[ g,
+                ")",
+                ""
+            ]
+        ]
+    ];
+
+(* !SetDelayed *)
+format[ r: Verbatim[ SetDelayed ][ a_, b_ ] ] :=
+    Module[ { fits, g },
+
+        fits  = fitsOnLineQ @ r;
+        g = rhsParenQ[ SetDelayed, b ];
+
+        StringJoin[
+            Block[ { $prefix = False }, formatLHS[ SetDelayed, a ] ],
+            If[ g,  " := (", " := " ],
+            If[ fits,
+                cFormat @ b,
+                StringJoin[
+                    "\n",
+                    Internal`WithLocalSettings[
+                        Increment @ $level,
+                        StringJoin[ indent[ ], cFormat @ b ],
+                        Decrement @ $level
+                    ],
+                    "\n"
+                ]
+            ],
+            If[ g,
+                ")",
+                ""
+            ],
+            If[ fits,
+                "",
+                "\n"
+            ]
+        ]
+    ];
+
+(* !UpSetDelayed *)
+format[ r: Verbatim[ UpSetDelayed ][ a_, b_ ] ] :=
+    Module[ { fits, g },
+
+        fits  = fitsOnLineQ @ r;
+        g = rhsParenQ[ UpSetDelayed, b ];
+
+        StringJoin[
+            Block[ { $prefix = False }, formatLHS[ UpSetDelayed, a ] ],
+            If[ g,  " ^:= (", " ^:= " ],
+            If[ fits,
+                cFormat @ b,
+                StringJoin[
+                    "\n",
+                    Internal`WithLocalSettings[
+                        Increment @ $level,
+                        StringJoin[ indent[ ], cFormat @ b ],
+                        Decrement @ $level
+                    ],
+                    "\n"
+                ]
+            ],
+            If[ g,
+                ")",
+                ""
+            ],
+            If[ fits,
+                "",
+                "\n"
+            ]
+        ]
+    ];
+
+(* !Association *)
+format[assoc_Association /; AssociationQ@Unevaluated@assoc && fitsOnLineQ @ assoc ] :=
+    With[ { tagged = tagAssociations @ assoc },
+        StringJoin[
+            "<| ",
+            StringRiffle[ StringTrim[ cFormat /@ Normal[ tagged, Association ], "\n" ], ", " ],
+            " |>"
+        ]
+    ];
+
+
+format[ Association[ rules: (Rule|RuleDelayed)[ _, _ ] ... ] ] :=
+    formatAssoc @ Replace[
+        unevaluatedAssociation @ rules,
+        {
+            Rule[ k_, v_ ] :> $key @ k -> $value @ v,
+            RuleDelayed[ k_, v_ ] :> $key @ k -> $delayed @ v
+        },
+        { 1 }
+    ];
+
+
+
+unevaluatedAssociation // ClearAll;
+unevaluatedAssociation // Attributes = { HoldAllComplete };
+
+
+formatAssoc // ClearAll;
+
+formatAssoc[ tagged_ ] /; $fancyAlign :=
+    Module[
+        {
+            normal, ind, indSize, maxKeySize, maxValSize, limit,
+            check, align, aligned
+        },
+
+        (* normal     = Normal[ tagged, Association ]; *)
+        normal     = tagged;
+        ind        = indent[ ];
+        indSize    = StringLength @ ind;
+        maxKeySize = 0;
+        maxValSize = 0;
+        limit      = currentLineWidth[ ];
+
+        check[ k_ -> v_ ] :=
+            With[ { ks = cFormat @ k, vs = cFormat @ v },
+
+                (* Echo[ HoldForm[ k -> v ], "check" ]; *)
+                If[ StringContainsQ[ StringJoin[ ks, vs ], "\n" ],
+                    (* Echo[ k -> v, "line" ]; *)
+                    Throw[ $noAlign, $tag ]
+                ];
+
+                maxKeySize = Max[ maxKeySize, StringLength @ ks ];
+                maxValSize = Max[ maxValSize, StringLength @ vs ];
+
+                If[ indSize+$indentSize + maxKeySize + maxValSize + 5 > limit,
+                    (* Echo[ k -> v, "length" ]; *)
+                    Throw[ $noAlign, $tag ]
+                ];
+
+                (* { indent[ ], ks, If[ Head @ v === $delayed, " :> ", " -> " ], vs } *)
+                If[ Head @ v === $delayed,
+                    { indent[ ], ks, " :> ", vs },
+                    { indent[ ], ks, " -> ", vs }
+                ]
+
+            ];
+
+        align[ { i_, k_, r_, v_ } ] :=
+            StringJoin[
+                i,
+                StringPadRight[ k, maxKeySize, " " ],
+                r,
+                v
+            ];
+
+        aligned = Catch[
+            withIndent @ StringRiffle[ align /@ (List @@ (check /@ normal)), ",\n" ],
+            $tag
+        ];
+
+        StringJoin[
+            "<|",
+            "\n",
+            StringTrim[
+                If[ StringQ @ aligned,
+                    aligned,
+                    withIndent @ StringRiffle[
+                        StringTrim[
+                            List @@ (Function[ StringJoin[ indent[ ], cFormat[ # ] ] ] /@ normal),
+                            "\n"..
+                        ],
+                        ",\n"
+                    ]
+                ],
+                "\n"
+            ],
+            "\n",
+            indent @ $level,
+            "|>"
+        ]
+    ];
+
+
+
+
+formatAssoc[ tagged_ ] :=
+  StringJoin[
+            "<|",
+            "\n",
+            StringTrim[
+                withIndent @ StringRiffle[
+                        StringTrim[
+                            List @@ (Function[ StringJoin[ indent[ ], cFormat[ # ] ] ] /@ tagged),
+                            "\n"..
+                        ],
+                        ",\n"
+                    ],
+                "\n"
+            ],
+            "\n",
+            indent @ $level,
+            "|>"
+        ];
+
+
+
+
+format[Association[rules : (_Rule | _RuleDelayed) ..] /; fitsOnLineQ @ Association @ rules ] :=
+    StringJoin[
+        "<| ",
+        StringRiffle[ List @@ cFormat /@ HoldComplete[ rules ], ", " ],
+        " |>"
+    ];
+
+
+(* !List *)
+format[ list_List ] /; fitsOnLineQ @ list :=
+    StringJoin[ "{ ", StringRiffle[ cFormat /@ Unevaluated @ list, ", " ], " }" ];
+
+
+format[ { items___ } ] /; $fastMode :=
+    StringJoin[
+        "{",
+        "\n",
+        StringTrim[
+            Internal`WithLocalSettings[
+                $level++,
+                StringRiffle[
+                    StringTrim[
+                        Apply[
+                            List,
+                            Map[
+                                Function[
+                                    Null,
+                                    indent[ ] <> cFormat[ #1 ],
+                                    { HoldAllComplete }
+                                ],
+                                HoldComplete @ items
+                            ]
+                        ],
+                        Longest[ "\n".. ]
+                    ],
+                    ",\n"
+                ],
+                $level--
+            ],
+            "\n"
+        ],
+        "\n",
+        indent @ $level,
+        "}"
+    ];
+
+
+format[ { rules: (Rule|RuleDelayed)[ _, _ ]... } ] :=
+    StringReplace[
+        format @ Association @ rules,
+        { StartOfString ~~ "<|" :> "{", "|>" ~~ EndOfString :> "}" }
+    ];
+
+
+format[ { items___ } ] :=
+    Module[ { strings, short },
+        strings = List @@ cFormat /@ HoldComplete @ items;
+        short = StringJoin[ "{ ", Riffle[ strings, ", " ], " }" ];
+        stringFitsOnLineQ @ short;
+        If[ stringFitsOnLineQ @ short,
+            short,
+            StringJoin[
+                "{",
+                "\n",
+                StringTrim[ Internal`WithLocalSettings[
+                    Increment @ $level,
+                    StringRiffle[
+                        Apply[
+                            List,
+                            Map[
+                                Function[
+                                    Null,
+                                    StringTrim[ StringJoin[ indent[ ], cFormat @ #1 ], "\n"],
+                                    { HoldAllComplete }
+                                ],
+                                HoldComplete @ items
+                            ]
+                        ],
+                        ",\n"
+                    ],
+                    Decrement @ $level
+                ], "\n" ],
+                "\n",
+                indent @ $level,
+                "}"
+            ]
+        ]
+    ];
+
+
+format[ f_[ args___ ] ] /; ! TrueQ @ $fastMode && fitsOnLineQ @ f @ args :=
+    Module[ { h, a },
+        $prefix = True;
+        h = formatHead @ f;
+        a = StringRiffle[ formatArgList[ None, args ], ", " ];
+        If[ a === "",
+            StringJoin[ h, "[ ]" ],
+            StringJoin[ h, "[ ", a, " ]" ]
+        ]
+    ];
+
+
+format[ f_[ args___ ] ] /; ! TrueQ @ $fastMode :=
+    Module[ { h, lines },
+        $prefix = True;
+        h = formatHead @ f;
+        lines = withIndent @ formatArgLines @ args;
+        If[ lines === { },
+            StringJoin[ h, "[ ]" ],
+            StringJoin[
+                h, "[\n",
+                StringRiffle[ StringTrim[ lines, Longest[ "\n" ..] ], ",\n"],
+                "\n", indent[ ], "]"
+            ]
+        ]
+    ];
+
+
+format[ f_[ args___ ] ] /; TrueQ @ $fastMode :=
+    StringJoin[
+        toString @ f,
+        "[\n",
+        Internal`WithLocalSettings[
+            $level++,
+            Riffle[
+                StringTrim[
+                    Apply[
+                        List,
+                        Map[
+                            Function[
+                                Null,
+                                indent[ ] <> cFormat[ #1 ],
+                                { HoldAllComplete }
+                            ],
+                            HoldComplete @ args
+                        ]
+                    ],
+                    Longest[ "\n".. ]
+                ],
+                ",\n"
+            ],
+            $level--
+        ],
+        "\n",
+        indent @ $level,
+        "]"
+    ];
+
+
+format[other_] := toString @ other;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*numberForm*)
+numberForm // ClearAll;
+
+numberForm /:
+    Format[ numberForm[ r_, a_ ], InputForm ] :=
+        OutputForm @ numberFormString[ r, a ];
+
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*numberFormString*)
+numberFormString // ClearAll;
+
+numberFormString[ r_Real, Except[ _Integer? NonNegative ] ] :=
+    StringReplace[
+        ToString[ r, InputForm ],
+        StringExpression[ "SetAccuracy[", d__, ",", ___, "]" ] :>
+            ToString[ N @ ToExpression @ d, InputForm ]
+    ];
+
+numberFormString[ r_Real, a_Integer ] :=
+    realToString[ r, a ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*realToString*)
+realToString[ r_, m_: 6 ] :=
+    StringReplace[
+        realToString0[ r, m ],
+        StringExpression[ ".", EndOfString ] :> ".0"
+    ];
+
+realToString0[ r_, m_ ] :=
+    Module[ { id, string },
+        id = Ceiling @ RealExponent @ r;
+        string = Which[
+            id >= m + 3,
+                (*ToString[ Round[ r, 10.0^(id - m) ], InputForm ]*)
+                sciForm[ r, m, id ]
+            ,
+            Abs @ r < 10.0^(-(m - 1)),
+                "0.0"
+            ,
+            id > Min[ 6, m ],
+                StringJoin[ ToString @ Round @ r, ".0" ]
+            ,
+            id <= Max[ -5, -m + 1 ],
+                ToString @ DecimalForm[ Round[ r, 10.0^(id - m) ], m ]
+            ,
+            True,
+                ToString @ Round[ r, 10.0^(-(m - id)) ]
+        ];
+        If[ StringContainsQ[ string, "*^" ],
+            sciForm[ r, m, id ],
+            string
+        ]
+    ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*sciForm*)
+sciForm // ClearAll;
+
+sciForm[ r_, m_ ] :=
+    sciForm[ r, m, Ceiling @ RealExponent @ r ];
+
+sciForm[ r_, m_, id_ ] :=
+    Module[ { mant, exp },
+        { mant, exp } = MantissaExponent @ Round[ r, 10.0^(id - m) ];
+        StringJoin[ realToString[ mant*10, m ], "*^", ToString[ exp + -1 ] ]
+    ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*toString*)
+toString // ClearAll;
+toString // Attributes = { HoldAllComplete };
+
+toString[ $key[ k_ ] -> $value[ v_ ] ] := toString[ k -> v ];
+toString[ $key[ k_ ] -> $delayed[ v_ ] ] := toString[ k :> v ];
+toString[ ($key|$delayed|$value)[ a_ ] ] := toString @ a;
+
+toString[ expr_ /; ! FreeQ[ HoldComplete @ expr, $key|$delayed|$value ] ] :=
+  With[ { untagged = untagAssociations @ HoldComplete @ expr },
+      If[ TrueQ @ $sCache,
+          (toString[ Verbatim @ expr ] = toString @@ untagged),
+          toString @@ untagged
+      ] /;
+        FreeQ[ HoldComplete @ untagged, $key|$delayed|$value ]
+  ];
+
+toString[ expr_ ] /; $sCache := toString[ Verbatim @ expr ] =
+    toString0 @ expr;
+
+toString[ expr_ ] := toString0 @ expr;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*toString0*)
+toString0 // ClearAll;
+toString0 // Attributes = { HoldAllComplete };
+toString0[ expr_ ] :=
+    Replace[ HoldComplete[ expr ] /. { $$slot -> Slot },
+             HoldComplete[ e_ ] :>
+                ToString[ Unevaluated @ e,
+                          InputForm,
+                          CharacterEncoding -> $formatEncoding
+                ]
+    ] // StringTrim;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$key*)
+$key // ClearAll;
+$key // Attributes = { HoldAllComplete };
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$value*)
+$value // ClearAll;
+$value // Attributes = { HoldAllComplete };
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$delayed*)
+$delayed // ClearAll;
+$delayed // Attributes = { HoldAllComplete };
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*untagAssociations*)
+untagAssociations // ClearAll;
+untagAssociations // Attributes = { HoldAllComplete };
+
+untagAssociations[ expr_ ] :=
+  expr //. {
+      a: KeyValuePattern[ $key[ k_ ] -> $delayed[ v_ ] ] :>
+        RuleCondition @
+          KeyDrop[ Insert[ a, Unevaluated[ k :> v ], Key @ $key @ k ],
+                   Key @ $key @ k
+          ],
+      a: KeyValuePattern[ $key[ k_ ] -> $value[ v_ ] ] :>
+        RuleCondition @
+          KeyDrop[ Insert[ a, Unevaluated[ k -> v ], Key @ $key @ k ],
+                   Key @ $key @ k
+          ]
+  };
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$formatEncoding*)
+$formatEncoding // ClearAll;
+$formatEncoding = "Unicode";
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*fitsOnLineQ*)
+fitsOnLineQ // ClearAll;
+fitsOnLineQ // Attributes = { HoldAllComplete };
+fitsOnLineQ[ expr_ ] := stringFitsOnLineQ @ toString @ expr;
+fitsOnLineQ[ expr_, offset_ ] := stringFitsOnLineQ[ toString @ expr, offset ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*stringFitsOnLineQ*)
+stringFitsOnLineQ // ClearAll;
+
+stringFitsOnLineQ[ string_String ] :=
+    TrueQ @ And[
+        StringLength @ string < currentLineWidth[ ],
+        StringFreeQ[ string, "\n" ]
+    ];
+
+stringFitsOnLineQ[ string_String, offset_ ] :=
+    TrueQ @ And[
+        StringLength @ string < currentLineWidth[ ] - offset,
+        StringFreeQ[ string, "\n" ]
+    ];
+
+stringFitsOnLineQ[ ___ ] := False;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*currentLineWidth*)
+currentLineWidth // ClearAll;
+
+currentLineWidth[ ] :=
+  If[ $relativeWidth,
+      $pageWidth,
+      $pageWidth - $level*$indentSize
+  ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$relativeWidth*)
+$relativeWidth // ClearAll;
+$relativeWidth = False;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$pageWidth*)
+$pageWidth // ClearAll;
+$pageWidth = 80;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$level*)
+$level // ClearAll;
+$level = 0;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$indentSize*)
+$indentSize // ClearAll;
+$indentSize = 4;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$assocLeft*)
+$assocLeft = HoldPattern @ Alternatives[
+    Part,
+    Application,
+    Divide,
+    CircleMinus,
+    PlusMinus,
+    MinusPlus,
+    LeftTee,
+    DoubleLeftTee,
+    UpTee,
+    DownTee,
+    Condition,
+    ReplaceAll,
+    ReplaceRepeated,
+    Because
+];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$assocRight*)
+$assocRight = HoldPattern @ Alternatives[
+    Map,
+    MapAll,
+    Apply,
+    Power,
+    Implies,
+    RightTee,
+    DoubleRightTee,
+    SuchThat,
+    TwoWayRule,
+    Rule,
+    RuleDelayed,
+    AddTo,
+    SubtractFrom,
+    TimesBy,
+    DivideBy,
+    ApplyTo,
+    Therefore,
+    Set,
+    SetDelayed,
+    UpSet,
+    UpSetDelayed,
+    Function
+];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*headParenQ*)
+headParenQ // ClearAll;
+headParenQ // Attributes = { HoldAllComplete };
+headParenQ[ sym_[ ___ ] ] := prec @ sym < 660;
+headParenQ[ ___  ] := False;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*formatHead*)
+formatHead // ClearAll;
+formatHead // Attributes = { HoldAllComplete };
+
+$noFullFormHeads = Alternatives[
+    CompoundExpression,
+    Condition,
+    Optional,
+    Pattern
+];
+
+formatHead[ s_Symbol? symbolQ ] := toString @ s;
+
+With[ { nf = $noFullFormHeads },
+formatHead[ h: nf[ ___ ] ] := StringJoin[ "(", Block[ { $prefix = False }, cFormat @ h ], ")" ];
+];
+
+formatHead[ h: f_[ a___ ] ] /; fitsOnLineQ @ h :=
+    If[ headParenQ @ h,
+        Block[ { $prefix = True }, StringJoin[ "(", cFormat @ h, ")" ] ],
+        StringJoin[
+            Block[ { $prefix = False }, formatHead @ f ],
+            "[ ",
+            StringRiffle[ formatArgList[ f, a ], ", " ],
+            " ]"
+        ]
+    ];
+
+formatHead[ h_ ] := Block[ { $prefix = False }, cFormat @ h ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*lhsParenQ*)
+lhsParenQ // ClearAll;
+lhsParenQ // Attributes = { HoldAllComplete };
+
+With[ { la = $assocLeft, ra = $assocRight },
+lhsParenQ[ h:la, (h:la)[ ___ ] ] := False;
+lhsParenQ[ h:ra, (h:ra)[ ___ ] ] := True;
+];
+
+lhsParenQ[ args___ ] := reqParenQ @ args;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*reqParenQ*)
+reqParenQ // ClearAll;
+reqParenQ // Attributes = { HoldAllComplete };
+
+reqParenQ[ f_, h_[ ___ ] ] := TrueQ[ prec @ f >= prec @ h ];
+
+reqParenQ[ f_ ] := Function[ e, reqParenQ[ f, e ], HoldAllComplete ];
+
+reqParenQ[ Power|Times, neg_ ] :=
+    Internal`SyntacticNegativeQ @ Unevaluated @ neg;
+
+reqParenQ[ _, __ ] := False;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*prec*)
+prec // ClearAll;
+prec // Attributes = { HoldAllComplete };
+
+(* prec[ Function ] = 1000.0; *)
+
+(* https://bugs.wolfram.com/show?number=408557 *)
+prec[ TagSetDelayed        ] := 100.0; (* ¯\_(ツ)_/¯ *)
+prec[ sym_Symbol ? symbolQ ] := Precedence @ Unevaluated @ sym;
+prec[ ___                  ] := 1000.0;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*rhsParenQ*)
+rhsParenQ // ClearAll;
+rhsParenQ // Attributes = { HoldAllComplete };
+
+With[ { la = $assocLeft, ra = $assocRight },
+rhsParenQ[ h:la, (h:la)[ ___ ] ] := True;
+rhsParenQ[ h:ra, (h:ra)[ ___ ] ] := False;
+];
+
+rhsParenQ[ SetDelayed, _Set ] := False;
+rhsParenQ[ args___ ] := reqParenQ @ args;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*indent*)
+indent // ClearAll;
+indent[n_] := StringJoin@ConstantArray[" ", {n, $indentSize}];
+indent[] := indent[$level];
+
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*equivStringsQ*)
+equivStringsQ // ClearAll;
+
+equivStringsQ[ s1_String, s2_String ] :=
+  Quiet @ SameQ[
+      ToExpression[ s1, InputForm, HoldComplete ],
+      ToExpression[ s2, InputForm, HoldComplete ]
+  ];
+
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$prefix*)
+$prefix // ClearAll;
+$prefix = True;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*formatLHS*)
+formatLHS // ClearAll;
+formatLHS // Attributes = { HoldAllComplete };
+
+formatLHS[ parent_, expr_ ] :=
+    If[ lhsParenQ[ parent, expr ],
+        StringJoin[ "(", cFormat @ expr, ")" ],
+        cFormat @ expr
+    ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*formatRHS*)
+formatRHS // ClearAll;
+formatRHS // Attributes = { HoldAllComplete };
+
+formatRHS[ parent_, expr_ ] :=
+    If[ rhsParenQ[ parent, expr ],
+        StringJoin[ "(", cFormat @ expr, ")" ],
+        cFormat @ expr
+    ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$noPrefixHeads*)
+$noPrefixHeads // ClearAll;
+
+$noPrefixHeads = Alternatives[
+    CompoundExpression,
+    Except,
+    Function,
+    List,
+    Message,
+    Not,
+    Pattern,
+    OptionsPattern
+];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$noPrefixInner*)
+$noPrefixInner // ClearAll;
+
+$noPrefixInner = HoldPattern @ Alternatives[
+    _Not,
+    _Integer,
+    _Real,
+    _PatternTest,
+    HoldPattern[ Blank|BlankSequence|BlankNullSequence ][ ___ ],
+    HoldPattern[ Repeated|RepeatedNull ][ _ ]
+];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*prefixQ*)
+prefixQ // ClearAll;
+prefixQ // Attributes = { HoldAllComplete };
+
+With[ { h = $noPrefixHeads, i = $noPrefixInner },
+prefixQ[ h[ ___ ] ] := False;
+prefixQ[ _[ i ] ] := False;
+];
+
+prefixQ[ (f_?symbolQ)[ (g_?symbolQ)[ a___ ] ] ] :=
+    TrueQ @ And[
+        $prefix,
+        $prefixEnabled,
+        Or[ prec @ g > 640,
+            Block[ { $prefix = False },
+                StringStartsQ[ cFormat @ g @ a, toString @ g ~~ "[" ]
+            ]
+        ]
+    ];
+
+
+prefixQ[ ___ ] := TrueQ[ $prefix && $prefixEnabled ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$prefixEnabled*)
+$prefixEnabled // ClearAll;
+$prefixEnabled = True;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*makePrefix*)
+makePrefix // ClearAll;
+makePrefix // Attributes = { HoldAllComplete };
+
+
+makePrefix[ slot_Slot, _ ] :=
+  toString @ slot;
+
+
+makePrefix[ f_[ s_String ], _ ] :=
+  StringJoin[
+      Block[ { $prefix = False }, cFormat @ f ],
+      "[ ",
+      toString @ s,
+      " ]"
+  ];
+
+
+makePrefix[ e: _List|Association[ (_Rule|_RuleDelayed ) .. ], _ ] :=
+  With[ { str = Block[ { $prefix = False }, cFormat @ e ] },
+      $prefix = True;
+      str
+  ];
+
+
+makePrefix[ e: _[ Verbatim[ Pattern ][ ___ ] ], _ ] :=
+  With[ { str = Block[ { $prefix = False }, cFormat @ e ] },
+      $prefix = True;
+      str
+  ];
+
+
+makePrefix[ f_[ g_[ args___ ] ], 0 ] :=
+    Module[ { fs, ga, pform },
+        fs = cFormat @ f;
+        ga = cFormat @ g @ args;
+        pform = StringJoin[ fs, " @ ", ga ];
+
+        If[ And[ ! StringStartsQ[ ga, "(" ],
+                 MatchQ[ Quiet @ ToExpression[ pform, InputForm, HoldComplete ],
+                         HoldComplete @ Verbatim[ f ][ Verbatim[ g ][ ___ ] ]
+                 ]
+            ],
+            verifyLength[ pform, makePrefix[ f @ g @ args, 0 ] ],
+            Block[ { $prefix = False }, cFormat @ f @ g @ args ]
+        ]
+    ];
+
+
+makePrefix[ f_[ g_[ args___ ] ], 1 ] :=
+  Module[ { fs, ga, pform },
+      fs = cFormat @ f;
+      ga = Internal`WithLocalSettings[
+              $level++,
+              StringJoin[ indent[], cFormat @ g @ args ],
+              $level--
+          ];
+      pform = StringJoin[ fs, " @\n", ga ];
+
+      If[ And[ ! StringStartsQ[ ga, WhitespaceCharacter...~~"(" ],
+                 MatchQ[ Quiet @ ToExpression[ pform, InputForm, HoldComplete ],
+                         HoldComplete @ Verbatim[ f ][ Verbatim[ g ][ ___ ] ]
+                 ]
+          ],
+          verifyLength[ pform, makePrefix[ f @ g @ args, 1 ] ],
+          Block[ { $prefix = False }, cFormat @ f @ g @ args ]
+      ]
+  ];
+
+
+makePrefix[ f_[ g_[ args___ ] ], 2 ] :=
+  Module[ { fs, gs, hs, pform },
+      fs = cFormat @ f;
+      gs = cFormat @ g;
+      hs = StringJoin[ fs, " @ ", gs ];
+      pform = StringJoin[
+          hs, "[\n",
+          Internal`WithLocalSettings[
+              $level++,
+              Riffle[ List @@ Function[ Null, StringJoin[ indent[ ], cFormat[ #1 ] ], { HoldAllComplete } ] /@ HoldComplete[ args ], ",\n" ],
+              $level--
+          ],
+          "\n", indent[$level], "]"
+      ];
+      If[ MatchQ[ Quiet @ ToExpression[ pform, InputForm, HoldComplete ],
+                  HoldComplete[ Verbatim[ f ][ Verbatim[ g ][ ___ ] ] ]
+          ],
+          verifyLength[ pform, makePrefix[ f @ g @ args, 2 ] ],
+          Block[ { $prefix = False },
+              cFormat @ f @ g @ args
+          ]
+      ]
+  ];
+
+
+makePrefix[ f_[ x_ ], _ ] :=
+  Module[ { fs, xs, pform },
+      fs = cFormat @ f;
+      xs = cFormat @ x;
+      pform = StringJoin[ fs, " @ ", xs ];
+      If[ MatchQ[ Quiet @ ToExpression[ pform, InputForm, HoldComplete ],
+                  HoldComplete[ f[ _ ] ]
+          ],
+          If[ stringFitsOnLineQ @ pform,
+              pform,
+              StringJoin[
+                  fs, " @\n",
+                  Internal`WithLocalSettings[
+                      $level++,
+                      StringJoin[ indent[ ], xs ],
+                      $level--
+                  ]
+              ]
+          ],
+          StringJoin[ fs, "[", xs, "]" ]
+      ]
+  ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*tagAssociations*)
+tagAssociations // ClearAll;
+tagAssociations // Attributes = { HoldAllComplete };
+
+tagAssociations[ expr_ ] :=
+  expr //. {
+      a: Except[ _List, KeyValuePattern[ k_ :> v_ ] ] :>
+        RuleCondition @
+          KeyDrop[ Insert[ a, $key @ k -> $delayed @ v, Unevaluated @ Key @ k ],
+                   Unevaluated @ Key @ k
+          ],
+      a: Except[ _List, KeyValuePattern[ k: Except[ _$key ] -> v: Except[ _$value ] ] ] :>
+        RuleCondition @
+          KeyDrop[ Insert[ a, $key @ k -> $value @ v, Unevaluated @ Key @ k ],
+                   Unevaluated @ Key @ k
+          ]
+  };
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*tighten*)
+tighten // ClearAll;
+
+tighten[ str_String ] :=
+  StringReplace[
+      str,
+      {
+          "[  ]" -> "[ ]",
+          "{  }" -> "{ }"
+      }
+  ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*formatArg*)
+formatArg // ClearAll;
+formatArg // Attributes = { HoldAllComplete };
+
+formatArg[ parent_, expr_ ] :=
+    Module[ { pref, paren, str },
+
+        pref  = prec @ parent < 640;
+        paren = reqParenQ[ parent, expr ];
+        str   = Block[ { $prefix = pref }, cFormat @ expr ];
+
+        If[ paren, StringJoin[ "(", str, ")" ], str ]
+    ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*formatArgList*)
+formatArgList // ClearAll;
+formatArgList // Attributes = { HoldAllComplete };
+
+formatArgList[ None, args___ ] :=
+    Cases[ HoldComplete @ args, e_ :> cFormat @ e ];
+
+formatArgList[ parent_, args___ ] :=
+    Cases[ HoldComplete @ args, e_ :> formatArg[ parent, e ] ];
+
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*realQ*)
+realQ // ClearAll;
+realQ // Attributes = { HoldAllComplete };
+realQ[ r_Real ] := Developer`RealQ @ Unevaluated @ r;
+realQ[ ___ ] := False;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$defaultFormatHeads*)
+$defaultFormatHeads // ClearAll;
+
+$defaultFormatHeads := {
+    ByteArray,
+    DateObject,
+    Image,
+    RawArray,
+    IconizedObject,
+    System`NumericArray,
+    CodeEquivalence`Types`TypedSymbol
+};
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*makeSpecialBoxes*)
+makeSpecialBoxes // ClearAll;
+makeSpecialBoxes // Attributes = { HoldAllComplete };
+
+makeSpecialBoxes[ x: DateObject[ ___? safeArg ] ] :=
+  With[ { e = Quiet @ x }, MakeBoxes[ e, StandardForm ] /; DateObjectQ @ e ];
+
+makeSpecialBoxes[ x: ByteArray[ ___? safeArg ] ] :=
+  With[ { e = Quiet @ x }, MakeBoxes[ e, StandardForm ] /; ByteArrayQ @ e ];
+
+makeSpecialBoxes[ e_ ] :=
+  MakeBoxes[ e, StandardForm ];
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*safeArg*)
+safeArg // ClearAll;
+safeArg // Attributes = { HoldAllComplete };
+safeArg[ { ___? safeArg } ] := True;
+safeArg[ x: _Integer|_Real|_String ] := AtomQ @ Unevaluated @ x;
+
+(* ::**********************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Error handling*)
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*catchTop*)
+catchTop // beginDefinition;
+catchTop // Attributes = { HoldFirst };
+
+catchTop[ eval_ ] :=
+    Block[ { $catching = True, $failed = False, catchTop = # & },
+        Catch[ eval, $top ]
+    ];
+
+catchTop // endDefinition;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*throwFailure*)
+throwFailure // beginDefinition;
+throwFailure // Attributes = { HoldFirst };
+
+throwFailure[ tag_String, params___ ] :=
+    throwFailure[ MessageName[ ReadableForm, tag ], params ];
+
+throwFailure[ msg_, args___ ] :=
+    Module[ { failure },
+        failure = messageFailure[ msg, Sequence @@ HoldForm /@ { args } ];
+        If[ TrueQ @ $catching,
+            Throw[ failure, $top ],
+            failure
+        ]
+    ];
+
+throwFailure // endDefinition;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*messageFailure*)
+messageFailure // beginDefinition;
+messageFailure // Attributes = { HoldFirst };
+
+messageFailure[ args___ ] :=
+    Module[ { quiet },
+        quiet = If[ TrueQ @ $failed, Quiet, Identity ];
+        WithCleanup[
+            quiet @ ResourceFunction[ "MessageFailure" ][ args ],
+            $failed = True
+        ]
+    ];
+
+messageFailure // endDefinition;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*throwInternalFailure*)
+throwInternalFailure // beginDefinition;
+throwInternalFailure // Attributes = { HoldFirst };
+
+throwInternalFailure[ eval_, a___ ] :=
+    throwFailure[ ReadableForm::internal, $bugReportLink, HoldForm @ eval, a ];
+
+throwInternalFailure // endDefinition;
+
+(* ::**********************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*$bugReportLink*)
+$bugReportLink := $bugReportLink = Hyperlink[
+    "Report this issue \[RightGuillemet]",
+    URLBuild @ <|
+        "Scheme"   -> "https",
+        "Domain"   -> "resources.wolframcloud.com",
+        "Path"     -> { "FunctionRepository", "feedback-form" },
+        "Fragment" -> SymbolName @ ReadableForm
+    |>
+];
+EndPackage[ ];

--- a/ResourceFunctions/ResourceFunctionMessage.wl
+++ b/ResourceFunctions/ResourceFunctionMessage.wl
@@ -1,0 +1,152 @@
+(* ::Package:: *)
+
+(*
+    Local copy of the "ResourceFunctionMessage" resource function (version 2.1.1) from the Wolfram Function Repository.
+
+    Resource: https://resources.wolframcloud.com/FunctionRepository/resources/ResourceFunctionMessage
+    Source:   generated from the published definition (ResourceFunction["ResourceFunctionMessage", "DefinitionList"]) and formatted
+              with the ReadableForm resource function; the development source of this function is
+              https://github.com/rhennigan/ResourceFunctions/tree/main/Definitions/ResourceFunctionMessage
+
+    Kernel/Common.wl (importResourceFunction) loads this file in preference to fetching the resource function from
+    the Function Repository, so the paclet can be built and loaded from source without cloud access. This directory
+    is not part of the built paclet: the MX build inlines these definitions. The definitions are assigned as a
+    definition list, exactly as the Function Repository publishes them (re-evaluating them as ordinary code would
+    merge rules such as f[ args___ ] and its e: HoldPattern[ f[ ___ ] ] fallthrough), wrapped in BeginPackage/EndPackage
+    so the symbols live in the "Wolfram`AgentTools`ResourceFunctions`ResourceFunctionMessage`" context.
+    Do not edit the definitions here; update the upstream resource function and regenerate the file
+    (see ResourceFunctions/README.md).
+*)
+
+BeginPackage[ "Wolfram`AgentTools`ResourceFunctions`ResourceFunctionMessage`" ];
+
+Language`ExtendedFullDefinition[ ] = 
+    Language`DefinitionList[
+        HoldForm @ ResourceFunctionMessage -> {
+            DownValues -> {
+                HoldPattern @ ResourceFunctionMessage[
+                    msg: HoldPattern @ MessageName[ symbol_Symbol, tag: Repeated[ _String, { 1, 2 } ] ],
+                    args___
+                ] :>
+                    If[ TrueQ[ ! messageQuietedQ @ msg ],
+                        Module[ { label, template, message },
+                            checkUserMessage[ ];
+                            label = messageLabelBox[ symbol, tag ];
+                            
+                            template = 
+                                messageTemplate[
+                                    symbol,
+                                    tag,
+                                    HoldComplete @ args
+                                ];
+
+                            message = padTemplate[ template, args ];
+                            Message[
+                                ResourceFunction::usermessage,
+                                Row @ { label, ": ", message }
+                            ]
+                        ],
+                        Null
+                    ]
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ messageQuietedQ -> {
+            DownValues -> {
+                HoldPattern @ messageQuietedQ[ msg: MessageName[ _Symbol, tag___ ] ] :>
+                    Module[ { stack, msgOrGeneral, msgPatt },
+                        stack = Lookup[ Internal`QuietStatus[ ], Stack ];
+                        msgOrGeneral = generalMessagePattern @ msg;
+                        msgPatt = All | { ___, msgOrGeneral, ___ };
+                        TrueQ @ And[
+                            FreeQ[ stack, { _, _, msgPatt }, 2 ],
+                            ! FreeQ[ stack, { _, msgPatt, _ }, 2 ]
+                        ]
+                    ]
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ generalMessagePattern -> {
+            DownValues -> {
+                HoldPattern @ generalMessagePattern[ msg: MessageName[ _Symbol, tag___ ] ] :>
+                    If[ StringQ @ msg,
+                        HoldPattern @ msg,
+                        HoldPattern[ msg | MessageName[ General, tag ] ]
+                    ]
+            },
+            Attributes -> { HoldFirst }
+        },
+        HoldForm @ checkUserMessage -> {
+            DownValues -> {
+                HoldPattern @ checkUserMessage[ ] :>
+                    If[ ! StringQ @ ResourceFunction::usermessage,
+                        Internal`WithLocalSettings[
+                            Unprotect @ ResourceFunction,
+                            ResourceFunction::usermessage = "`1`",
+                            Protect @ ResourceFunction
+                        ]
+                    ]
+            }
+        },
+        HoldForm @ messageLabelBox -> {
+            DownValues -> {
+                HoldPattern @ messageLabelBox[ symbol_Symbol, tag__String ] :>
+                    With[ { symName = SymbolName @ Unevaluated @ symbol },
+                        RawBoxes @ StyleBox[ RowBox @ { symName, "::", tag }, "MessageName" ]
+                    ]
+            }
+        },
+        HoldForm @ messageTemplate -> {
+            DownValues -> {
+                HoldPattern @ messageTemplate[ symbol_Symbol, tag__String, args_HoldComplete ] :>
+                    Replace[
+                        MessageName[ symbol, tag ],
+                        Except[ _String? StringQ ] :>
+                            Replace[
+                                MessageName[ General, tag ],
+                                Except[ _String? StringQ ] :>
+                                    StringJoin[
+                                        "-- Message text not found --",
+                                        StringJoin @ Table[
+                                            { " (`", ToString @ i, "`)" },
+                                            { i, Length @ args }
+                                        ]
+                                    ]
+                            ]
+                    ]
+            }
+        },
+        HoldForm @ padTemplate -> {
+            DownValues -> {
+                HoldPattern @ padTemplate[ template_String, args___ ] :>
+                    With[
+                        {
+                            sc = slotCount @ template,
+                            ac = Length @ HoldComplete @ args
+                        },
+                        Row @ TemplateApply[
+                            DeleteCases[
+                                StringTemplate @ template,
+                                InsertionFunction | CombinerFunction -> _
+                            ],
+                            {
+                                args,
+                                Sequence @@ ConstantArray[ "", Max[ 0, sc - ac ] ]
+                            }
+                        ]
+                    ]
+            }
+        },
+        HoldForm @ slotCount -> {
+            DownValues -> {
+                HoldPattern @ slotCount[ template_String ] :>
+                    Count[
+                        StringTemplate @ template,
+                        TemplateSlot[ _Integer ],
+                        { 2 }
+                    ]
+            }
+        }
+    ];
+
+EndPackage[ ];

--- a/Scripts/BuildMX.wls
+++ b/Scripts/BuildMX.wls
@@ -57,6 +57,20 @@ copyTemporary0[ dir_, tmp_, file_ ] :=
     ];
 
 (* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*copyResourceFunctions*)
+(* The local resource function definitions (see ResourceFunctions/README.md) are not paclet extension files, so
+   copyTemporary skips them, but importResourceFunction looks for them next to the copy of the paclet it is loaded from
+   when inlining the definitions into the MX file. They are copied after expandTags so their Confirm tags are left alone. *)
+copyResourceFunctions[ dir_, tmp_ ] :=
+    With[ { source = FileNameJoin @ { dir, "ResourceFunctions" } },
+        If[ DirectoryQ @ source,
+            CopyDirectory[ source, FileNameJoin @ { tmp, "ResourceFunctions" } ],
+            None
+        ]
+    ];
+
+(* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*relativePath*)
 relativePath[ dir0_, file0_ ] :=
@@ -140,7 +154,16 @@ getNewTags[ root_, file_ ] :=
 
 $tagTemplate = StringTemplate[ "\"`Tag`@@`File`:`Line1`,`Column1`-`Line2`,`Column2`\"" ];
 
-astPattern := astPattern = ResourceFunction[ "ASTPattern", "Function" ];
+(* Prefer the local copy of the ASTPattern resource function (see ResourceFunctions/README.md), so that the build does not
+   need the Function Repository. The Block keeps its BeginPackage/EndPackage from changing this script's context path. *)
+$localASTPatternFile = FileNameJoin @ { $pacletDir, "ResourceFunctions", "ASTPattern.wl" };
+
+astPattern := astPattern =
+    If[ FileExistsQ @ $localASTPatternFile,
+        Block[ { $Context = $Context, $ContextPath = $ContextPath }, Get @ $localASTPatternFile ];
+        Symbol[ "Wolfram`AgentTools`ResourceFunctions`ASTPattern`ASTPattern" ],
+        ResourceFunction[ "ASTPattern", "Function" ]
+    ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -175,6 +198,9 @@ If[ $assertions,
     cicd`ConsoleLog[ "Inserting confirmation source info..." ];
     cicd`ScriptConfirm @ expandTags @ tmp
 ];
+
+cicd`ConsoleLog[ "Copying local resource function definitions..." ];
+cicd`ScriptConfirmMatch[ copyResourceFunctions[ $pacletDir, tmp ], _String | None ];
 
 cicd`ConsoleLog[ "Loading paclet..." ];
 PacletDirectoryUnload @ $pacletDir;

--- a/Scripts/Common.wl
+++ b/Scripts/Common.wl
@@ -27,7 +27,8 @@ DefinitionNotebookClient`$DisabledHints = <| "MessageTag" -> #, "Level" -> All, 
     "HugeRaster",
     "InternalContextWarning",
     "InvalidFirstVersion",
-    "NoGithubRepoFound"
+    "NoGithubRepoFound",
+    "PublisherUpdateNotAllowed"
 };
 
 $messageHistoryLength = 10;

--- a/Tests/ResourceFunctions.wlt
+++ b/Tests/ResourceFunctions.wlt
@@ -1,0 +1,187 @@
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+VerificationTest[
+    Needs[ "Wolfram`AgentToolsTests`", FileNameJoin @ { DirectoryName @ $TestFileName, "Common.wl" } ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "GetDefinitions@@Tests/ResourceFunctions.wlt:7,1-12,2"
+]
+
+VerificationTest[
+    Needs[ "Wolfram`AgentTools`" ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "LoadContext@@Tests/ResourceFunctions.wlt:14,1-19,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Local Definitions*)
+VerificationTest[
+    $resourceFunctionDirectory = FileNameJoin @ { DirectoryName[ $TestFileName, 2 ], "ResourceFunctions" },
+    _String? DirectoryQ,
+    SameTest -> MatchQ,
+    TestID   -> "ResourceFunctionDirectory@@Tests/ResourceFunctions.wlt:24,1-29,2"
+]
+
+(* Every resource function the paclet uses has a local definition, except ReplaceContext, which is only needed when
+   importing from the Function Repository *)
+VerificationTest[
+    Select[
+        DeleteCases[ Keys @ Wolfram`AgentTools`Common`Private`$resourceVersions, "ReplaceContext" ],
+        ! FileExistsQ @ FileNameJoin @ { $resourceFunctionDirectory, #1 <> ".wl" } &
+    ],
+    { },
+    SameTest -> MatchQ,
+    TestID   -> "LocalDefinitionsExist@@Tests/ResourceFunctions.wlt:33,1-41,2"
+]
+
+(* Each local definition file lives in its own context *)
+VerificationTest[
+    Select[
+        FileNames[ "*.wl", $resourceFunctionDirectory ],
+        ! StringContainsQ[
+            ReadString @ #1,
+            "BeginPackage[ \"Wolfram`AgentTools`ResourceFunctions`" <> FileBaseName @ #1 <> "`\" ]"
+        ] &
+    ],
+    { },
+    SameTest -> MatchQ,
+    TestID   -> "LocalDefinitionsWrapped@@Tests/ResourceFunctions.wlt:44,1-55,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Imported Functions*)
+(* Imports resolve to the local definitions: inlined at build time in an MX build, loaded at first use from source *)
+VerificationTest[
+    With[ { f = Wolfram`AgentTools`Tools`SymbolDefinition`Private`readableForm }, Context @ f ],
+    "Wolfram`AgentTools`ResourceFunctions`ReadableForm`",
+    SameTest -> MatchQ,
+    TestID   -> "ReadableFormImport@@Tests/ResourceFunctions.wlt:61,1-66,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`resourceFunctionAvailableQ @ Wolfram`AgentTools`Tools`SymbolDefinition`Private`readableForm,
+    True,
+    SameTest -> MatchQ,
+    TestID   -> "ReadableFormAvailable@@Tests/ResourceFunctions.wlt:68,1-73,2"
+]
+
+(* Loading a local definition must not leave its context on $ContextPath *)
+VerificationTest[
+    Select[ $ContextPath, StringStartsQ[ "Wolfram`AgentTools`ResourceFunctions`" ] ],
+    { },
+    SameTest -> MatchQ,
+    TestID   -> "NoContextPathLeak@@Tests/ResourceFunctions.wlt:76,1-81,2"
+]
+
+VerificationTest[
+    ToString @ Wolfram`AgentTools`Tools`SymbolDefinition`Private`readableForm @ Unevaluated[ f[ x_ ] := x + 1 ],
+    "f[ x_ ] := x + 1",
+    SameTest -> MatchQ,
+    TestID   -> "ReadableFormWorks@@Tests/ResourceFunctions.wlt:83,1-88,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`messageFailure[ "UnknownTool", "TestTool" ],
+    Failure[ "AgentTools::UnknownTool", _ ]? (#1[ "MessageParameters" ] === { "TestTool" } &),
+    { AgentTools::UnknownTool },
+    SameTest -> MatchQ,
+    TestID   -> "MessageFailureWorks@@Tests/ResourceFunctions.wlt:90,1-96,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Tools`importMarkdownString[ "# Title\n\nSome text", "Notebook" ],
+    _Notebook,
+    SameTest -> MatchQ,
+    TestID   -> "ImportMarkdownStringWorks@@Tests/ResourceFunctions.wlt:98,1-103,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`exportMarkdownString @ Notebook @ { Cell[ "Hello", "Text" ] },
+    _String? (StringContainsQ[ "Hello" ]),
+    SameTest -> MatchQ,
+    TestID   -> "ExportMarkdownStringWorks@@Tests/ResourceFunctions.wlt:105,1-110,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Tools`CodeInspector`Private`astPattern @ HoldPattern[ f[ _ ] ],
+    _CodeParser`CallNode,
+    SameTest -> MatchQ,
+    TestID   -> "ASTPatternWorks@@Tests/ResourceFunctions.wlt:112,1-117,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Unavailable Resource Functions*)
+(* A resource function with no local definition that cannot be fetched gives a placeholder that fails with a message
+   when used, and the import is not memoized so it is retried on the next use *)
+VerificationTest[
+    Wolfram`AgentTools`Common`importResourceFunction[ $testResourceFunction, "NoSuchAgentToolsTestResourceFunction", "1.0.0" ];
+    $testResourceFunction,
+    _Wolfram`AgentTools`Common`Private`resourceFunctionUnavailable,
+    SameTest -> MatchQ,
+    TestID   -> "UnavailablePlaceholder@@Tests/ResourceFunctions.wlt:124,1-130,2"
+]
+
+VerificationTest[
+    $testResourceFunction[ 1, 2 ],
+    Failure[ "AgentTools::ResourceFunctionUnavailable", _ ]? (#1[ "MessageParameters" ] === { "NoSuchAgentToolsTestResourceFunction" } &),
+    { AgentTools::ResourceFunctionUnavailable },
+    SameTest -> MatchQ,
+    TestID   -> "UnavailableFailure@@Tests/ResourceFunctions.wlt:132,1-138,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Common`resourceFunctionAvailableQ @ $testResourceFunction,
+    False,
+    SameTest -> MatchQ,
+    TestID   -> "UnavailableNotAvailable@@Tests/ResourceFunctions.wlt:140,1-145,2"
+]
+
+VerificationTest[
+    OwnValues @ $testResourceFunction,
+    { _ :> _Wolfram`AgentTools`Common`Private`resolveResourceFunction },
+    SameTest -> MatchQ,
+    TestID   -> "UnavailableNotMemoized@@Tests/ResourceFunctions.wlt:147,1-152,2"
+]
+
+(* The SymbolDefinition tool falls back to InputForm when ReadableForm is not available *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Tools`SymbolDefinition`Private`readableForm =
+                Wolfram`AgentTools`Common`Private`resourceFunctionUnavailable[ "ReadableForm" ]
+        },
+        Wolfram`AgentTools`Tools`SymbolDefinition`Private`formatDefinitionReadable[
+            { HoldForm[ f[ x_ ] := x + 1 ] },
+            { "System`" },
+            "Global`"
+        ]
+    ],
+    $Failed,
+    SameTest -> MatchQ,
+    TestID   -> "SymbolDefinitionReadableFallback@@Tests/ResourceFunctions.wlt:155,1-170,2"
+]
+
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Tools`SymbolDefinition`Private`readableForm =
+                Wolfram`AgentTools`Common`Private`resourceFunctionUnavailable[ "ReadableForm" ]
+        },
+        $DefaultMCPTools[ "SymbolDefinition" ][ "Function" ][
+            <| "symbols" -> "Wolfram`AgentTools`$MCPTransport", "includeContextDetails" -> False, "maxLength" -> 10000 |>
+        ]
+    ],
+    _? (StringContainsQ[ ToString @ #1, "$MCPTransport = None" ] &),
+    SameTest -> MatchQ,
+    TestID   -> "SymbolDefinitionToolFallback@@Tests/ResourceFunctions.wlt:172,1-185,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/ServerErrorHandling.wlt
+++ b/Tests/ServerErrorHandling.wlt
@@ -1,0 +1,268 @@
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+(* :!CodeAnalysis::Disable::NoSurroundingCatch:: *) (* tagless Throw is exercised deliberately *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+VerificationTest[
+    Needs[ "Wolfram`AgentToolsTests`", FileNameJoin @ { DirectoryName @ $TestFileName, "Common.wl" } ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "GetDefinitions@@Tests/ServerErrorHandling.wlt:8,1-13,2"
+]
+
+VerificationTest[
+    Needs[ "Wolfram`AgentTools`" ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "LoadContext@@Tests/ServerErrorHandling.wlt:15,1-20,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*catchUncaughtThrows*)
+VerificationTest[
+    Wolfram`AgentTools`Server`catchUncaughtThrows[ 1 + 1, { "caught", ##1 } & ],
+    2,
+    SameTest -> MatchQ,
+    TestID   -> "CatchUncaughtThrows-Normal@@Tests/ServerErrorHandling.wlt:25,1-30,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Server`catchUncaughtThrows[ Throw[ 1, TestThrowTag ], { "caught", ##1 } & ],
+    { "caught", 1, TestThrowTag },
+    SameTest -> MatchQ,
+    TestID   -> "CatchUncaughtThrows-TaggedThrow@@Tests/ServerErrorHandling.wlt:32,1-37,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Server`catchUncaughtThrows[ Throw[ 2 ], { "caught", ##1 } & ],
+    { "caught", 2, None },
+    SameTest -> MatchQ,
+    TestID   -> "CatchUncaughtThrows-TaglessThrow@@Tests/ServerErrorHandling.wlt:39,1-44,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Server`catchUncaughtThrows[ Abort[ ], { "caught", ##1 } & ],
+    { "caught", $Aborted, Abort },
+    SameTest -> MatchQ,
+    TestID   -> "CatchUncaughtThrows-Abort@@Tests/ServerErrorHandling.wlt:46,1-51,2"
+]
+
+(* Throws caught inside the evaluation are unaffected *)
+VerificationTest[
+    Wolfram`AgentTools`Server`catchUncaughtThrows[ Catch[ Throw[ 3, InnerTag ], InnerTag ], { "caught", ##1 } & ],
+    3,
+    SameTest -> MatchQ,
+    TestID   -> "CatchUncaughtThrows-InnerCatch@@Tests/ServerErrorHandling.wlt:54,1-59,2"
+]
+
+(* The paclet's own failures are still caught by stealthCatchTop first *)
+VerificationTest[
+    Wolfram`AgentTools`Common`catchAlways @ Wolfram`AgentTools`Server`catchUncaughtThrows[
+        Wolfram`AgentTools`Server`stealthCatchTop @ Wolfram`AgentTools`Common`throwFailure[ "UnknownTool", "x" ],
+        { "caught", ##1 } &
+    ],
+    Failure[ "AgentTools::UnknownTool", _ ],
+    { AgentTools::UnknownTool },
+    SameTest -> MatchQ,
+    TestID   -> "CatchUncaughtThrows-PacletFailureUnaffected@@Tests/ServerErrorHandling.wlt:62,1-71,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Request Handlers*)
+VerificationTest[
+    Wolfram`AgentTools`Server`uncaughtRequestThrow[ "tools/call", "boom", TestThrowTag ],
+    Failure[ "AgentTools::UncaughtThrow", _ ]? (MatchQ[ #1[ "MessageParameters" ], { "tools/call", _String? (StringContainsQ[ "TestThrowTag" ]) } ] &),
+    { AgentTools::UncaughtThrow },
+    SameTest -> MatchQ,
+    TestID   -> "UncaughtRequestThrow-Tagged@@Tests/ServerErrorHandling.wlt:76,1-82,2"
+]
+
+VerificationTest[
+    Wolfram`AgentTools`Server`uncaughtRequestThrow[ None, $Aborted, Abort ],
+    Failure[ "AgentTools::RequestAborted", _ ],
+    { AgentTools::RequestAborted },
+    SameTest -> MatchQ,
+    TestID   -> "UncaughtRequestThrow-Abort@@Tests/ServerErrorHandling.wlt:84,1-90,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Tool Calls*)
+VerificationTest[
+    $callTestTool = Function[
+        tool,
+        (* The transports call handleMethod inside catchAlways, which scopes the paclet's error-handling state *)
+        Block[ { Wolfram`AgentTools`Server`$llmTools = <| "TestTool" -> tool |> },
+            Wolfram`AgentTools`Common`catchAlways @ Wolfram`AgentTools`Common`handleMethod[
+                "tools/call",
+                <| "method" -> "tools/call", "params" -> <| "name" -> "TestTool", "arguments" -> <| |> |> |>,
+                <| "jsonrpc" -> "2.0", "id" -> 1 |>
+            ]
+        ]
+    ];
+    Null,
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "DefineCallTestTool@@Tests/ServerErrorHandling.wlt:95,1-111,2"
+]
+
+VerificationTest[
+    $callTestTool[ Function[ "ok" ] ],
+    KeyValuePattern[ "result" -> KeyValuePattern @ { "isError" -> False, "content" -> { KeyValuePattern[ "text" -> "ok" ] } } ],
+    SameTest -> MatchQ,
+    TestID   -> "ToolsCall-Normal@@Tests/ServerErrorHandling.wlt:113,1-118,2"
+]
+
+(* A Throw with a tag nothing in the paclet catches becomes a tool error instead of ending the server *)
+VerificationTest[
+    $callTestTool[ Function[ Throw[ "boom", TestThrowTag ] ] ],
+    KeyValuePattern[
+        "result" -> KeyValuePattern @ {
+            "isError" -> True,
+            "content" -> { KeyValuePattern[ "text" -> _String? (StringContainsQ[ "TestThrowTag" ]) ] }
+        }
+    ],
+    { AgentTools::UncaughtToolThrow },
+    SameTest -> MatchQ,
+    TestID   -> "ToolsCall-UncaughtTaggedThrow@@Tests/ServerErrorHandling.wlt:121,1-132,2"
+]
+
+VerificationTest[
+    $callTestTool[ Function[ Throw[ "boom" ] ] ],
+    KeyValuePattern[
+        "result" -> KeyValuePattern @ {
+            "isError" -> True,
+            "content" -> { KeyValuePattern[ "text" -> _String? (StringContainsQ[ "Throw[\"boom\"]" ]) ] }
+        }
+    ],
+    { AgentTools::UncaughtToolThrow },
+    SameTest -> MatchQ,
+    TestID   -> "ToolsCall-UncaughtTaglessThrow@@Tests/ServerErrorHandling.wlt:134,1-145,2"
+]
+
+VerificationTest[
+    $callTestTool[ Function[ Abort[ ] ] ],
+    KeyValuePattern[ "result" -> KeyValuePattern[ "isError" -> True ] ],
+    { AgentTools::ToolAborted },
+    SameTest -> MatchQ,
+    TestID   -> "ToolsCall-Abort@@Tests/ServerErrorHandling.wlt:147,1-153,2"
+]
+
+(* The network-failure tag thrown by CloudObject when the Wolfram Cloud is unreachable gets a specific message *)
+VerificationTest[
+    $callTestTool[ Function[ Throw[ $Failed, CloudObject`Private`NetworkCallFailure ] ] ],
+    KeyValuePattern[
+        "result" -> KeyValuePattern @ {
+            "isError" -> True,
+            "content" -> { KeyValuePattern[ "text" -> _String? (StringContainsQ[ "Wolfram Cloud" ]) ] }
+        }
+    ],
+    { AgentTools::CloudUnavailable },
+    SameTest -> MatchQ,
+    TestID   -> "ToolsCall-CloudUnavailable@@Tests/ServerErrorHandling.wlt:156,1-167,2"
+]
+
+(* The paclet's own failures are reported as before *)
+VerificationTest[
+    $callTestTool[ Function[ Wolfram`AgentTools`Common`throwFailure[ "UnknownTool", "x" ] ] ],
+    KeyValuePattern[
+        "result" -> KeyValuePattern @ {
+            "isError" -> True,
+            "content" -> { KeyValuePattern[ "text" -> _String? (StringContainsQ[ "Unknown tool" ]) ] }
+        }
+    ],
+    { AgentTools::UnknownTool },
+    SameTest -> MatchQ,
+    TestID   -> "ToolsCall-PacletFailure@@Tests/ServerErrorHandling.wlt:170,1-181,2"
+]
+
+(* Failure messages are rendered as plain text rather than boxes *)
+VerificationTest[
+    $callTestTool[ Function[ Wolfram`AgentTools`Common`throwFailure[ "UnknownTool", "x" ] ] ][[ "result", "content", 1, "text" ]],
+    "[Error] Unknown tool: x.",
+    { AgentTools::UnknownTool },
+    SameTest -> MatchQ,
+    TestID   -> "ToolsCall-FailureTextIsPlain@@Tests/ServerErrorHandling.wlt:184,1-190,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Context Tools Without Cloud Access*)
+(* When Chatbook's searches fail (typically because the Wolfram Cloud could not be reached), the context tools report a
+   clear failure instead of an opaque internal one *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Tools`Context`Private`relatedDocumentation0 =
+                Function[ Failure[ "General::ChatbookInternal", <| |> ] ]
+        },
+        Wolfram`AgentTools`Common`catchAlways @ Wolfram`AgentTools`Common`relatedDocumentation[ "test" ]
+    ],
+    Failure[ "AgentTools::DocumentationSearchFailed", _ ]? (#1[ "MessageParameters" ] === { "General::ChatbookInternal" } &),
+    { AgentTools::DocumentationSearchFailed },
+    SameTest -> MatchQ,
+    TestID   -> "RelatedDocumentation-ChatbookFailure@@Tests/ServerErrorHandling.wlt:197,1-209,2"
+]
+
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Tools`Context`Private`relatedWolframAlphaResults0 =
+                Function[ Failure[ "General::ChatbookInternal", <| |> ] ]
+        },
+        Wolfram`AgentTools`Common`catchAlways @ Wolfram`AgentTools`Common`relatedWolframAlphaResults[ "test" ]
+    ],
+    Failure[ "AgentTools::WolframAlphaSearchFailed", _ ]? (#1[ "MessageParameters" ] === { "General::ChatbookInternal" } &),
+    { AgentTools::WolframAlphaSearchFailed },
+    SameTest -> MatchQ,
+    TestID   -> "RelatedWolframAlphaResults-ChatbookFailure@@Tests/ServerErrorHandling.wlt:211,1-223,2"
+]
+
+(* The same failure through a tools/call of the real tool *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`AgentTools`Tools`Context`Private`relatedDocumentation0 =
+                Function[ Failure[ "General::ChatbookInternal", <| |> ] ],
+            Wolfram`AgentTools`Server`$llmTools = <| "WolframLanguageContext" -> $DefaultMCPTools[ "WolframLanguageContext" ] |>
+        },
+        Wolfram`AgentTools`Common`catchAlways @ Wolfram`AgentTools`Common`handleMethod[
+            "tools/call",
+            <| "method" -> "tools/call", "params" -> <| "name" -> "WolframLanguageContext", "arguments" -> <| "context" -> "test" |> |> |>,
+            <| "jsonrpc" -> "2.0", "id" -> 1 |>
+        ]
+    ],
+    KeyValuePattern[
+        "result" -> KeyValuePattern @ {
+            "isError" -> True,
+            "content" -> { KeyValuePattern[ "text" -> _String? (StringStartsQ[ "[Error] Documentation search is currently unavailable (General::ChatbookInternal)" ]) ] }
+        }
+    ],
+    { AgentTools::DocumentationSearchFailed },
+    SameTest -> MatchQ,
+    TestID   -> "ToolsCall-WolframLanguageContext-ChatbookFailure@@Tests/ServerErrorHandling.wlt:226,1-248,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Response Serialization*)
+VerificationTest[
+    Wolfram`AgentTools`Server`Local`Private`serializeResponse[ <| "jsonrpc" -> "2.0", "id" -> 5, "result" -> <| "a" -> 1 |> |> ],
+    "{\"jsonrpc\":\"2.0\",\"id\":5,\"result\":{\"a\":1}}",
+    SameTest -> MatchQ,
+    TestID   -> "SerializeResponse-Normal@@Tests/ServerErrorHandling.wlt:253,1-258,2"
+]
+
+(* A response that cannot be encoded as JSON becomes an internal error response for the same request *)
+VerificationTest[
+    Quiet @ Wolfram`AgentTools`Server`Local`Private`serializeResponse[ <| "jsonrpc" -> "2.0", "id" -> 5, "result" -> <| "a" -> Hold[ 1 ] |> |> ],
+    _String? (StringContainsQ[ #1, "\"id\":5" ] && StringContainsQ[ #1, "\"code\":-32603" ] &),
+    SameTest -> MatchQ,
+    TestID   -> "SerializeResponse-Unserializable@@Tests/ServerErrorHandling.wlt:261,1-266,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)

--- a/docs/building.md
+++ b/docs/building.md
@@ -58,6 +58,15 @@ During development, you may want to:
 
 See [Getting Started](getting-started.md#important-mx-files) for more details on MX files during development.
 
+## Resource Functions and Offline Builds
+
+The paclet uses a few functions from the Wolfram Function Repository, pinned to the versions in `$resourceVersions` in `Kernel/Common.wl`. Their definitions are also kept as local copies in `ResourceFunctions/` (one `.wl` file per function, each wrapped in `BeginPackage`/`EndPackage` for the context ``Wolfram`AgentTools`ResourceFunctions`<Name>` ``). `importResourceFunction` prefers a local copy and only falls back to fetching the resource function when there is none, so:
+
+- The MX build inlines the local definitions and does not need cloud access. `Scripts/BuildMX.wls` copies `ResourceFunctions/` into the temporary build copy of the paclet and uses the local `ASTPattern` for the source annotations it inserts.
+- Loading the paclet from source loads a local copy at the first use of the imported symbol. If a resource function has no local copy and cannot be fetched either, the imported symbol becomes a placeholder that fails with `AgentTools::ResourceFunctionUnavailable` when used, and the import is retried on the next use instead of caching the failure.
+
+The directory is not declared in `PacletInfo.wl` and is not part of the built paclet. See [ResourceFunctions/README.md](../ResourceFunctions/README.md) for the provenance of each copy and how to update one when a pinned version changes.
+
 ## Building Agent Skills
 
 Agent skills are built separately from the paclet. The build script generates `.wls` scripts from MCP tool definitions and distributes them to skill directories:

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -307,6 +307,16 @@ catchAlways @ riskySubOperation[ ]
 
 Use when you want to handle errors instead of propagating them to the nearest `catchTop`. Typically used in combination with `Quiet` to suppress messages.
 
+### `catchUncaughtThrows[eval, handler]`
+
+The MCP server's exception boundary (`Kernel/Server/Shared.wl`). `catchTop` and friends only catch the paclet's own `$catchTopTag` throws. A `Throw` with any other tag (for example ``CloudObject`Private`NetworkCallFailure``, which the cloud framework throws when the Wolfram Cloud cannot be reached), a tagless `Throw`, or an `Abort[]` would unwind through the whole server, and in the local transport that ends the read loop and with it the server process. `catchUncaughtThrows` evaluates `eval` and hands any such exception to `handler[value, tag]`, where `tag` is `None` for a tagless `Throw` and `Abort` for an abort, returning the handler's result:
+
+```wl
+result = catchUncaughtThrows[ stealthCatchTop @ tool @ args, uncaughtToolThrow[ toolName, ##1 ] & ];
+```
+
+It wraps tool evaluation in `evaluateTool` (where `uncaughtToolThrow` turns the exception into the tool's error result, with `AgentTools::CloudUnavailable` for the cloud network-failure tag), `handleMethod` in both transports (where `uncaughtRequestThrow` produces a failure that becomes a JSON-RPC internal error response), and tool warmup in the local read loop. Always place it *outside* `catchTop`/`stealthCatchTop`, so the paclet's own failures are handled first.
+
 ## Bug Report Generation
 
 When `throwInternalFailure` is called, the system automatically:
@@ -325,6 +335,7 @@ When `throwInternalFailure` is called, the system automatically:
 - Define all message tags in `Kernel/Messages.wl`
 - Use `catchMine` for exported functions
 - Let errors propagate naturally; avoid catching and re-throwing unless you plan to handle them in a different way
+- Code that runs inside the MCP server must not let a `Throw` with a foreign tag escape: keep `catchUncaughtThrows` around every place where tool or request handling is evaluated (see above)
 
 ## Example: Complete Function Implementation
 


### PR DESCRIPTION
## Summary

The wolframcloud.com outage exposed two problems in the local MCP server, and it also means the Function Repository is unavailable at build time. This PR makes the paclet fail gracefully without cloud access and makes it buildable without the Function Repository.

**What went wrong during the outage**

- A `WolframLanguageContext` call ended the server process. Chatbook's documentation search raised `Throw[$Failed, CloudObject`Private`NetworkCallFailure]`; nothing in the paclet catches that tag, so the throw unwound through the read loop, the script ended with exit code 0, and the client saw "Connection closed".
- `SymbolDefinition` printed `Missing[NotAvailable][Unevaluated[...]]` for every definition: the `ReadableForm` import failed in the protected-mode sandbox kernel (which cannot see the local resource cache) and the failure was memoized for the life of the server.

**Server**

- `catchUncaughtThrows` (`Kernel/Server/Shared.wl`) is an exception boundary for foreign `Throw` tags, tagless `Throw`, and `Abort`. It wraps tool evaluation (the exception becomes the tool's error result, with `AgentTools::CloudUnavailable` for the cloud network-failure tag), `handleMethod` in both transports (JSON-RPC internal error), and tool warmup in the local read loop.
- A response that cannot be serialized as JSON becomes an internal error response instead of ending the server.
- `Failure` messages in tool results are rendered as plain text; the `Failure["Message"]` property wraps parameters in `Short` boxes, which came out as box syntax.
- Failures of Chatbook's documentation and Wolfram|Alpha searches are reported as `AgentTools::DocumentationSearchFailed` / `AgentTools::WolframAlphaSearchFailed` instead of an opaque internal failure.

**Resource functions**

- New `ResourceFunctions/` directory (not declared in `PacletInfo.wl`, so not part of the built paclet) with a local copy of each Function Repository function the paclet uses, each wrapped in `BeginPackage`/`EndPackage` for its own context.
- `importResourceFunction` prefers a local copy: in MX builds it is inlined exactly like a fetched definition; from source it is loaded at first use. Imports are memoized only on success; otherwise the symbol becomes a placeholder that fails with `AgentTools::ResourceFunctionUnavailable` and the import is retried next time.
- `Scripts/BuildMX.wls` copies the directory into the temporary build copy and uses the local `ASTPattern` for its source annotations.
- The `SymbolDefinition` tool falls back to `InputForm` formatting when `ReadableForm` is not available.

**Provenance of the local copies** (see `ResourceFunctions/README.md`)

- `ImportMarkdownString`, `MessageFailure`, `ReadableForm`: verbatim copies from rhennigan/ResourceFunctions (commit 08ee812); verified identical to the published, pinned versions.
- `ASTPattern`, `ExportMarkdownString`: the repository's development versions are newer than the published 1.0.0 versions, so these were generated from the published definitions (from the local resource cache) to keep behavior identical to current releases. `ResourceFunctionMessage` (a dependency of `MessageFailure`, not in the repository) was generated the same way. These three are stored as definition-list assignments because re-evaluating `f[ args___ ] := ...` next to its `e: HoldPattern[ f[ ___ ] ] := ...` fallthrough merges the two rules.

## Test plan

- [x] New `Tests/ServerErrorHandling.wlt`: `catchUncaughtThrows` semantics (normal, tagged, tagless, abort, inner catch, paclet failures unaffected), `tools/call` with throwing/aborting tools including the cloud tag, plain failure text, response serialization fallback, context-tool failures.
- [x] New `Tests/ResourceFunctions.wlt`: local copies exist and are wrapped, imports resolve to the local context, functional smoke tests of every copy, unavailable-placeholder behavior (failure, not memoized), SymbolDefinition fallback.
- [x] Full suite against the built paclet (MX): 2427 tests, 32 failures, all in tests that require the cloud (cloud notebook deploys in `Tools.wlt`, resource-object lookups in `CreateMCPServer.wlt`, search prompts in `Prompts.wlt`, the usage endpoint in `UsageData.wlt`); every other file passes. `CloudDeployment.wlt` was skipped (deploys to the real cloud).
- [x] Drove a throwaway copy of the real server over JSON-RPC during the outage: `WolframLanguageContext` now returns `[Error] Documentation search is currently unavailable (...)` and the server keeps serving subsequent requests; `SymbolDefinition` output is correct again.
- [x] `Scripts/BuildMX.wls` and `Scripts/BuildPaclet.wls --check=false` succeed offline (the definition-notebook check fails offline on the cloud-dependent `PublisherUpdateNotAllowed` hint; the CodeInspector is clean on all changed files).
- [ ] CI once the cloud is back (GitHub Actions uses cloud-based licensing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fx1TKznVhzxdCujbMybQF5
